### PR TITLE
fix: give the twelve sidebar groups their icons

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,6 +35,8 @@ The sidebar organises tabs into 12 groups (11 collapsible + a flat top-level Das
 `NavItem` hierarchy built by `BuildNavGroups()` using `Group()` plus one of two item helpers:
 `Tab<TVm>()`, which defers resolving the view-model until the tab is first opened, and `EagerItem()`
 for the few entries whose view-model must exist at startup. Dashboard renders as a flat top-level entry.
+Each group carries an icon, passed to `Group()` as a Segoe Fluent Icons code point and asserted distinct;
+leaves carry none, so the icon column belongs to the twelve headings rather than the fifty-eight pages.
 Collapsed groups show a child count badge, subtitle (derived
 from child labels joined with " · "), and tooltip.
 `MainWindowViewModel.SelectedNav` mirrors selection into `NavItem.IsSelected`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.1] - 2026-09-03
+
+The twelve groups down the left of the window now have icons. They were meant to all along: the space for
+one was reserved next to every entry in that list, and it was empty, so the whole rail was a column of
+text with a blank margin beside it.
+
+### Fixed
+- **The sidebar icons appear.** Each entry in the navigation list had a slot for an icon and a property to
+  hold it, and nothing ever put a character in that property — so the slot rendered as whitespace on all
+  fifty-eight entries. Every one of the twelve groups now has its own symbol, all distinct: a house for
+  Dashboard, a hard drive for Storage, a trash can for Cleanup, a shield for Privacy & Security, and so
+  on. The individual pages inside a group are deliberately left without one. Fifty-eight icons in a rail
+  this narrow is noise, and the group heading is what you actually scan; the reclaimed space goes to the
+  page names, which now have room to be read in full.
+
+### Changed
+- **The "running as administrator" badge is a shield rather than a padlock.** The padlock is what the
+  Privacy & Security group in the list directly above it now uses, and one symbol cannot mean both a
+  subject and "this window has administrator rights" a few centimetres apart. The badge, its position, and
+  its colour are otherwise unchanged.
+
 ## [1.76.0] - 2026-09-02
 
 Pressing Escape now stops whatever the current tab is doing — a disk scan, a cleanup, a speed test. Until

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -242,17 +242,45 @@ public class MainWindowViewModelTests
         Assert.Equal(ids.Count, ids.Distinct().Count());
     }
 
+    /// <summary>
+    /// Leaf nav items carry a label, a view and content. They no longer carry a glyph.
+    /// </summary>
+    /// <remarks>
+    /// This assertion used to include <c>Glyph</c>, and it was FAILING the whole time: every item was
+    /// constructed with <c>Glyph = ""</c>, so the non-blank check could not pass. It went unnoticed
+    /// because CI compile-checks this project without executing it — the one test that would have caught
+    /// the empty sidebar gutter on day one was in the one place nothing runs it.
+    /// <para>Icons now live on the group, so the glyph half moved to
+    /// <see cref="NavGroups_CarryDistinctGlyphs"/>, where it is a real assertion instead of an
+    /// impossible one.</para>
+    /// </remarks>
     [Fact]
-    public void NavItems_AllHaveLabelsAndGlyphs()
+    public void NavItems_AllHaveLabelsAndAView()
     {
         var vm = new MainWindowViewModel();
         Assert.All(vm.NavItems, n =>
         {
             Assert.False(string.IsNullOrWhiteSpace(n.Label));
-            Assert.False(string.IsNullOrWhiteSpace(n.Glyph));
             Assert.NotNull(n.Content);
             Assert.NotNull(n.ViewType);
         });
+    }
+
+    /// <summary>
+    /// Every group carries a glyph, and no two groups share one.
+    /// </summary>
+    /// <remarks>
+    /// Distinctness is the point rather than mere presence: twelve rows drawn with the same icon
+    /// differentiate nothing, which is the state the sidebar was already in with twelve empty ones.
+    /// </remarks>
+    [Fact]
+    public void NavGroups_CarryDistinctGlyphs()
+    {
+        var vm = new MainWindowViewModel();
+        Assert.All(vm.NavGroups, g => Assert.False(string.IsNullOrWhiteSpace(g.Glyph)));
+
+        var glyphs = vm.NavGroups.Select(g => g.Glyph).ToList();
+        Assert.Equal(glyphs.Count, glyphs.Distinct(StringComparer.Ordinal).Count());
     }
 
     // ── NavGroup tests ──────────────────────────────────────────────

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2335,10 +2335,88 @@ public partial class ArchitectureTests
         Assert.True(offenders.Count == 0,
             "These glyphs are above U+FFFF and name no font, so Windows falls back to Segoe UI Emoji "
             + "and draws a colour emoji instead of an icon. Use the Segoe Fluent Icons equivalent with "
-            + "FontFamily=\"Segoe Fluent Icons,Segoe MDL2 Assets\" (the shield is &#xE83D;):\n  "
+            + "FontFamily=\"Segoe Fluent Icons,Segoe MDL2 Assets\" (the shield this app uses is "
+            + "&#xEA18;):\n  "
             + string.Join("\n  ", offenders)
             + $"\n({scanned} astral references seen, {glyphs} icon glyphs scanned)");
     }
+
+    /// <summary>
+    /// Every sidebar group carries a distinct glyph, and none of them is the glyph the elevation badge
+    /// draws.
+    /// </summary>
+    /// <remarks>
+    /// Two failure modes, and the second is the one that needs a rule. Twelve groups drawn with the same
+    /// icon differentiate nothing — which is the state the rail was already in with twelve empty ones. And
+    /// the badge previously drew <c>E72E</c>, the padlock, which is now the Privacy &amp; Security group's
+    /// icon: one symbol cannot mean both a topic and "needs administrator" in a window that shows both at
+    /// once.
+    /// <para>Lives here rather than beside the other nav assertions in the integration project, because
+    /// CI compile-checks that project without executing it. The assertion that would have caught the
+    /// empty gutter on day one was there, failing, unrun, for as long as the gutter existed.</para>
+    /// <para>Deliberately scoped to the shell's own chrome. Glyphs repeat freely across empty-state
+    /// illustrations — <c>E946</c> appears in seven of them — and that is fine: those are never on screen
+    /// together, and none of them is an identity symbol.</para>
+    /// </remarks>
+    [Fact]
+    public void EverySidebarGroupGlyph_IsDistinctAndNotTheElevationBadge()
+    {
+        var app = FindAppProjectDir();
+        var vm = File.ReadAllText(Path.Combine(app, "ViewModels", "MainWindowViewModel.cs"));
+        var shell = File.ReadAllText(Path.Combine(app, "MainWindow.xaml"));
+
+        var groups = GroupGlyph().Matches(vm).Cast<Match>()
+            .Select(m => (Id: m.Groups["id"].Value, Glyph: m.Groups["glyph"].Value.ToUpperInvariant()))
+            .ToArray();
+
+        Assert.True(groups.Length >= 12,
+            $"only {groups.Length} group glyphs were parsed out of BuildNavGroups — the Group(...) call "
+            + "shape changed and this guard is no longer reading the sidebar.");
+
+        var duplicates = groups
+            .GroupBy(g => g.Glyph, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .Select(g => $"{g.Key} is used by {string.Join(", ", g.Select(x => x.Id))}")
+            .ToArray();
+        Assert.True(duplicates.Length == 0,
+            "two sidebar groups draw the same icon, so the rail differentiates nothing between them:\n  "
+            + string.Join("\n  ", duplicates));
+
+        // The badge's glyph, sliced from its own element. Asserting the slice was found matters: a marker
+        // that stops matching would otherwise leave this comparing against an empty string, which every
+        // group glyph trivially differs from.
+        var badgeAt = shell.IndexOf("AutomationProperties.AutomationId=\"ElevationBadge\"",
+                                    StringComparison.Ordinal);
+        Assert.True(badgeAt > 0,
+            "MainWindow.xaml has no element with AutomationId=\"ElevationBadge\" — if it was renamed, "
+            + "update this guard in the same PR rather than losing the check.");
+
+        var badge = CharacterReference().Match(shell, badgeAt);
+        Assert.True(badge.Success,
+            "no character reference follows the elevation badge, so its glyph could not be read.");
+
+        var badgeGlyph = badge.Groups["hex"].Value.ToUpperInvariant();
+        var clash = groups.Where(g => string.Equals(g.Glyph, badgeGlyph, StringComparison.Ordinal))
+            .Select(g => g.Id)
+            .ToArray();
+
+        Assert.True(clash.Length == 0,
+            $"the elevation badge draws U+{badgeGlyph}, which is also the icon for "
+            + $"{string.Join(", ", clash)}. The badge means \"needs administrator\" and the group means a "
+            + "topic — one symbol cannot carry both in a window that shows them together. Change one.");
+    }
+
+    /// <summary>
+    /// A sidebar group declaration, capturing its id and the escaped codepoint of its glyph:
+    /// <c>Group("grp-x", "Label", ""</c>.
+    /// </summary>
+    [GeneratedRegex(@"Group\(""(?<id>[^""]+)"",\s*""[^""]+"",\s*""\\u(?<glyph>[0-9A-Fa-f]{4})""",
+                    RegexOptions.CultureInvariant)]
+    private static partial Regex GroupGlyph();
+
+    /// <summary>A XAML character reference, capturing the hex codepoint.</summary>
+    [GeneratedRegex(@"&#x(?<hex>[0-9A-Fa-f]{4});", RegexOptions.CultureInvariant)]
+    private static partial Regex CharacterReference();
 
     // A character reference above U+FFFF — i.e. &#x1F???; and up, which is where the emoji planes are.
     // Five hex digits or more cannot be a BMP icon-font glyph.

--- a/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
@@ -507,7 +507,6 @@ public class BandwidthMonitorViewModelTests : IDisposable
     {
         Id = "nav-test",
         Label = "Test",
-        Glyph = "",
         ViewType = typeof(object),
         Content = content,
     };
@@ -544,7 +543,6 @@ public class BandwidthMonitorViewModelTests : IDisposable
         {
             Id = "nav-lazy",
             Label = "Lazy",
-            Glyph = "",
             ViewType = typeof(object),
             ContentFactory = () => { built++; return new object(); },
         };

--- a/SysManager/SysManager.Tests/NavGroupTests.cs
+++ b/SysManager/SysManager.Tests/NavGroupTests.cs
@@ -65,9 +65,9 @@ public class NavGroupTests
             Label = "Test",
             Glyph = "T",
             Children = {
-            new NavItem { Id = "a", Label = "A", Glyph = "A",
+            new NavItem { Id = "a", Label = "A",
                 Content = new object(), ViewType = typeof(object) },
-            new NavItem { Id = "b", Label = "B", Glyph = "B",
+            new NavItem { Id = "b", Label = "B",
                 Content = new object(), ViewType = typeof(object) },
         }
         };
@@ -89,7 +89,6 @@ public class NavGroupTests
         {
             Id = "a",
             Label = "A",
-            Glyph = "A",
             Content = new object(),
             ViewType = typeof(object),
         };
@@ -103,7 +102,6 @@ public class NavGroupTests
         {
             Id = "a",
             Label = "A",
-            Glyph = "A",
             Content = new object(),
             ViewType = typeof(object),
             IsInDevelopment = true,
@@ -163,7 +161,6 @@ public class NavGroupTests
     {
         Id = "a",
         Label = "A",
-        Glyph = "A",
         Content = new object(),
         ViewType = typeof(object),
     };

--- a/SysManager/SysManager.Tests/NavItemLazyContentTests.cs
+++ b/SysManager/SysManager.Tests/NavItemLazyContentTests.cs
@@ -25,7 +25,6 @@ public class NavItemLazyContentTests
     {
         Id = "lazy",
         Label = "Lazy",
-        Glyph = "",
         ViewType = typeof(object),
         ContentFactory = factory,
     };
@@ -90,7 +89,6 @@ public class NavItemLazyContentTests
         {
             Id = "eager",
             Label = "Eager",
-            Glyph = "",
             ViewType = typeof(object),
             Content = vm,
         };
@@ -133,7 +131,7 @@ public class NavItemLazyContentTests
     [Fact]
     public void Content_WithNeitherEagerNorFactory_Throws()
     {
-        var item = new NavItem { Id = "bad", Label = "Bad", Glyph = "", ViewType = typeof(object) };
+        var item = new NavItem { Id = "bad", Label = "Bad", ViewType = typeof(object) };
         Assert.Throws<InvalidOperationException>(() => _ = item.Content);
     }
 }

--- a/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
+++ b/SysManager/SysManager.Tests/SidebarSelectionContractTests.cs
@@ -59,7 +59,10 @@ public class SidebarSelectionContractTests
 
         Assert.Equal(2, liveRows.Count);
         Assert.Equal(2, liveMarks.Count);
-        Assert.Equal(4, liveTexts.Count);
+        // Three, and which three matters: the single-item row's glyph and label, and the leaf row's label.
+        // A leaf has no glyph of its own — the group above it carries the icon — so a fourth here would
+        // mean the empty gutter came back.
+        Assert.Equal(3, liveTexts.Count);
         Assert.All(liveRows, row => Assert.Null(row.Attribute("Background")));
         Assert.All(liveMarks, mark => Assert.Null(mark.Attribute("Visibility")));
         Assert.All(

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -154,7 +154,12 @@
                                                        Style="{StaticResource SidebarActiveMark}"
                                                        Margin="-14,0,0,0"/>
                                             <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="{Binding Glyph}"
+                                                <!-- The GROUP's glyph, reached past this Border's
+                                                     DataContext="{Binding Children[0]}". A single-item
+                                                     group is drawn as a flat row but it is still a group,
+                                                     so it carries the group's icon — the Button above is
+                                                     where the NavGroup is in scope. -->
+                                                <TextBlock Text="{Binding DataContext.Glyph, RelativeSource={RelativeSource AncestorType=Button}}"
                                                            Style="{StaticResource SidebarNavText}"
                                                            FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                                            FontSize="14" Margin="0,0,12,0"
@@ -296,15 +301,13 @@
                                                                        Margin="-28,0,0,0"/>
                                                             <!-- DockPanel (not a horizontal StackPanel): a StackPanel gives its
                                                                  children infinite width, so the label's grid never constrained and the
-                                                                 PREVIEW pill overflowed the 220px sidebar. Docking the glyph left lets
-                                                                 the content fill the real remaining width, so the label ellipsizes and
-                                                                 the pill always shows. -->
+                                                                 PREVIEW pill overflowed the 220px sidebar. Kept now that the leaf glyph
+                                                                 is gone, because the label/pill grid still needs a real width to
+                                                                 constrain against.
+                                                                 No glyph on a leaf: 58 icons in a 220px rail is noise, and the group
+                                                                 header is what a reader scans. The gutter that used to sit here always
+                                                                 empty is reclaimed by the label instead. -->
                                                             <DockPanel>
-                                                                <TextBlock Text="{Binding Glyph}" DockPanel.Dock="Left"
-                                                                           Style="{StaticResource SidebarNavText}"
-                                                                           FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                                                           FontSize="13" Margin="0,0,10,0"
-                                                                           VerticalAlignment="Center"/>
                                                                 <StackPanel VerticalAlignment="Center">
                                                                     <!-- Label + PREVIEW pill in a 2-column grid (label = *, pill = Auto):
                                                                          a horizontal StackPanel measured with infinite width, so on a long
@@ -352,7 +355,12 @@
                             Padding="10,3" HorizontalAlignment="Left"
                             AutomationProperties.AutomationId="ElevationBadge">
                         <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="&#xE72E;"
+                            <!-- Shield (EA18), not the padlock this used to draw. The padlock is now the
+                                 Privacy & Security group's icon in the rail directly above, and one
+                                 symbol cannot mean both a topic and "needs administrator" in the same
+                                 window. Present in Segoe MDL2 Assets too, so Windows 10 shows a shield
+                                 rather than a box. -->
+                            <TextBlock Text="&#xEA18;"
                                        FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                        FontSize="11" Margin="0,0,6,0" VerticalAlignment="Center">
                                 <TextBlock.Style>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.0</Version>
-    <FileVersion>1.76.0.0</FileVersion>
-    <AssemblyVersion>1.76.0.0</AssemblyVersion>
+    <Version>1.76.1</Version>
+    <FileVersion>1.76.1.0</FileVersion>
+    <AssemblyVersion>1.76.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -150,7 +150,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             {
                 Id = id,
                 Label = label,
-                Glyph = "",
                 ViewType = viewType,
                 IsInDevelopment = inDevelopment,
                 ContentFactory = () => _sp.GetRequiredService<TVm>(),
@@ -168,7 +167,6 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         {
             Id = id,
             Label = label,
-            Glyph = "",
             ViewType = viewType,
             Content = content,
             IsInDevelopment = inDevelopment,
@@ -180,10 +178,10 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     private NavGroup[] BuildNavGroups() =>
     [
-        Group("grp-dashboard", "Dashboard",
+        Group("grp-dashboard", "Dashboard", "\uE80F",  // Home
             EagerItem("nav-dashboard", "Dashboard", typeof(Views.DashboardView), _dashboard ?? Eager<DashboardViewModel>())),
 
-        Group("grp-system", "System",
+        Group("grp-system", "System", "\uE770",  // SettingsDisplaySound
             Tab<SystemHealthViewModel>("nav-system-health",    "System Health",    typeof(Views.SystemHealthView)),
             Tab<WindowsUpdateViewModel>("nav-windows-update",  "Windows Update",   typeof(Views.WindowsUpdateView)),
             Tab<PerformanceViewModel>("nav-performance",       "Performance Mode", typeof(Views.PerformanceView)),
@@ -196,14 +194,14 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Tab<SystemFixesViewModel>("nav-system-fixes",      "System Fixes",     typeof(Views.SystemFixesView)),
             Tab<TweaksHubViewModel>("nav-tweaks-hub",          "Tweaks Hub",       typeof(Views.TweaksHubView), inDevelopment: true)),
 
-        Group("grp-gaming", "Gaming & Profiles",
+        Group("grp-gaming", "Gaming & Profiles", "\uE7FC",  // Game
             Tab<GamingProfileViewModel>("nav-gaming-profile",   "Gaming Profile",       typeof(Views.GamingProfileView), inDevelopment: true),
             Tab<StandbyMemoryViewModel>("nav-standby-cleaner",  "Standby List Cleaner", typeof(Views.StandbyMemoryView)),
             Tab<TimerResolutionViewModel>("nav-timer-resolution", "Timer Resolution",   typeof(Views.TimerResolutionView)),
             Tab<CpuAffinityViewModel>("nav-cpu-affinity",       "CPU Core Affinity",    typeof(Views.CpuAffinityView)),
             Tab<DisplayProfileViewModel>("nav-display-profiles", "Display Profiles",    typeof(Views.DisplayProfileView))),
 
-        Group("grp-monitor", "Monitor",
+        Group("grp-monitor", "Monitor", "\uE9D9",  // Diagnostic
             Tab<ProcessManagerViewModel>("nav-processes",       "Process Manager",    typeof(Views.ProcessManagerView)),
             Tab<ResourceHistoryViewModel>("nav-resource-history", "Resource History", typeof(Views.ResourceHistoryView), inDevelopment: true),
             Tab<PrivacyMonitorViewModel>("nav-privacy-monitor", "Camera/Mic/Location", typeof(Views.PrivacyMonitorView)),
@@ -212,29 +210,29 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Tab<SettingsWatchdogViewModel>("nav-settings-watchdog", "Settings Watchdog", typeof(Views.SettingsWatchdogView), inDevelopment: true),
             Tab<BandwidthMonitorViewModel>("nav-bandwidth-monitor", "Bandwidth Monitor", typeof(Views.BandwidthMonitorView))),
 
-        Group("grp-cleanup", "Cleanup",
+        Group("grp-cleanup", "Cleanup", "\uE74D",  // Delete
             Tab<CleanupViewModel>("nav-cleanup",                     "Quick Cleanup",         typeof(Views.CleanupView)),
             Tab<DeepCleanupViewModel>("nav-deep-cleanup",            "Deep Cleanup",          typeof(Views.DeepCleanupView)),
             Tab<ShortcutCleanerViewModel>("nav-shortcut-cleaner",    "Shortcut Cleaner",      typeof(Views.ShortcutCleanerView)),
             Tab<ScheduledMaintenanceViewModel>("nav-scheduled-maintenance", "Scheduled Maintenance", typeof(Views.ScheduledMaintenanceView), inDevelopment: true)),
 
-        Group("grp-storage", "Storage",
+        Group("grp-storage", "Storage", "\uEDA2",  // HardDrive
             Tab<DiskAnalyzerViewModel>("nav-disk-analyzer", "Disk Analyzer",    typeof(Views.DiskAnalyzerView)),
             Tab<DuplicateFileViewModel>("nav-duplicates",   "Duplicate Finder", typeof(Views.DuplicateFileView))),
 
-        Group("grp-network", "Network",
+        Group("grp-network", "Network", "\uE968",  // NetworkTower
             Tab<PingViewModel>("nav-ping",                   "Ping",           typeof(Views.PingView)),
             Tab<TracerouteViewModel>("nav-traceroute",       "Traceroute",     typeof(Views.TracerouteView)),
             Tab<SpeedTestViewModel>("nav-speed-test",        "Speed Test",     typeof(Views.SpeedTestView)),
             Tab<NetworkRepairViewModel>("nav-network-repair", "Network Repair", typeof(Views.NetworkRepairView)),
             Tab<DnsHostsViewModel>("nav-dns-hosts", "DNS & Hosts", typeof(Views.DnsHostsView))),
 
-        Group("grp-apps", "Apps",
+        Group("grp-apps", "Apps", "\uE71D",  // AllApps
             Tab<AppUpdatesViewModel>("nav-app-updates",    "App Updates",    typeof(Views.AppUpdatesView)),
             Tab<BulkInstallerViewModel>("nav-bulk-installer", "Bulk Installer", typeof(Views.BulkInstallerView)),
             Tab<UninstallerViewModel>("nav-uninstaller",   "Uninstaller",    typeof(Views.UninstallerView))),
 
-        Group("grp-privacy", "Privacy & Security",
+        Group("grp-privacy", "Privacy & Security", "\uE72E",  // Lock
             Tab<PrivacyViewModel>("nav-privacy-settings",  "Privacy & Telemetry",   typeof(Views.PrivacyView)),
             Tab<FileShredderViewModel>("nav-file-shredder", "File Shredder",         typeof(Views.FileShredderView)),
             Tab<AppBlockerViewModel>("nav-app-blocker",     "App Blocker",           typeof(Views.AppBlockerView)),
@@ -244,13 +242,13 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Tab<DefenderViewModel>("nav-defender-tweaks",   "Defender Tweaks",       typeof(Views.DefenderView)),
             Tab<NotificationBlockerViewModel>("nav-notification-blocker", "Notification Blocker", typeof(Views.NotificationBlockerView), inDevelopment: true)),
 
-        Group("grp-customization", "Customization",
+        Group("grp-customization", "Customization", "\uE790",  // Personalize
             Tab<ContextMenuViewModel>("nav-context-menu",   "Context Menu",          typeof(Views.ContextMenuView)),
             // DarkMode is eager (schedule poll must run app-wide); hand the DI singleton to its NavItem.
             EagerItem("nav-dark-mode", "Dark Mode Scheduler", typeof(Views.DarkModeView), Eager<DarkModeViewModel>()),
             Tab<AudioMixerViewModel>("nav-volume-control",  "Volume Control",        typeof(Views.AudioMixerView))),
 
-        Group("grp-info", "Info",
+        Group("grp-info", "Info", "\uE946",  // Info
             Tab<DriversViewModel>("nav-drivers",       "Drivers",        typeof(Views.DriversView)),
             Tab<BatteryHealthViewModel>("nav-battery", "Battery Health", typeof(Views.BatteryHealthView)),
             Tab<LogsViewModel>("nav-logs",             "System Logs",    typeof(Views.LogsView)),
@@ -260,15 +258,24 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             // that same instance so the sidebar version label and the tab show one shared VM.
             EagerItem("nav-about", "About", typeof(Views.AboutView), About)),
 
-        Group("grp-advanced", "Advanced",
+        Group("grp-advanced", "Advanced", "\uE713",  // Settings
             Tab<ProfileViewModel>("nav-profile-export", "Profile Export / Import", typeof(Views.ProfileView)),
             Tab<CliInterfaceViewModel>("nav-cli-interface", "CLI Interface",     typeof(Views.CliInterfaceView), inDevelopment: true),
             Tab<EnvironmentVariablesViewModel>("nav-env-variables", "Environment Variables", typeof(Views.EnvironmentVariablesView))),
     ];
 
-    private static NavGroup Group(string id, string label, params NavItem[] children)
+    /// <summary>
+    /// Builds a sidebar group. <paramref name="glyph"/> is a Segoe Fluent Icons codepoint, drawn on the
+    /// group header and — for a single-item group — on its flat row.
+    /// </summary>
+    /// <remarks>
+    /// Every codepoint used here was checked against the installed font files, not chosen from a list:
+    /// each is present in BOTH Segoe Fluent Icons and Segoe MDL2 Assets, because the app falls back to
+    /// MDL2 on Windows 10 and a codepoint missing from it renders as an empty box.
+    /// </remarks>
+    private static NavGroup Group(string id, string label, string glyph, params NavItem[] children)
     {
-        var g = new NavGroup { Id = id, Label = label, Glyph = "" };
+        var g = new NavGroup { Id = id, Label = label, Glyph = glyph };
         foreach (var c in children) g.Children.Add(c);
         g.Subtitle = string.Join(" · ", children.Select(c => c.Label));
         g.Tooltip = string.Join("\n", children.Select(c => c.Label));

--- a/SysManager/SysManager/ViewModels/NavItem.cs
+++ b/SysManager/SysManager/ViewModels/NavItem.cs
@@ -25,7 +25,6 @@ public sealed partial class NavItem : ObservableObject, IDisposable
 
     public required string Id { get; init; }
     public required string Label { get; init; }
-    public required string Glyph { get; init; }
     public required Type ViewType { get; init; }
 
     /// <summary>

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -16,6 +16,17 @@ A short animated tour also lives under [`docs/gifs/`](../gifs/)
 (`feature-tour.gif`, `cleanup-tools.gif`) and is embedded at the top of the
 README's Screenshots section.
 
+## Outstanding recapture
+
+Every shot in this folder, and both GIFs under [`docs/gifs/`](../gifs/), was taken before
+1.76.1 gave the twelve sidebar groups their icons. The rail in each one is therefore a
+column of text with an empty margin beside it, which is not what the app looks like now.
+Nothing else in the shots is stale — the change was confined to that rail and to the
+administrator badge, which is now a shield rather than a padlock.
+
+The whole set wants retaking in one pass rather than piecemeal, so that the rail matches
+across all of them. Until then treat the sidebar in every image as out of date.
+
 ## Format and size
 
 - **Format**: PNG. No JPEG (banding in the dark theme looks bad).


### PR DESCRIPTION
Closes #1492.

## What was wrong

`NavItem` declared `public required string Glyph { get; init; }`, and all three construction sites —
`Tab<TVm>()`, `EagerItem()`, and `Group()` — set it to `""`. `MainWindow.xaml` bound a `TextBlock` to it
beside every one of the 58 entries, so the sidebar reserved a gutter for an icon and then drew whitespace in
it, on every row, forever. Nothing was broken enough to fail a build or a test; the rail just looked
unfinished.

## What this does

**The twelve groups get distinct icons.** `Group()` takes the code point as a parameter, and each call site
names the icon it passes:

| Group | Code point | Icon |
|---|---|---|
| Dashboard | `E80F` | Home |
| System | `E770` | SettingsDisplaySound |
| Gaming & Profiles | `E7FC` | Game |
| Monitor | `E9D9` | Diagnostic |
| Cleanup | `E74D` | Delete |
| Storage | `EDA2` | HardDrive |
| Network | `E968` | NetworkTower |
| Apps | `E71D` | AllApps |
| Privacy & Security | `E72E` | Lock |
| Customization | `E790` | Personalize |
| Info | `E946` | Info |
| Advanced | `E713` | Settings |

**Leaves get none, on purpose.** 58 icons in a 220px rail is noise, and the group heading is what a reader
scans. The leaf `TextBlock` is removed and its gutter goes to the label, which now has room to be read in
full before it ellipsizes. The `DockPanel` around it stays — the label/PREVIEW-pill grid still needs a
finite width to constrain against, which is the reason it was not a `StackPanel` to begin with.

**`NavItem.Glyph` is deleted, not left blank.** Nothing binds it any more, and a `required` property that
every caller satisfies with `""` is worse than no property.

**The elevation badge becomes a shield (`EA18`).** It was the padlock, `E72E` — which is now the Privacy &
Security group's icon in the rail directly above it. One symbol cannot mean both a subject and "this window
has administrator rights" a few centimetres apart. Position, colour, and behaviour are unchanged.

**The single-item row reads the group's glyph.** Dashboard renders as a flat row rather than a collapsible
group, and its inner `Border` overrides `DataContext` to `Children[0]`, so the glyph is reached through the
ancestor `Button`, where the `NavGroup` is still in scope. That idiom
(`{Binding DataContext.X, RelativeSource={RelativeSource AncestorType=…}}`) is already used in 20 other
views.

## Fonts checked, not assumed

The XAML falls back `Segoe Fluent Icons,Segoe MDL2 Assets`, and WPF falls back per-family, not per-glyph: a
code point present in the Windows 11 font and absent from the Windows 10 one renders as an empty box, and no
test in the suite can see that. All 13 code points were looked up in `GlyphTypeface.CharacterToGlyphMap` for
both installed fonts (2032 and 1833 glyphs respectively). Every one resolves in both.

## Two tests that had never run

`SysManager.IntegrationTests` is compile-checked by CI but never executed, so a failing assertion there is
invisible. Two were failing from the day they were written:

- `NavItems_AllHaveLabelsAndGlyphs` asserted a non-blank glyph on every leaf.
- `NavGroups_AllHaveChildren` asserted the same on every group.

Both were true statements about what the code should do and false statements about what it did. The first is
split into `NavItems_AllHaveLabelsAndAView` (label, content, view type) and a new
`NavGroups_CarryDistinctGlyphs`; the second now passes unchanged. Distinctness is the assertion rather than
mere presence, because twelve rows drawn with one icon differentiate no better than twelve empty ones.

## New guard

`EverySidebarGroupGlyph_IsDistinctAndNotTheElevationBadge` in the blocking unit suite reads
`MainWindowViewModel.cs` and `MainWindow.xaml` as text and asserts: at least twelve groups parse, no two
share a code point, and none of them equals whatever the `ElevationBadge` element draws. The collision this
change exists to remove cannot come back silently, in either direction — changing the badge back to the
padlock fails it just as surely as giving a group the shield.

Red/green proof, four mutations, each rebuilt and run:

| Mutation | Result |
|---|---|
| Storage is given Cleanup's icon | red, names `grp-cleanup` |
| the badge goes back to the padlock | red, names `grp-privacy` |
| the group parse pattern stops matching | red, "no longer reading the sidebar" |
| the `ElevationBadge` automation id is renamed | red, "no element with AutomationId" |

Each mutation was reverted with a byte-for-byte SHA check, and the guard is green afterwards. The third case
targets the guard's own regex deliberately: the point is the vacuity floor, so a parse that stops finding
groups has to fail loudly instead of reporting twelve distinct glyphs out of zero.

`LiveRows_ShareSelectedVisualTreatment` counted four live `SidebarNavText` `TextBlock`s and now counts
three, because the removed leaf glyph was one of them. The comment beside it names which three, so a fourth
reappearing reads as the gutter coming back rather than as a number needing a bump.

## Regression sweep

- All four projects build, 0 warnings and 0 errors.
- Full `ArchitectureTests` sweep: 82 green, plus the two known runner-only failures (the author-header
  check flags the throwaway runner's own file; the static-user check cannot find the test source directory
  from an output folder). Both are green in CI.
- Nav, sidebar, automation and bandwidth suites: 73 green, 0 red.
- Every `.Glyph` reference in the tree re-checked; the four call sites that passed `Glyph = ""` are gone and
  none remain.
- 58 leaves re-derived from source (55 `Tab<>` + 3 `EagerItem`), matching the integration assertion and the
  README's claim, so the count quoted in the changelog is not from memory.

## Docs

`ARCHITECTURE.md` gains the group-icon rule in the sidebar paragraph. `docs/screenshots/README.md` records
that all 45 screenshots and both GIFs predate this change and show the old rail; they want retaking in one
pass on the workstation that runs the app, so the rail matches across the set.
