### PR TITLE
fix: give collapsed sidebar groups a subtitle that fits

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,8 +37,8 @@ The sidebar organises tabs into 12 groups (11 collapsible + a flat top-level Das
 for the few entries whose view-model must exist at startup. Dashboard renders as a flat top-level entry.
 Each group carries an icon, passed to `Group()` as a Segoe Fluent Icons code point and asserted distinct;
 leaves carry none, so the icon column belongs to the twelve headings rather than the fifty-eight pages.
-Collapsed groups show a child count badge, subtitle (derived
-from child labels joined with " · "), and tooltip.
+Collapsed groups show a child count badge, a written two-line subtitle passed to `Group()` and asserted to
+fit that budget, and a tooltip still generated from the child labels.
 `MainWindowViewModel.SelectedNav` mirrors selection into `NavItem.IsSelected`.
 The flat Dashboard row and grouped leaf rows are invokable `SidebarNavButton`
 controls. Their inner visuals consume selection through the shared `SidebarNavRow`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.2] - 2026-09-03
+
+When a group in the left-hand list is closed, the line under its name now tells you what the group is for,
+in plain words, on two lines. It used to try to list every page inside the group on one line, which meant it
+listed two or three of them and cut the rest off mid-word.
+
+### Fixed
+- **The closed groups in the sidebar say what they are for.** That line was built by stringing together the
+  names of every page in the group, which for System came to 175 characters in a space about 26 wide — so
+  what you actually read was "System Health · Windows Upda…", two pages out of eleven. Ten of the twelve
+  groups were cut off, Storage included, which only holds two pages. Each group now has a short written
+  line instead, on two lines so it fits whole: System reads "Updates, startup, repairs, restore points",
+  Privacy & Security reads "Tracking, ads and preinstalled apps". It also answers a more useful question —
+  if ads keep appearing, "ads" is easier to spot than "Debloater & Ads". The count in brackets and the
+  hover tooltip, which still lists every page by name, are unchanged.
+
 ## [1.76.1] - 2026-09-03
 
 The twelve groups down the left of the window now have icons. They were meant to all along: the space for

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -2413,6 +2414,121 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"Group\(""(?<id>[^""]+)"",\s*""[^""]+"",\s*""\\u(?<glyph>[0-9A-Fa-f]{4})""",
                     RegexOptions.CultureInvariant)]
     private static partial Regex GroupGlyph();
+
+    /// <summary>
+    /// Every sidebar group's collapsed subtitle is written copy that fits the two lines it is given.
+    /// </summary>
+    /// <remarks>
+    /// The subtitle used to be every child label joined with " · ". For System that produced 175 characters
+    /// in a slot about 26 wide, so two of eleven tabs survived the ellipsis — and the same was true of ten
+    /// other groups, Storage included, which has only two children. Both halves of the fix need pinning:
+    /// written copy that still gets one line is no better off, and a two-line box holding a 175-character
+    /// label dump is no better either.
+    /// <para>The " · " test is the sharp one. It fails the moment someone goes back to generating the
+    /// subtitle from child labels, which is the specific thing that was wrong, rather than merely checking
+    /// that some string is present.</para>
+    /// </remarks>
+    [Fact]
+    public void EverySidebarGroupSubtitle_IsWrittenCopyThatFitsTwoLines()
+    {
+        var app = FindAppProjectDir();
+        var vm = File.ReadAllText(Path.Combine(app, "ViewModels", "MainWindowViewModel.cs"));
+        var shell = File.ReadAllText(Path.Combine(app, "MainWindow.xaml"));
+
+        var groups = GroupSubtitle().Matches(vm).Cast<Match>()
+            .Select(m => (Id: m.Groups["id"].Value,
+                          Label: m.Groups["label"].Value,
+                          Subtitle: m.Groups["subtitle"].Value))
+            .ToArray();
+
+        Assert.True(groups.Length >= 12,
+            $"only {groups.Length} group subtitles were parsed out of BuildNavGroups — the Group(...) call "
+            + "shape changed and this guard is no longer reading the sidebar.");
+
+        var blank = groups.Where(g => string.IsNullOrWhiteSpace(g.Subtitle)).Select(g => g.Id).ToArray();
+        Assert.True(blank.Length == 0,
+            "these groups print nothing under their label while collapsed, so the rail says how many tabs "
+            + $"are hidden but not what they are for: {string.Join(", ", blank)}");
+
+        var dumped = groups.Where(g => g.Subtitle.Contains(" · ", StringComparison.Ordinal))
+            .Select(g => $"{g.Id}: \"{g.Subtitle}\"")
+            .ToArray();
+        Assert.True(dumped.Length == 0,
+            "a group subtitle is a list of child labels joined with \" · \" again. That is the defect this "
+            + "replaced: the joined string ran to 175 characters for System in a slot two lines deep, so it "
+            + "truncated and named two tabs out of eleven. Write a line in the user's words instead — the "
+            + "verbatim child list is already in the tooltip.\n  "
+            + string.Join("\n  ", dumped));
+
+        // 26 characters per line at FontSize 11 in the ~136px the slot actually has, times the two lines the
+        // TextBlock is clamped to. Over budget is not a crash; the tail just goes silently to the ellipsis,
+        // which is precisely the failure this guard exists to keep from coming back.
+        const int budget = 52;
+        var overlong = groups.Where(g => g.Subtitle.Length > budget)
+            .Select(g => $"{g.Id}: {g.Subtitle.Length} chars, \"{g.Subtitle}\"")
+            .ToArray();
+        Assert.True(overlong.Length == 0,
+            $"these subtitles are longer than the {budget} characters two lines hold, so their tail is "
+            + "trimmed away unread:\n  " + string.Join("\n  ", overlong));
+
+        var echoes = groups
+            .Where(g => string.Equals(g.Subtitle, g.Label, StringComparison.OrdinalIgnoreCase))
+            .Select(g => g.Id)
+            .ToArray();
+        Assert.True(echoes.Length == 0,
+            "these subtitles just repeat the group label printed directly above them, which tells a reader "
+            + $"nothing they cannot already see: {string.Join(", ", echoes)}");
+
+        // Everything above reads the CALL SITES. On its own that leaves the factory free to ignore what they
+        // pass — put the join back inside Group() and twelve well-written arguments would sail past while
+        // the rail truncated exactly as before. So the assignment itself is asserted, not merely the strings.
+        var factoryAt = vm.IndexOf("private static NavGroup Group(", StringComparison.Ordinal);
+        Assert.True(factoryAt > 0, "the Group(...) factory was renamed; update this guard in the same PR.");
+        var factory = vm[factoryAt..vm.IndexOf("partial void OnSelectedNavChanged", StringComparison.Ordinal)];
+        Assert.Contains("g.Tooltip", factory, StringComparison.Ordinal);   // the slice really is the factory
+
+        Assert.Contains("g.Subtitle = subtitle;", factory, StringComparison.Ordinal);
+        Assert.DoesNotContain("Subtitle = string.Join", factory, StringComparison.Ordinal);
+
+        // The XAML half, sliced forward from the binding so that the prose above it — which names
+        // TextWrapping, LineHeight and MaxLines while explaining them — cannot satisfy these on its own.
+        var subtitleAt = shell.IndexOf("Text=\"{Binding Subtitle}\"", StringComparison.Ordinal);
+        Assert.True(subtitleAt > 0,
+            "MainWindow.xaml no longer binds a TextBlock to Subtitle, so the written copy reaches nobody.");
+        var element = shell[subtitleAt..shell.IndexOf('>', subtitleAt)];
+
+        Assert.Contains("TextWrapping=\"Wrap\"", element, StringComparison.Ordinal);
+        Assert.Contains("LineStackingStrategy=\"BlockLineHeight\"", element, StringComparison.Ordinal);
+
+        var lineHeight = Measure(SubtitleLineHeight(), element);
+        var maxHeight = Measure(SubtitleMaxHeight(), element);
+        Assert.True(lineHeight > 0 && maxHeight > 0,
+            $"the subtitle's line clamp could not be read (LineHeight={lineHeight}, MaxHeight={maxHeight}). "
+            + "WPF has no MaxLines — that is WinUI — so those two attributes ARE the two-line limit.");
+        Assert.True(Math.Abs(maxHeight - (lineHeight * 2)) < 0.01,
+            $"the subtitle allows {maxHeight / lineHeight:0.##} lines, not two. MaxHeight must be exactly "
+            + $"twice LineHeight ({lineHeight} x 2 = {lineHeight * 2}); the copy is written to a two-line "
+            + $"budget and MaxHeight={maxHeight} silently changes it.");
+    }
+
+    /// <summary>Reads a numeric XAML attribute out of an element slice, or 0 when it is absent.</summary>
+    private static double Measure(Regex pattern, string element) =>
+        pattern.Match(element) is { Success: true } m
+            ? double.Parse(m.Groups["v"].Value, CultureInfo.InvariantCulture)
+            : 0;
+
+    /// <summary>
+    /// A sidebar group declaration, capturing its id, label and written subtitle.
+    /// </summary>
+    [GeneratedRegex(@"Group\(""(?<id>[^""]+)"",\s*""(?<label>[^""]+)"",\s*""\\u[0-9A-Fa-f]{4}"",\s*""(?<subtitle>[^""]*)""",
+                    RegexOptions.CultureInvariant)]
+    private static partial Regex GroupSubtitle();
+
+    [GeneratedRegex(@"LineHeight=""(?<v>[0-9.]+)""", RegexOptions.CultureInvariant)]
+    private static partial Regex SubtitleLineHeight();
+
+    [GeneratedRegex(@"MaxHeight=""(?<v>[0-9.]+)""", RegexOptions.CultureInvariant)]
+    private static partial Regex SubtitleMaxHeight();
 
     /// <summary>A XAML character reference, capturing the hex codepoint.</summary>
     [GeneratedRegex(@"&#x(?<hex>[0-9A-Fa-f]{4});", RegexOptions.CultureInvariant)]

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -227,11 +227,21 @@
                                                                    FontSize="10" Foreground="{DynamicResource TextSecondary}"
                                                                    Opacity="0.7" Margin="2,0,0,0"/>
                                                     </StackPanel>
-                                                    <!-- Subtitle: visible only when collapsed -->
+                                                    <!-- Subtitle: visible only when collapsed. Wraps to
+                                                         exactly two lines; on one it had about 26
+                                                         characters, which truncated all eleven groups.
+                                                         WPF has no MaxLines (that is WinUI), so the
+                                                         ceiling is LineHeight x 2 with BlockLineHeight
+                                                         pinning the line box, which makes the height
+                                                         independent of font metrics. TextTrimming stays
+                                                         as the backstop for copy that outgrows even two. -->
                                                     <TextBlock Text="{Binding Subtitle}"
                                                                FontFamily="{StaticResource UiFont}"
                                                                FontSize="11" Foreground="{DynamicResource TextSecondary}"
                                                                Opacity="0.65" Margin="23,2,0,0"
+                                                               TextWrapping="Wrap"
+                                                               LineHeight="14" LineStackingStrategy="BlockLineHeight"
+                                                               MaxHeight="28"
                                                                TextTrimming="CharacterEllipsis">
                                                         <TextBlock.Style>
                                                             <Style TargetType="TextBlock">

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.1</Version>
-    <FileVersion>1.76.1.0</FileVersion>
-    <AssemblyVersion>1.76.1.0</AssemblyVersion>
+    <Version>1.76.2</Version>
+    <FileVersion>1.76.2.0</FileVersion>
+    <AssemblyVersion>1.76.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -178,10 +178,10 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     private NavGroup[] BuildNavGroups() =>
     [
-        Group("grp-dashboard", "Dashboard", "\uE80F",  // Home
+        Group("grp-dashboard", "Dashboard", "\uE80F", "How this PC is doing",  // Home
             EagerItem("nav-dashboard", "Dashboard", typeof(Views.DashboardView), _dashboard ?? Eager<DashboardViewModel>())),
 
-        Group("grp-system", "System", "\uE770",  // SettingsDisplaySound
+        Group("grp-system", "System", "\uE770", "Updates, startup, repairs, restore points",  // SettingsDisplaySound
             Tab<SystemHealthViewModel>("nav-system-health",    "System Health",    typeof(Views.SystemHealthView)),
             Tab<WindowsUpdateViewModel>("nav-windows-update",  "Windows Update",   typeof(Views.WindowsUpdateView)),
             Tab<PerformanceViewModel>("nav-performance",       "Performance Mode", typeof(Views.PerformanceView)),
@@ -194,14 +194,14 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Tab<SystemFixesViewModel>("nav-system-fixes",      "System Fixes",     typeof(Views.SystemFixesView)),
             Tab<TweaksHubViewModel>("nav-tweaks-hub",          "Tweaks Hub",       typeof(Views.TweaksHubView), inDevelopment: true)),
 
-        Group("grp-gaming", "Gaming & Profiles", "\uE7FC",  // Game
+        Group("grp-gaming", "Gaming & Profiles", "\uE7FC", "Make games run smoother",  // Game
             Tab<GamingProfileViewModel>("nav-gaming-profile",   "Gaming Profile",       typeof(Views.GamingProfileView), inDevelopment: true),
             Tab<StandbyMemoryViewModel>("nav-standby-cleaner",  "Standby List Cleaner", typeof(Views.StandbyMemoryView)),
             Tab<TimerResolutionViewModel>("nav-timer-resolution", "Timer Resolution",   typeof(Views.TimerResolutionView)),
             Tab<CpuAffinityViewModel>("nav-cpu-affinity",       "CPU Core Affinity",    typeof(Views.CpuAffinityView)),
             Tab<DisplayProfileViewModel>("nav-display-profiles", "Display Profiles",    typeof(Views.DisplayProfileView))),
 
-        Group("grp-monitor", "Monitor", "\uE9D9",  // Diagnostic
+        Group("grp-monitor", "Monitor", "\uE9D9", "What is running, and what it is using",  // Diagnostic
             Tab<ProcessManagerViewModel>("nav-processes",       "Process Manager",    typeof(Views.ProcessManagerView)),
             Tab<ResourceHistoryViewModel>("nav-resource-history", "Resource History", typeof(Views.ResourceHistoryView), inDevelopment: true),
             Tab<PrivacyMonitorViewModel>("nav-privacy-monitor", "Camera/Mic/Location", typeof(Views.PrivacyMonitorView)),
@@ -210,29 +210,29 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Tab<SettingsWatchdogViewModel>("nav-settings-watchdog", "Settings Watchdog", typeof(Views.SettingsWatchdogView), inDevelopment: true),
             Tab<BandwidthMonitorViewModel>("nav-bandwidth-monitor", "Bandwidth Monitor", typeof(Views.BandwidthMonitorView))),
 
-        Group("grp-cleanup", "Cleanup", "\uE74D",  // Delete
+        Group("grp-cleanup", "Cleanup", "\uE74D", "Free up space and tidy up",  // Delete
             Tab<CleanupViewModel>("nav-cleanup",                     "Quick Cleanup",         typeof(Views.CleanupView)),
             Tab<DeepCleanupViewModel>("nav-deep-cleanup",            "Deep Cleanup",          typeof(Views.DeepCleanupView)),
             Tab<ShortcutCleanerViewModel>("nav-shortcut-cleaner",    "Shortcut Cleaner",      typeof(Views.ShortcutCleanerView)),
             Tab<ScheduledMaintenanceViewModel>("nav-scheduled-maintenance", "Scheduled Maintenance", typeof(Views.ScheduledMaintenanceView), inDevelopment: true)),
 
-        Group("grp-storage", "Storage", "\uEDA2",  // HardDrive
+        Group("grp-storage", "Storage", "\uEDA2", "See what is filling the disk",  // HardDrive
             Tab<DiskAnalyzerViewModel>("nav-disk-analyzer", "Disk Analyzer",    typeof(Views.DiskAnalyzerView)),
             Tab<DuplicateFileViewModel>("nav-duplicates",   "Duplicate Finder", typeof(Views.DuplicateFileView))),
 
-        Group("grp-network", "Network", "\uE968",  // NetworkTower
+        Group("grp-network", "Network", "\uE968", "Test the connection, fix the internet",  // NetworkTower
             Tab<PingViewModel>("nav-ping",                   "Ping",           typeof(Views.PingView)),
             Tab<TracerouteViewModel>("nav-traceroute",       "Traceroute",     typeof(Views.TracerouteView)),
             Tab<SpeedTestViewModel>("nav-speed-test",        "Speed Test",     typeof(Views.SpeedTestView)),
             Tab<NetworkRepairViewModel>("nav-network-repair", "Network Repair", typeof(Views.NetworkRepairView)),
             Tab<DnsHostsViewModel>("nav-dns-hosts", "DNS & Hosts", typeof(Views.DnsHostsView))),
 
-        Group("grp-apps", "Apps", "\uE71D",  // AllApps
+        Group("grp-apps", "Apps", "\uE71D", "Install, update and remove programs",  // AllApps
             Tab<AppUpdatesViewModel>("nav-app-updates",    "App Updates",    typeof(Views.AppUpdatesView)),
             Tab<BulkInstallerViewModel>("nav-bulk-installer", "Bulk Installer", typeof(Views.BulkInstallerView)),
             Tab<UninstallerViewModel>("nav-uninstaller",   "Uninstaller",    typeof(Views.UninstallerView))),
 
-        Group("grp-privacy", "Privacy & Security", "\uE72E",  // Lock
+        Group("grp-privacy", "Privacy & Security", "\uE72E", "Tracking, ads and preinstalled apps",  // Lock
             Tab<PrivacyViewModel>("nav-privacy-settings",  "Privacy & Telemetry",   typeof(Views.PrivacyView)),
             Tab<FileShredderViewModel>("nav-file-shredder", "File Shredder",         typeof(Views.FileShredderView)),
             Tab<AppBlockerViewModel>("nav-app-blocker",     "App Blocker",           typeof(Views.AppBlockerView)),
@@ -242,13 +242,13 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             Tab<DefenderViewModel>("nav-defender-tweaks",   "Defender Tweaks",       typeof(Views.DefenderView)),
             Tab<NotificationBlockerViewModel>("nav-notification-blocker", "Notification Blocker", typeof(Views.NotificationBlockerView), inDevelopment: true)),
 
-        Group("grp-customization", "Customization", "\uE790",  // Personalize
+        Group("grp-customization", "Customization", "\uE790", "Right-click menu, dark mode, volume",  // Personalize
             Tab<ContextMenuViewModel>("nav-context-menu",   "Context Menu",          typeof(Views.ContextMenuView)),
             // DarkMode is eager (schedule poll must run app-wide); hand the DI singleton to its NavItem.
             EagerItem("nav-dark-mode", "Dark Mode Scheduler", typeof(Views.DarkModeView), Eager<DarkModeViewModel>()),
             Tab<AudioMixerViewModel>("nav-volume-control",  "Volume Control",        typeof(Views.AudioMixerView))),
 
-        Group("grp-info", "Info", "\uE946",  // Info
+        Group("grp-info", "Info", "\uE946", "Drivers, battery, logs and reports",  // Info
             Tab<DriversViewModel>("nav-drivers",       "Drivers",        typeof(Views.DriversView)),
             Tab<BatteryHealthViewModel>("nav-battery", "Battery Health", typeof(Views.BatteryHealthView)),
             Tab<LogsViewModel>("nav-logs",             "System Logs",    typeof(Views.LogsView)),
@@ -258,7 +258,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             // that same instance so the sidebar version label and the tab show one shared VM.
             EagerItem("nav-about", "About", typeof(Views.AboutView), About)),
 
-        Group("grp-advanced", "Advanced", "\uE713",  // Settings
+        Group("grp-advanced", "Advanced", "\uE713", "Command line and portable settings",  // Settings
             Tab<ProfileViewModel>("nav-profile-export", "Profile Export / Import", typeof(Views.ProfileView)),
             Tab<CliInterfaceViewModel>("nav-cli-interface", "CLI Interface",     typeof(Views.CliInterfaceView), inDevelopment: true),
             Tab<EnvironmentVariablesViewModel>("nav-env-variables", "Environment Variables", typeof(Views.EnvironmentVariablesView))),
@@ -266,18 +266,28 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     /// <summary>
     /// Builds a sidebar group. <paramref name="glyph"/> is a Segoe Fluent Icons codepoint, drawn on the
-    /// group header and — for a single-item group — on its flat row.
+    /// group header and — for a single-item group — on its flat row. <paramref name="subtitle"/> is the
+    /// line printed under the label while the group is collapsed.
     /// </summary>
     /// <remarks>
     /// Every codepoint used here was checked against the installed font files, not chosen from a list:
     /// each is present in BOTH Segoe Fluent Icons and Segoe MDL2 Assets, because the app falls back to
     /// MDL2 on Windows 10 and a codepoint missing from it renders as an empty box.
+    /// <para>The subtitle is written, not generated. It used to be every child label joined with " · ",
+    /// which for System came to 175 characters in a slot about 26 characters wide: two of eleven tabs
+    /// survived the ellipsis, and the same was true of ten other groups. It also answered the wrong
+    /// question. Someone looking for why ads keep appearing does not scan for "Debloater &amp; Ads"; the
+    /// subtitle now says "ads" in the words she would use. Two lines, so it fits whole.</para>
+    /// <para>Written copy can drift from the tabs it describes when one moves group, which is why it lives
+    /// on the same line as the group it belongs to — the two are edited together, and the full list of
+    /// children is still available verbatim in the tooltip below.</para>
     /// </remarks>
-    private static NavGroup Group(string id, string label, string glyph, params NavItem[] children)
+    private static NavGroup Group(
+        string id, string label, string glyph, string subtitle, params NavItem[] children)
     {
         var g = new NavGroup { Id = id, Label = label, Glyph = glyph };
         foreach (var c in children) g.Children.Add(c);
-        g.Subtitle = string.Join(" · ", children.Select(c => c.Label));
+        g.Subtitle = subtitle;
         g.Tooltip = string.Join("\n", children.Select(c => c.Label));
         return g;
     }

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -18,11 +18,12 @@ README's Screenshots section.
 
 ## Outstanding recapture
 
-Every shot in this folder, and both GIFs under [`docs/gifs/`](../gifs/), was taken before
-1.76.1 gave the twelve sidebar groups their icons. The rail in each one is therefore a
-column of text with an empty margin beside it, which is not what the app looks like now.
-Nothing else in the shots is stale — the change was confined to that rail and to the
-administrator badge, which is now a shield rather than a padlock.
+Every shot in this folder, and both GIFs under [`docs/gifs/`](../gifs/), predates two
+changes to the left-hand rail. 1.76.1 gave the twelve groups their icons, so the rail in
+each image is a column of text with an empty margin beside it. 1.76.2 replaced each
+collapsed group's subtitle — a truncated list of page names — with a written two-line
+description. Nothing else in the shots is stale: both changes were confined to that rail
+and to the administrator badge, which is now a shield rather than a padlock.
 
 The whole set wants retaking in one pass rather than piecemeal, so that the rail matches
 across all of them. Until then treat the sidebar in every image as out of date.


### PR DESCRIPTION
Closes #1518.

## What was wrong

`Group()` built each group's subtitle as `string.Join(" · ", children.Select(c => c.Label))` — every child
label, on one line, in a `TextBlock` with `TextTrimming="CharacterEllipsis"`.

That slot has about **136px**: 220 for the rail, minus the `ItemsControl`'s `Padding="10,0"`, the header
`Border`'s `Padding="14,10"`, the chevron column, and the subtitle's own `Margin="23,2,0,0"`. At `FontSize`
11 that is roughly **26 characters**. Re-measured from current source rather than taken from the issue:

| group | children | generated | readable |
|---|---|---|---|
| System | 11 | 175 chars | 2 of 11 |
| Privacy & Security | 8 | 150 | 2 of 8 |
| Monitor | 7 | 134 | 2 of 7 |
| Gaming & Profiles | 5 | 95 | 2 of 5 |
| Info | 6 | 78 | 2 of 6 |
| Cleanup | 4 | 71 | 2 of 4 |
| Advanced | 3 | 63 | 2 of 3 |
| Network | 5 | 61 | 3 of 5 |
| Customization | 3 | 51 | 2 of 3 |
| Apps | 3 | 42 | 2 of 3 |
| Storage | 2 | 32 | 2 of 2 |

Eleven groups truncated, not the two the issue reported. Only Dashboard escaped, and only because it is a
single-item group that renders as a flat row and prints no subtitle at all.

## What this does

`Group()` takes the subtitle as a parameter, on the same line as the group it belongs to, and the `TextBlock`
wraps to exactly two lines:

| group | subtitle | chars |
|---|---|---|
| Dashboard | How this PC is doing | 20 |
| System | Updates, startup, repairs, restore points | 41 |
| Gaming & Profiles | Make games run smoother | 23 |
| Monitor | What is running, and what it is using | 37 |
| Cleanup | Free up space and tidy up | 25 |
| Storage | See what is filling the disk | 28 |
| Network | Test the connection, fix the internet | 37 |
| Apps | Install, update and remove programs | 35 |
| Privacy & Security | Tracking, ads and preinstalled apps | 35 |
| Customization | Right-click menu, dark mode, volume | 35 |
| Info | Drivers, battery, logs and reports | 34 |
| Advanced | Command line and portable settings | 34 |

Written copy also answers a better question than a list of tab names. Someone whose problem is that ads keep
appearing scans for "ads"; "Debloater & Ads" is a word the app made up. The `(N)` count badge and the tooltip
are untouched — the tooltip still lists every child verbatim, which is the one affordance that already showed
everything.

**The two-line clamp.** WPF has no `MaxLines`; that is WinUI, and using it fails the build with MC3072. The
ceiling is `LineHeight="14"` with `LineStackingStrategy="BlockLineHeight"` and `MaxHeight="28"`, which pins
the line box so the height does not drift with font metrics. `TextTrimming` stays as the backstop for copy
that outgrows even two lines.

**Cost, stated plainly.** Twelve hand-written strings are a surface that can drift when a tab moves group.
They live on the same line as their `Group(...)` call so the two are edited together, and the guard below
enforces the budget mechanically. The collapsed rail also grows by one line per group.

## New guard

`EverySidebarGroupSubtitle_IsWrittenCopyThatFitsTwoLines`, in the blocking unit suite, checks both halves —
written copy that still gets one line is no better off, and a two-line box holding a 175-character label dump
is no better either:

- at least twelve groups parse (vacuity floor)
- no subtitle is blank
- **no subtitle contains `" · "`** — the sharp one: it fails the moment someone regenerates from child labels
- none exceeds the 52-character two-line budget
- none merely repeats the group label printed directly above it
- `Group()` assigns the parameter and does not contain `Subtitle = string.Join`
- the XAML wraps, uses `BlockLineHeight`, and has `MaxHeight` exactly twice `LineHeight`

That sixth check is the one worth explaining. Every other assertion reads the **call sites**, so on its own
the guard would let the join come back inside `Group()` while twelve well-written arguments sailed past and
the rail truncated exactly as before. Mutation C below is that case.

Red/green proof, five mutations, each rebuilt and run:

| Mutation | Result |
|---|---|
| a call site goes back to a label dump | red, "joined with ` · ` again" |
| a call site's copy outgrows two lines | red, "grp-storage: 66 chars" |
| the factory regenerates the join, ignoring the parameter | red, `g.Subtitle = subtitle;` not found |
| the clamp becomes three lines | red, "allows 3 lines, not two" |
| the subtitle stops wrapping | red, `TextWrapping="Wrap"` not found |

Both touched files restored byte-for-byte by SHA, guard green afterwards.

## Regression sweep

- All four projects build, 0 warnings and 0 errors.
- `ArchitectureTests`: 83 green, plus the two known runner-only failures (the author-header check flags the
  throwaway runner's own file; the static-user check cannot find the test source directory from an output
  folder). Both green in CI.
- Nav, sidebar, automation and bandwidth suites: 73 green, 0 red.
- `Subtitle` has exactly one consumer, re-checked: the collapsed group header. `NavGroupTests` builds
  `NavGroup` directly and is unaffected; the two UI tests named `Subtitle_Visible` assert page headers
  ("Live ping"), not sidebar text.
- `GroupGlyph()` in the v1.76.1 guard does not anchor past the glyph argument, so the added parameter leaves
  it matching; verified by running both sidebar guards together.
- Every touched file re-checked for orphan CRs, which is how a script-driven edit can silently flip a file to
  binary in git's eyes and stage a whole-file rewrite.

## Design

Built as an HTML mockup at the real 220px width first, with the current truncation beside two candidate
treatments — written two-line copy, and a generated "top two tabs + N more" one-liner that cannot drift but
still speaks in tab names. The two-line written version was chosen.
