### PR TITLE
feat: Escape stops the operation running on the open tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.0] - 2026-09-02
+
+Pressing Escape now stops whatever the current tab is doing — a disk scan, a cleanup, a speed test. Until
+now Escape did nothing anywhere in the app, and the Cancel button only appears once an operation is
+already running, so if you were not using a mouse there was no reliable way to stop one.
+
+### Added
+- **Escape stops the operation on the open tab.** Sixteen tabs can cancel what they are doing, and the
+  Cancel button for each is deliberately hidden until there is something to cancel — which is right for
+  the mouse, but meant the button appeared in the middle of the keyboard order, at an unpredictable place,
+  while the scan was already running. Escape now does it directly, on every one of those tabs. It only
+  acts while something is actually running, and only after the control you are on has had its own chance
+  to use the key, so it does not interfere with closing a drop-down or undoing an edit in a text box.
+  Stopping is always the safe direction — nothing is left half-changed, because each of these operations
+  was already built to be stoppable.
+
 ## [1.75.32] - 2026-09-02
 
 If you opened the appearance panel with the keyboard, you landed nowhere: the panel appeared but the

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ within a table or a row of filter chips. In the sidebar, `Enter` also opens the 
 on, the way it opens a folder in File Explorer. Opening the appearance panel moves focus into it, `Tab`
 cycles the themes inside it, and `Escape` closes it and puts focus back on the button you opened it from.
 
+`Escape` also stops whatever the open tab is doing — a disk scan, a cleanup, a speed test — on all sixteen
+tabs that can be cancelled. It only acts while something is running, and only after the control you are on
+has had its own chance to use the key, so it still closes a drop-down or undoes a text edit first.
+
 The focus outline is deliberately two thin lines of opposite shade — one light, one dark — rather
 than a single accent-coloured ring. A single colour cannot be visible everywhere: it has to show up
 on a purple primary button, a red delete button, a grey secondary button and a plain card, and any

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.75.x   | :white_check_mark: |
-| < 1.75   | :x:                |
+| 1.76.x   | :white_check_mark: |
+| < 1.76   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using NetArchTest.Rules;
 using SysManager.Services;
 
@@ -989,6 +990,99 @@ public partial class ArchitectureTests
     /// </summary>
     [GeneratedRegex(@"""([A-Za-z0-9][A-Za-z0-9._-]*\.json)""", RegexOptions.Compiled)]
     private static partial Regex JsonStateFile();
+
+    /// <summary>
+    /// Every tab with a Cancel button must let Escape reach it, and must pair Escape with the SAME busy
+    /// flag its own Cancel button is shown by.
+    /// </summary>
+    /// <remarks>
+    /// The app answers "is something running?" five different ways: <c>IsBusy</c> on twelve tabs, and
+    /// <c>IsShredding</c>, <c>IsScanning</c>, <c>IsHttpTesting</c> and <c>IsOoklaTesting</c> on the rest.
+    /// A shell that tested <c>IsBusy</c> would silently skip four tabs, and the pairing is invisible to
+    /// the compiler — nothing stops a view model gating Escape on a flag that has nothing to do with the
+    /// operation its Cancel button stops.
+    /// <para>So the contract is derived from the VIEW, which is the one place the intended pairing is
+    /// already stated: the element that carries <c>Command="{Binding Cancel…}"</c> also carries the
+    /// <c>Visibility</c> binding that decides when that button appears. The view model's
+    /// <c>EscapeCancel</c> override must name both.</para>
+    /// <para>Parsed with XDocument rather than a regex over the text, so "the same element" is a fact of
+    /// the tree instead of a guess about how close two attributes happen to be.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryCancellableTab_LetsEscapeReachItsOwnCancelCommand()
+    {
+        var app = FindAppProjectDir();
+        var presentation = XNamespace.Get("http://schemas.microsoft.com/winfx/2006/xaml/presentation");
+        var binding = new Regex(@"^\{Binding\s+(?<name>\w+)", RegexOptions.CultureInvariant);
+
+        var offenders = new List<string>();
+        var pairs = 0;
+
+        foreach (var view in Directory.EnumerateFiles(Path.Combine(app, "Views"), "*.xaml")
+                     .OrderBy(p => p, StringComparer.Ordinal))
+        {
+            var document = XDocument.Load(view);
+
+            foreach (var element in document.Descendants())
+            {
+                var command = binding.Match((string?)element.Attribute("Command") ?? string.Empty);
+                var visibility = binding.Match((string?)element.Attribute("Visibility") ?? string.Empty);
+                if (!command.Success || !visibility.Success) continue;
+
+                var commandName = command.Groups["name"].Value;
+                if (!commandName.StartsWith("Cancel", StringComparison.Ordinal)) continue;
+
+                var flag = visibility.Groups["name"].Value;
+                pairs++;
+
+                var viewName = Path.GetFileNameWithoutExtension(view);
+                var vmPath = Path.Combine(app, "ViewModels", viewName + "Model.cs");
+                if (!File.Exists(vmPath))
+                {
+                    offenders.Add($"{viewName}.xaml binds {commandName} but {viewName}Model.cs does not exist");
+                    continue;
+                }
+
+                // Comments stripped: several view models explain the Escape wiring in prose, and a
+                // Contains against the raw text would be satisfied by the explanation of an override
+                // that had been deleted.
+                var vm = string.Join('\n', File.ReadAllLines(vmPath)
+                    .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+                var overrideAt = vm.IndexOf("override IRelayCommand? EscapeCancel", StringComparison.Ordinal);
+                if (overrideAt < 0)
+                {
+                    offenders.Add($"{viewName}Model has no EscapeCancel override, so Escape does nothing "
+                                  + $"while {flag} is true and {commandName} is the button on screen");
+                    continue;
+                }
+
+                // The override's own expression, not the whole file: another member could mention the
+                // command and make this pass while Escape was gated on something unrelated.
+                var end = vm.IndexOf(';', overrideAt);
+                var expression = end > overrideAt ? vm[overrideAt..end] : vm[overrideAt..];
+
+                if (!expression.Contains(commandName, StringComparison.Ordinal))
+                    offenders.Add($"{viewName}Model gates Escape on something other than {commandName}, "
+                                  + "which is the command its own Cancel button runs");
+                if (!expression.Contains(flag, StringComparison.Ordinal))
+                    offenders.Add($"{viewName}Model gates Escape on a different flag than {flag}, which is "
+                                  + "what shows its Cancel button — so Escape and the button disagree "
+                                  + "about when there is something to stop");
+            }
+        }
+
+        // Vacuity floor: twelve tabs bind Cancel with a visibility flag today. A parse that stopped
+        // finding them would report success having checked nothing.
+        Assert.True(pairs >= 12,
+            $"only {pairs} Cancel-with-visibility bindings were found across Views/ — the parse is "
+            + "broken, not the views.");
+
+        Assert.True(offenders.Count == 0,
+            "Escape must stop the operation the tab's own Cancel button stops, gated on the same flag:\n  "
+            + string.Join("\n  ", offenders)
+            + $"\n({pairs} Cancel bindings checked)");
+    }
 
     /// <summary>
     /// Every issue template must apply at least one label, and every label it names must be one this

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -8,7 +8,8 @@
         MinWidth="960" MinHeight="640"
         Background="{DynamicResource Surface0}"
         Icon="Resources/app.ico"
-        AutomationProperties.AutomationId="MainWindow">
+        AutomationProperties.AutomationId="MainWindow"
+        KeyDown="Window_KeyDown">
     <Window.DataContext>
         <vm:MainWindowViewModel/>
     </Window.DataContext>

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -303,6 +303,33 @@ public partial class MainWindow : Window
     // window. Selecting a preset does NOT close the popup, so this does not fight trying several themes.
     private void ThemePopupHost_Closed(object sender, EventArgs e) => ThemeBtn.Focus();
 
+    /// <summary>
+    /// Escape stops whatever the open tab is doing.
+    /// </summary>
+    /// <remarks>
+    /// Bubbling <c>KeyDown</c>, deliberately not <c>PreviewKeyDown</c>. A ComboBox closing its dropdown
+    /// and a TextBox reverting an edit both consume Escape and both come first; this only ever sees the
+    /// key nothing else wanted. The theme popup is likewise unaffected — it handles Escape on its own
+    /// child and marks it handled.
+    /// <para>Nothing happens unless the tab returns a command, which its view model does only while it
+    /// has something running. Cancelling is always the safe direction — every cancel path here is a
+    /// CancellationToken the services already honour — so unlike a destructive action this is a
+    /// legitimate thing for a bare keypress to do.</para>
+    /// <para><c>IsContentCreated</c> is checked so this cannot construct a view model as a side effect of
+    /// a keypress. In practice the selected tab is always materialised; relying on that rather than
+    /// asserting it is how a lazy graph gets built by accident.</para>
+    /// </remarks>
+    private void Window_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key is not Key.Escape) return;
+        if (DataContext is not MainWindowViewModel vm) return;
+        if (vm.SelectedNav is not { IsContentCreated: true, Content: ViewModelBase active }) return;
+        if (active.EscapeCancel is not { } cancel) return;
+
+        cancel.Execute(null);
+        e.Handled = true;
+    }
+
     private void ThemePopup_PreviewKeyDown(object sender, KeyEventArgs e)
     {
         if (e.Key is not Key.Escape) return;

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.75.32</Version>
-    <FileVersion>1.75.32.0</FileVersion>
-    <AssemblyVersion>1.75.32.0</AssemblyVersion>
+    <Version>1.76.0</Version>
+    <FileVersion>1.76.0.0</FileVersion>
+    <AssemblyVersion>1.76.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BootAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BootAnalyzerViewModel.cs
@@ -19,6 +19,10 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class BootAnalyzerViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsBusy ? CancelCommand : null;
+
     private readonly BootAnalyzerService _service;
     private CancellationTokenSource? _cts;
 

--- a/SysManager/SysManager/ViewModels/BrowserCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BrowserCleanerViewModel.cs
@@ -20,6 +20,10 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class BrowserCleanerViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsBusy ? CancelCommand : null;
+
     private readonly BrowserCleanerService _service;
     private CancellationTokenSource? _cts;
 

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -20,6 +20,10 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class BulkInstallerViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsBusy ? CancelCommand : null;
+
     private readonly BulkInstallerService _service;
     private readonly AppIconService _iconService;
     private readonly EtaCalculator _installEta = new();

--- a/SysManager/SysManager/ViewModels/DebloaterViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DebloaterViewModel.cs
@@ -21,6 +21,10 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class DebloaterViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsBusy ? CancelCommand : null;
+
     private readonly DebloaterService _service;
     private readonly ISessionRestorePoint _restorePoint;
     private CancellationTokenSource? _cts;

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -20,6 +20,10 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class DiskAnalyzerViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsBusy ? CancelAnalysisCommand : null;
+
     private readonly DiskAnalyzerService _service;
     private readonly DiskScanHistoryService _history;
     private CancellationTokenSource? _cts;

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -26,6 +26,10 @@ namespace SysManager.ViewModels;
 /// </remarks>
 public sealed partial class DuplicateFileViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsBusy ? CancelScanCommand : null;
+
     private readonly DuplicateFileService _service;
     private CancellationTokenSource? _cts;
 

--- a/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileShredderViewModel.cs
@@ -19,6 +19,10 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class FileShredderViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsShredding ? CancelCommand : null;
+
     private readonly FileShredderService _service;
     private CancellationTokenSource? _cts;
 

--- a/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
@@ -20,6 +20,10 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class RestorePointsViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsBusy ? CancelCommand : null;
+
     private readonly RestorePointService _service;
     private CancellationTokenSource? _cts;
 

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -18,6 +18,10 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class ShortcutCleanerViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsScanning ? CancelCommand : null;
+
     private readonly ShortcutCleanerService _service;
     private CancellationTokenSource? _cts;
 

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -16,6 +16,10 @@ namespace SysManager.ViewModels;
 /// <summary>HTTP + Ookla speed tests with persistent history.</summary>
 public sealed partial class SpeedTestViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        (IsOoklaTesting || IsHttpTesting) ? CancelSpeedCommand : null;
+
     public NetworkSharedState Shared { get; }
     private readonly SpeedTestHistoryService _history;
     private readonly EtaCalculator _eta = new();

--- a/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemFixesViewModel.cs
@@ -22,6 +22,10 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class SystemFixesViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsBusy ? CancelCommand : null;
+
     private readonly SystemFixService _service;
     private CancellationTokenSource? _cts;
 

--- a/SysManager/SysManager/ViewModels/SystemReportViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemReportViewModel.cs
@@ -21,6 +21,10 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class SystemReportViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsBusy ? CancelCommand : null;
+
     private readonly SystemReportService _service;
     private CancellationTokenSource? _cts;
 

--- a/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
@@ -19,6 +19,10 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class TaskSchedulerViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsBusy ? CancelCommand : null;
+
     private readonly TaskSchedulerService _service;
     private List<ScheduledTaskInfo> _all = [];
 

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -17,6 +17,10 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class UninstallerViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsBusy ? CancelCommand : null;
+
     private readonly UninstallerService _service;
     private readonly EtaCalculator _uninstallEta = new();
     private readonly Action<PowerShellLine> _lineHandler;

--- a/SysManager/SysManager/ViewModels/ViewModelBase.cs
+++ b/SysManager/SysManager/ViewModels/ViewModelBase.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using Serilog;
 
 namespace SysManager.ViewModels;
@@ -25,6 +26,21 @@ public abstract partial class ViewModelBase : ObservableObject, IDisposable
     /// false while the override was releasing everything — exactly the window that needs guarding.</para>
     /// </summary>
     protected bool IsDisposed { get; private set; }
+
+    /// <summary>
+    /// The command Escape should run on this tab, or <c>null</c> when there is nothing to stop.
+    /// </summary>
+    /// <remarks>
+    /// One property rather than a "can cancel" flag beside a command, because the two must not be
+    /// separable. The app answers "is something running?" five different ways — <c>IsBusy</c> on twelve
+    /// tabs, and <c>IsShredding</c>, <c>IsScanning</c>, <c>IsHttpTesting</c> and <c>IsOoklaTesting</c> on
+    /// the rest — so a shell that tested <c>IsBusy</c> would silently skip four of them. Returning the
+    /// command only while busy puts the flag and the command in one expression, in the view model that
+    /// owns both.
+    /// <para>Defaults to null, which is the correct default rather than a gap: a tab with nothing to
+    /// cancel must not swallow the key. Escape then falls through to whatever else would handle it.</para>
+    /// </remarks>
+    protected internal virtual IRelayCommand? EscapeCancel => null;
 
     /// <summary>
     /// Completes when the constructor's <see cref="InitializeAsync"/> work has finished

--- a/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
@@ -17,6 +17,10 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class WindowsFeaturesViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? EscapeCancel =>
+        IsBusy ? CancelCommand : null;
+
     private readonly WindowsFeaturesService _service;
     private readonly ISessionRestorePoint _restorePoint;
     private CancellationTokenSource? _scanCts;


### PR DESCRIPTION
Closes #1550.

Escape did nothing anywhere in this app until today — `Key.Escape` had zero hits
across the whole solution before #2079 added the first one, for the theme popup. On a
multi-minute drive scan, the panic key a non-technical user reaches for was inert.

The Cancel button is deliberately hidden until an operation is running, and that is
right for the mouse. For the keyboard it means the button materialises into the tab
order mid-operation, at a position that depends on what else is visible, so reaching
it means tabbing blindly through a toolbar while the scan runs.

The trap is the busy flag, and the issue's risk note named it exactly. Sixteen Cancel
bindings across fifteen views, and FIVE different flags decide when the button shows:
`IsBusy` on twelve, then `IsShredding`, `IsScanning`, `IsHttpTesting` and
`IsOoklaTesting`. A shell that tested `IsBusy` would silently skip four tabs — File
Shredder, Shortcut Cleaner and both halves of Speed Test.

So the seam is one property, not a flag beside a command:

    protected internal virtual IRelayCommand? EscapeCancel => null;

Each tab overrides it in one line — `IsShredding ? CancelCommand : null` — which puts
the flag and the command in a single expression, in the view model that owns both.
There is no way to wire one without the other. Null is the right default rather than a
gap: a tab with nothing to cancel must not swallow the key.

The fifteen overrides were generated from a measurement of each view's own
`Visibility` binding rather than typed out, because typing them is fifteen chances to
pair the wrong flag with the wrong command.

In the shell it is a bubbling `KeyDown`, not `PreviewKeyDown`. A ComboBox closing its
dropdown and a TextBox reverting an edit both consume Escape and both come first; this
only ever sees the key nothing else wanted. `IsContentCreated` is checked so a keypress
cannot construct a view model as a side effect — the selected tab is always
materialised in practice, and relying on that rather than asserting it is how a lazy
graph gets built by accident.

The guard is the part that keeps this true. `EveryCancellableTab_LetsEscapeReachItsOwnCancelCommand`
derives the contract from the VIEW, which is the one place the intended pairing is
already stated: the element carrying `Command="{Binding Cancel…}"` also carries the
`Visibility` binding that decides when that button appears, so the view model's
override must name both. Parsed with XDocument rather than a regex over the text, so
"the same element" is a fact of the tree instead of a guess about how close two
attributes happen to be. It reads the override's own expression, not the whole file —
another member mentioning the command would otherwise make it pass while Escape was
gated on something unrelated.

Red/green, four mutations, each red with its own message. Two of them are the reason
the guard exists, because both compile and both look right: File Shredder gated on
`IsBusy` instead of `IsShredding` (Escape would do nothing during the one operation
that tab runs), and Task Scheduler gated on `RefreshCommand` instead of
`CancelCommand` (Escape would start a scan instead of stopping one). Plus a missing
override, and the parse finding nothing. Restore byte-for-byte, green after.

Regression: 590 green across 415 tests in the 28 suites covering the fifteen changed
view models, 81 green on the 76-method architecture sweep, 10 green on the contract
suites. The 2 sweep reds are the local runner's own artefacts and are green in CI. App
and tests build with 0 warnings.

Not verifiable here: that Escape visibly stops a running scan needs the app, which is
a machine that runs the application. What is pinned mechanically is that every cancellable tab is
wired to its own command and its own flag.

Minor, not addressed: `feat:` so this releases as 1.76.0. Nine other view models
declare a Cancel command whose view binds no visibility-gated Cancel button, so they
are outside this contract — worth a look separately, since a command bound by nothing
is a shape this repo has been bitten by before.
