### PR TITLE
fix: give both admin banners one geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.3] - 2026-09-03
+
+The strip at the top of a page that says whether SysManager is running as administrator changes when you
+grant it. It used to change more than it needed to: the corners went from slightly rounded to more rounded,
+and the strip got 26 pixels shorter, so everything below it jumped.
+
+### Fixed
+- **The administrator strip keeps its shape when you elevate.** Thirty-one pages draw two versions of that
+  strip in the same place — one asking for administrator rights, one confirming you have them — and the two
+  had been written with different corner rounding and different internal spacing. Swapping between them moved
+  everything underneath by 26 pixels and visibly changed the corners, at the exact moment the app should look
+  steady. Both now use the same rounding and spacing, so the only thing that changes is the wording, the
+  colour, and the "Run as administrator" button disappearing once there is nothing left to click. That button
+  is 18 of the original 26 pixels and cannot be helped; the other 8, and the corners, were an accident.
+
+### Changed
+- **The strip asking for administrator rights is slightly more rounded and 8 pixels shorter.** It adopted the
+  rounding and spacing the confirming version already used, which is also the rounding every other card in
+  the app uses. Nothing moved position and no wording changed.
+
 ## [1.76.2] - 2026-09-03
 
 When a group in the left-hand list is closed, the line under its name now tells you what the group is for,

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -434,6 +434,70 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// The two elevation banners that share a slot must share one geometry.
+    /// </summary>
+    /// <remarks>
+    /// 27 views render both banners in the same <c>Grid.Row</c>, swapped on <c>IsElevated</c>, and the two
+    /// were hand-written with different geometry: <c>CornerRadius="8" Padding="14,12"</c> when not elevated
+    /// in 27 of 27 views, <c>CornerRadius="12" Padding="12,8"</c> when elevated in 29 of 29. Measured, the
+    /// banner in that fixed slot was 61.29px in one state and 35.29px in the other, so everything below it
+    /// jumped 26px at the moment the user granted elevation — and the corners visibly changed shape with it.
+    /// <para>18px of that jump is the "Run as administrator" button, which the elevated state has nothing to
+    /// replace with, and no geometry removes it. This asserts the part that was an accident: one radius, one
+    /// padding, both states.</para>
+    /// <para>Companion to <see cref="EveryGoldElevationBanner_PromisesMoreAccess"/>, which guards what the
+    /// banner SAYS. Same parse, different concern, so they stay separate tests. Both read the markup rather
+    /// than a comment, which also means a view that copies the old block without the comment cannot slip
+    /// past.</para>
+    /// </remarks>
+    [Fact]
+    public void BothAdminBanners_ShareOneGeometry()
+    {
+        var viewsDir = Path.Combine(FindAppProjectDir(), "Views");
+        var seen = new List<(string View, string State, string Geometry)>();
+
+        foreach (var file in Directory.GetFiles(viewsDir, "*.xaml"))
+        {
+            XDocument doc;
+            try { doc = XDocument.Parse(File.ReadAllText(file)); }
+            catch (System.Xml.XmlException) { continue; }
+
+            foreach (var border in doc.Descendants().Where(e => e.Name.LocalName == "Border"))
+            {
+                var visibility = (string?)border.Attribute("Visibility") ?? "";
+                if (!visibility.Contains("IsElevated", StringComparison.Ordinal)) continue;
+
+                var radius = (string?)border.Attribute("CornerRadius");
+                var padding = (string?)border.Attribute("Padding");
+                if (radius is null || padding is null) continue;
+
+                // Inverse == shown when NOT elevated, which is the other banner in the same slot.
+                var state = visibility.Contains("Inverse", StringComparison.Ordinal) ? "not-elevated" : "elevated";
+                seen.Add((Path.GetFileName(file), state, $"CornerRadius={radius} Padding={padding}"));
+            }
+        }
+
+        // Guards the guard: with no banners parsed, "all geometries agree" is true of an empty set.
+        Assert.True(seen.Count >= 50,
+            $"only {seen.Count} elevation banners parsed out of Views/ — the markup this reads has changed "
+            + "shape, so the check is passing on an empty set.");
+
+        var geometries = seen
+            .GroupBy(b => b.Geometry, StringComparer.Ordinal)
+            .OrderByDescending(g => g.Count())
+            .Select(g => $"{g.Key} — {g.Count()} banner(s): "
+                         + string.Join(", ", g.Select(b => $"{b.View} ({b.State})").Take(4))
+                         + (g.Count() > 4 ? ", …" : ""))
+            .ToArray();
+
+        Assert.True(geometries.Length == 1,
+            "the elevation banners do not agree on their geometry. Both states occupy the SAME slot in 27 "
+            + "views, so a difference here is the layout below them jumping the moment the user elevates — "
+            + "which is the one moment the app should look steady. Pick one radius and one padding:\n  "
+            + string.Join("\n  ", geometries));
+    }
+
+    /// <summary>
     /// <c>TextWrapping="Wrap"</c> must not sit inside a horizontal <c>StackPanel</c>, where it does
     /// nothing.
     /// </summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.2</Version>
-    <FileVersion>1.76.2.0</FileVersion>
-    <AssemblyVersion>1.76.2.0</AssemblyVersion>
+    <Version>1.76.3</Version>
+    <FileVersion>1.76.3.0</FileVersion>
+    <AssemblyVersion>1.76.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -28,7 +28,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -22,7 +22,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/BandwidthMonitorView.xaml
+++ b/SysManager/SysManager/Views/BandwidthMonitorView.xaml
@@ -30,7 +30,7 @@
 
         <!-- Elevation banner: not elevated (precise mode needs admin; safe mode already works) -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml
@@ -28,7 +28,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -28,7 +28,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -21,7 +21,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -29,7 +29,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -57,7 +57,7 @@
 
             <!-- ═══ ROW 1: Elevation banner ═══ -->
             <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                    BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                    BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                     Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
                 <DockPanel>
                     <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/DefenderView.xaml
+++ b/SysManager/SysManager/Views/DefenderView.xaml
@@ -32,7 +32,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -19,7 +19,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/EdgeOneDriveView.xaml
+++ b/SysManager/SysManager/Views/EdgeOneDriveView.xaml
@@ -28,7 +28,7 @@
         <!-- Elevation banner: not elevated. OneDrive removal works without admin; the Edge
              portion writes machine policy + scheduled tasks, so it needs elevation. -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -27,7 +27,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/FileLockView.xaml
+++ b/SysManager/SysManager/Views/FileLockView.xaml
@@ -31,7 +31,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/GamingProfileView.xaml
+++ b/SysManager/SysManager/Views/GamingProfileView.xaml
@@ -32,7 +32,7 @@
 
         <!-- Admin banner (some optimizations need elevation) -->
         <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml
@@ -16,7 +16,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/PerformanceView.xaml
+++ b/SysManager/SysManager/Views/PerformanceView.xaml
@@ -28,7 +28,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -27,7 +27,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -28,7 +28,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/RestorePointsView.xaml
+++ b/SysManager/SysManager/Views/RestorePointsView.xaml
@@ -28,7 +28,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -27,7 +27,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/SettingsWatchdogView.xaml
+++ b/SysManager/SysManager/Views/SettingsWatchdogView.xaml
@@ -51,7 +51,7 @@
 
         <!-- Elevation banner: not elevated (restoring HKLM-backed settings needs admin) -->
         <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -29,7 +29,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,16,28,0"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,16,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/StandbyMemoryView.xaml
+++ b/SysManager/SysManager/Views/StandbyMemoryView.xaml
@@ -32,7 +32,7 @@
 
         <!-- Elevation banner -->
         <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -27,7 +27,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/SystemFixesView.xaml
+++ b/SysManager/SysManager/Views/SystemFixesView.xaml
@@ -28,7 +28,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -23,7 +23,7 @@
 
                 <!-- Elevation banner: not elevated -->
                 <Border Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                        BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,12,0,0"
+                        BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,12,0,0"
                         Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
                     <DockPanel>
                         <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml
@@ -31,7 +31,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/TweaksHubView.xaml
+++ b/SysManager/SysManager/Views/TweaksHubView.xaml
@@ -71,7 +71,7 @@
 
         <!-- Admin banner (only Advanced tweaks need it) -->
         <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -29,7 +29,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
@@ -49,7 +49,7 @@
              the neutral Surface2/Border1 geometry of the not-elevated banner directly above instead, so
              the slot does not change appearance when the user elevates on another tab and arrives here. -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
             <!-- DockPanel, not the sibling banners' horizontal StackPanel: this message is the longest in
                  the app, and a StackPanel hands its children infinite width along its orientation, so

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -53,7 +53,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -30,7 +30,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="28,12,28,0"
+                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -22,8 +22,9 @@ Every shot in this folder, and both GIFs under [`docs/gifs/`](../gifs/), predate
 changes to the left-hand rail. 1.76.1 gave the twelve groups their icons, so the rail in
 each image is a column of text with an empty margin beside it. 1.76.2 replaced each
 collapsed group's subtitle — a truncated list of page names — with a written two-line
-description. Nothing else in the shots is stale: both changes were confined to that rail
-and to the administrator badge, which is now a shield rather than a padlock.
+description. 1.76.3 then gave the administrator strip at the top of 31 pages a single
+geometry, so where a shot shows that strip its corners and height are also out of date.
+Nothing else in the shots is stale.
 
 The whole set wants retaking in one pass rather than piecemeal, so that the rail matches
 across all of them. Until then treat the sidebar in every image as out of date.


### PR DESCRIPTION
Closes #1632.

## What was wrong

The two elevation banners occupy the same `Grid.Row` and swap on `IsElevated`, but were hand-written with
different geometry: `CornerRadius="8" Padding="14,12"` when not elevated, `CornerRadius="12" Padding="12,8"`
when elevated. Only 12 is the app's banner radius (`RadiusLg`); 8 is `RadiusMd`.

## Measured, not estimated

The issue calls the height difference "~4px". A WPF harness that builds both `Border` trees exactly as the
views declare them and calls `Measure()` at 1004px — a 1280 window less the 220 rail and the 28+28 gutter —
says otherwise:

| geometry | not elevated | elevated | shift |
|---|---|---|---|
| shipped before this PR | 61.29px | 35.29px | **26px** |
| both 12 / 12,8 (this PR) | 53.29px | 35.29px | 18px |
| both 12 / 14,12 | 61.29px | 43.29px | 18px |

**26px**, and the corners visibly changed with it. Both candidate paddings land on the same 18px, because
that residue is the "Run as administrator" button: the elevated state has nothing to replace it with, and no
geometry choice removes it. What this PR fixes is the 8px and the corners, which were an accident.

`12,8` was chosen over `14,12` so the elevated state — the one a user ends up in — is untouched, and the
change falls on the state they see first.

## Counted by markup, which changed the answer

The issue counted banners by grepping their comment: 27 not-elevated, 29 elevated. The guard parses the
markup instead — any `Border` whose `Visibility` binds `IsElevated` — and finds **62 banners across 31
views**, 31 in each state.

That difference was not academic. My first pass anchored on the comment and fixed 27 views; the guard then
went red and named five more still at the old geometry, in views that never carried the comment
(`DashboardView`, `GamingProfileView`, `StandbyMemoryView`, `TweaksHubView`, and a third banner in
`UninstallerView` — the one place where elevation *disables* a feature rather than unlocking one). The guard
finding real violations on its first run is the argument for reading markup rather than comments.

One `CornerRadius="8" Padding="14,12"` remains in `Views/`, in `LegacyPanelsView.xaml`, and is correctly
untouched: it is a `Button` `ControlTemplate` for a legacy-panel card, not a banner. The replacement was
scoped to `Border` tags binding `IsElevated` for exactly this reason — the pair occurs 33 times across the
views, and a global replace would have silently restyled unrelated elements.

## Deliberately not the AdminBanner extraction

The issue proposes extracting a shared `AdminBanner` control, which is #1618's scope and is an L. This is the
S underneath it: one geometry, no structural change, no refactor mixed into a fix. It also makes the
extraction safer — 62 identical blocks collapse more cleanly than 62 blocks in two shapes, and the guard
survives to hold the result.

For the same reason the radius is the literal `12` rather than `{StaticResource RadiusLg}`: that matches the
31 elevated banners exactly, and migrating all 62 to the token belongs in the extraction, where the token
gets written once.

## New guard

`BothAdminBanners_ShareOneGeometry`, in the blocking unit suite, groups every parsed banner by
`CornerRadius`+`Padding` and asserts exactly one distinct geometry, with a floor of 50 banners so the check
cannot pass on an empty set. Sibling to `EveryGoldElevationBanner_PromisesMoreAccess`, which guards what the
banner *says* — same parse, different concern, so they stay separate tests.

Asserting "one geometry" rather than "the not-elevated banner must be 12/12,8" is deliberate: it catches
drift in either direction, which mutation B below is.

Red/green proof, three mutations, each rebuilt and run:

| Mutation | Result |
|---|---|
| a not-elevated banner reverts to 8 / 14,12 | red, names `CleanupView.xaml (not-elevated)` |
| an **elevated** banner drifts to 14,12 instead | red, names `ServicesView.xaml` |
| the guard's `IsElevated` filter stops matching | red, "only 0 elevation banners parsed … passing on an empty set" |

All three files restored byte-for-byte by SHA, guard green afterwards. The first attempt at this proof
hand-wrote its anchors and reported "target appears 0 times" on all three cases — `\n` against CRLF files,
and one string that now occurs twice precisely because both banners share a geometry. The anchors are located
by parsing now, so they cannot go stale.

## Regression sweep

- All four projects build, 0 warnings and 0 errors.
- `ArchitectureTests`: 84 green (83 plus the new guard), plus the two known runner-only failures — the
  author-header check flags the throwaway runner's own file, and the static-user check cannot find the test
  source directory from an output folder. Both green in CI.
- Nav, sidebar, automation and bandwidth suites: 73 green, 0 red.
- `EveryGoldElevationBanner_PromisesMoreAccess` re-run explicitly: green, so the banner copy is unaffected.
- No not-elevated banner has a child with a negative margin, so nothing was coupled to the old padding. The
  elevated banner's 4px stripe *is* coupled — its `Margin="-12,-8,0,-8"` cancels `Padding="12,8"` — and that
  banner's padding is unchanged, so the stripe still reaches the border edge.
- Every touched file re-checked for orphan CRs and confirmed `w/crlf`, so none of the 32 diffs is a
  whole-file rewrite.

## Docs

`docs/screenshots/README.md` records that where a shot shows the administrator strip, its corners and height
are now out of date, alongside the two rail changes already noted for 1.76.1 and 1.76.2. No document stated
the geometry, so nothing else needed correcting.
