### PR TITLE
docs: show the comparison row SysManager loses

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ fully open source.
 | No telemetry / no account | ✅ | ❌ | ❌ | ✅ | ✅ |
 | Fully local (no cloud) | ✅ | ❌ | ✅ | ✅ | ✅ |
 | Portable single `.exe` | ✅ | ❌ | ✅ | ✅ | ✅ |
+| Code-signed binary | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Disk / cache cleanup | ✅ | ✅ | ✅ | ❌ | ❌ |
 | Privacy & telemetry toggles | ✅ | ⚠️ | ✅ | ✅ | ❌ |
 | Network diagnostics (ping / traceroute / speed) | ✅ | ❌ | ❌ | ❌ | ❌ |
@@ -112,6 +113,11 @@ fully open source.
 | Free | ✅ | ⚠️ | ✅ | ✅ | ✅ |
 
 <sub>⚠️ = partial, paywalled, or limited. Comparison reflects the free editions as of 2026; features evolve — corrections welcome via an issue.</sub>
+
+<sub>The signing row is the one where SysManager loses, and it is here on purpose — a table a project wins
+every row of tells you nothing. Builds are unsigned, so Windows shows a warning on first launch. Why, what
+that warning looks like, and how to check the download yourself:
+[First launch](#first-launch-windows-will-warn-you) · [Verifying the download](#verifying-the-download).</sub>
 
 ## Features
 


### PR DESCRIPTION
The comparison table gave SysManager a tick on all ten rows and never mentioned the
one dimension where every competitor genuinely beats it. A table a project wins every
row of reads as marketing, not assessment — and it undercuts the rest of the page,
which is unusually candid about exactly this: there is a whole section explaining the
SmartScreen warning, another on verifying the download yourself, and a signing posture
written out in SECURITY.md.

So the missing row was the credible one. Builds are unsigned; CCleaner, Wintoys, O&O
ShutUp10 and HWiNFO are all signed. That is now the eleventh row, with SysManager the
only ❌ in it.

The footnote says why the row is there and links the two sections that already explain
the consequence, rather than restating them: what the first-launch warning looks like,
and how to check the download. Both anchors are covered by
`TheReadmeTableOfContents_HasNoDeadAnchors`, which sweeps every in-page link in the
top-level markdown — proved by breaking each one and watching it go red naming
README.md:120, then restoring byte-for-byte.

67 internal links across 10 markdown files, 0 broken.
`NoPublicDocument_ClaimsAPublisherPinThatIsNotArmed` stays green: the new wording says
builds are unsigned, which is what the unarmed publisher pin requires it to say — that
guard is bidirectional, so it would also fail if this over-claimed.

No release: docs: is not a release type here.
