### PR TITLE
fix: stop the audio picker naming a device it is guessing at

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -389,7 +389,10 @@ Key services:
   SET call is invoked only after a successful `QueryInterface` for the exact IID and any failure
   returns false), and its endpoint-id/process-token string helpers are pure + unit-tested. The
   routing SET path can only be runtime-verified on a real desktop (laptop workstation), not the
-  build box.
+  build box. The READ path (`GetPersistedDefaultEndpoint`) is deliberately unimplemented and returns
+  null, so `IAudioMixerService.GetSessionOutputDevice` has a three-state contract — an endpoint id,
+  `string.Empty` for "read succeeded, no override", or null for "could not read" — and the row VM
+  renders null as unknown rather than as the default device.
 - `VolumePresetService` — persists named per-app volume/mute presets as JSON under
   `%LocalAppData%\SysManager\volume-presets.json`, keyed by exe name so a preset re-applies to
   whatever instance of an app is running. Save/parse/upsert and the "apply preset → live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.4] - 2026-09-03
+
+Volume Control no longer claims to know which speakers or headset an app is playing through when it does not.
+The picker beside each app used to always show your default device, even for an app you had sent somewhere
+else, so it could tell you an app was on the speakers while Windows was sending it to a headset.
+
+### Fixed
+- **The output-device picker stops naming a device it is only guessing at.** SysManager can send an app to a
+  specific device, but Windows does not report which one an app is currently using — that read is not
+  implemented. The picker filled the gap with your default device anyway, which looked like a fact and was
+  frequently wrong: pick a headset for an app, restart the app, and the picker went back to saying "Speakers"
+  while the headset override was still in force. It now shows "Choose a device" until you choose one, and its
+  tooltip says why. Choosing still works exactly as before, and choosing your default device still clears the
+  override. The same applies when an app is routed to a device that has since been unplugged: that reads as
+  unknown too, rather than as your default.
+
 ## [1.76.3] - 2026-09-03
 
 The strip at the top of a page that says whether SysManager is running as administrator changes when you

--- a/README.md
+++ b/README.md
@@ -235,7 +235,9 @@ Edit Windows environment variables without the cramped built-in dialog:
   row; on builds where it doesn't, the row shows a "Choose output device…" button that opens
   Windows' per-app sound settings so you're never left without a path. Plug a headset in while
   the tab is open and it appears on its own — the device list is re-read every ten seconds, and
-  each app keeps the destination you picked for it
+  each app keeps the destination you picked for it. Windows does not report which device an app
+  is currently using, so the picker says "Choose a device" rather than guessing: the override
+  you set stays in force in Windows, but SysManager will not claim to know it after a restart
 - **Volume presets** — save the current per-app volumes and mutes as a named preset (e.g.
   "Gaming", "Focus") and re-apply it in one click; presets are keyed by app so they work
   across restarts, and are stored locally in `%LocalAppData%\SysManager`

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -388,6 +388,53 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// An audio route SysManager cannot read must be shown as unknown, not as the system default.
+    /// </summary>
+    /// <remarks>
+    /// <c>GetSessionOutputDevice</c> used to return two states where it needed three: an empty id meant both
+    /// "this app follows the default" and "the route could not be read", and the row resolved either into the
+    /// entry flagged <c>IsDefault</c> — by NAME, because the picker holds real endpoints only. The read is a
+    /// stub that always fails, so every picker asserted the app was on the default device whatever Windows was
+    /// really doing with it, and an app the user had routed to a headset displayed "Speakers".
+    /// <para>Three things have to hold together and each can be broken alone, which is why they are one test:
+    /// the interface must keep the nullable return that lets "unknown" be expressed, the implementation must
+    /// not collapse it back with <c>?? string.Empty</c>, and the view must actually bind the flag. The last is
+    /// this codebase's most repeated defect — a property implemented, unit-tested, and bound by nothing, which
+    /// no compiler and no view-model test can see. <see cref="EveryViewModelCommand_IsReachableFromTheUi"/>
+    /// catches that for commands; a bool is not a command.</para>
+    /// </remarks>
+    [Fact]
+    public void TheAudioRouteRead_ReportsUnknownRatherThanTheDefault()
+    {
+        var appDir = FindAppProjectDir();
+        var contract = File.ReadAllText(Path.Combine(appDir, "Services", "IAudioMixerService.cs"));
+        var service = File.ReadAllText(Path.Combine(appDir, "Services", "AudioMixerService.cs"));
+        var view = File.ReadAllText(Path.Combine(appDir, "Views", "AudioMixerView.xaml"));
+
+        Assert.Contains("string? GetSessionOutputDevice", contract, StringComparison.Ordinal);
+
+        // Scoped to the method body, because the file legitimately uses "?? string.Empty" elsewhere and the
+        // prose above this guard names the very expression it forbids.
+        var at = service.IndexOf("public string? GetSessionOutputDevice", StringComparison.Ordinal);
+        Assert.True(at > 0,
+            "AudioMixerService.GetSessionOutputDevice no longer returns string?, so the service cannot say "
+            + "\"I do not know\" and the picker is back to naming a device it is only guessing at.");
+        var body = service[at..service.IndexOf("public bool SetSessionOutputDevice", at, StringComparison.Ordinal)];
+        Assert.DoesNotContain("?? string.Empty", body, StringComparison.Ordinal);
+
+        // The XAML half. Sliced from the picker's own binding forward, so the comment above it — which
+        // explains the placeholder in prose — cannot satisfy the assertions by itself.
+        var pickerAt = view.IndexOf("SelectedItem=\"{Binding SelectedOutputDevice", StringComparison.Ordinal);
+        Assert.True(pickerAt > 0, "AudioMixerView no longer binds the per-app output picker.");
+        var picker = view[pickerAt..];
+
+        Assert.Contains("OutputRouteUnknown", picker, StringComparison.Ordinal);
+        var placeholderAt = picker.IndexOf("OutputRouteUnknown", StringComparison.Ordinal);
+        var placeholder = picker[..placeholderAt];
+        Assert.Contains("IsHitTestVisible=\"False\"", placeholder, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// The gold elevation banner means one thing and only one thing: you are running as administrator,
     /// so MORE is available. Every tab that shows it must say so.
     /// </summary>

--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -261,7 +261,11 @@ public class AudioMixerViewModelTests
         var service = ServiceWith(Session("s1"));
         service.IsRoutingSupported.Returns(true);
         service.GetRenderDevices().Returns(_ => new List<AudioDevice> { Speakers, Headset });
-        if (route is not null) service.GetSessionOutputDevice("s1").Returns(route);
+        // Always configured, including with null. An unconfigured substitute does NOT return null for a
+        // string-returning member — NSubstitute's auto-values hand back string.Empty — so leaving it alone
+        // made a test for the "could not read the route" path silently exercise the "no override" path
+        // instead, and it reported the wrong state while looking correct.
+        service.GetSessionOutputDevice("s1").Returns(route);
         service.SetSessionOutputDevice(Arg.Any<string>(), Arg.Any<string>()).Returns(call =>
         {
             writes.Add(((string)call[0], (string)call[1]));
@@ -273,10 +277,12 @@ public class AudioMixerViewModelTests
     /// <summary>
     /// Routing an app to a device and then putting it back on the default must CLEAR the override, not pin
     /// the app to whichever device happens to be default right now.
-    /// <para>Goes headset-then-default rather than selecting the default directly: the row is built with the
-    /// default already selected (the service's route-read is a stub returning empty), so assigning it again
-    /// is not a property change, the write path would never run, and the test would pass while asserting
-    /// nothing.</para>
+    /// <para>Goes headset-then-default rather than selecting the default directly. It had to: the row used to
+    /// be built with the default already selected, because the route-read stub's empty answer resolved to that
+    /// entry, so assigning it again was not a property change, the write path never ran, and the test passed
+    /// while asserting nothing. The row now starts with no selection at all, so the first assignment is a real
+    /// change too — but the two-step is kept, because it is the sequence a user actually performs and it still
+    /// proves the second write clears rather than re-pins.</para>
     /// </summary>
     [Fact]
     public void PuttingAnAppBackOnTheDefaultDevice_ClearsTheOverride()
@@ -307,20 +313,36 @@ public class AudioMixerViewModelTests
     }
 
     /// <summary>
-    /// The read mirror: a route the service cannot resolve selects the default entry, and doing so must NOT
-    /// write back. A refresh that echoed its own snapshot would re-assert a route on every pass, and on the
-    /// failure branch would report a routing error the user never caused.
+    /// The read mirror, in all three of its states, and none of them may write back.
     /// </summary>
+    /// <remarks>
+    /// The service used to answer with two states where it needed three: an empty id meant both "this app
+    /// follows the system default" and "the route could not be read", and the row turned either into the
+    /// default device's NAME. Since the read is a stub that always fails, every picker asserted the app was on
+    /// the default device whatever Windows was doing with it. This test's earlier form pinned that: its own
+    /// data row said "nothing is known about this app's route" while asserting the default was displayed.
+    /// <para>An unresolvable id is unknown for the same reason. A route to an unplugged endpoint means the app
+    /// IS routed somewhere this list cannot name, and showing the default there is the same false claim in a
+    /// rarer case.</para>
+    /// <para>The no-write half is unchanged and is the part that catches a live regression: a refresh that
+    /// echoed its own snapshot would re-assert a route every pass, and on the failure branch would report a
+    /// routing error the user never caused.</para>
+    /// </remarks>
     [Theory]
-    [InlineData("", "the route-read stub returns empty, so nothing is known about this app's route")]
-    [InlineData("{unplugged}", "the persisted route names a device that is no longer present")]
-    public void ARouteTheServiceCannotResolve_SelectsTheDefaultEntry_AndWritesNothing(string route, string why)
+    [InlineData("", false, "an empty id is a SUCCESSFUL read finding no override, so the app follows the default")]
+    [InlineData("{unplugged}", true, "the persisted route names a device that is no longer present")]
+    [InlineData(null, true, "null is the service saying it could not read the route at all")]
+    public void TheReadMirror_ShowsWhatIsKnown_AndWritesNothing(string? route, bool unknown, string why)
     {
         var writes = new List<(string Session, string Device)>();
         using var vm = NewVm(RoutableService(writes, route));
 
         var row = vm.Sessions.Single();
-        Assert.True(row.SelectedOutputDevice?.IsDefault, why);
+        Assert.Equal(unknown, row.OutputRouteUnknown);
+        if (unknown)
+            Assert.Null(row.SelectedOutputDevice);
+        else
+            Assert.True(row.SelectedOutputDevice?.IsDefault, why);
         Assert.Empty(writes);
     }
 

--- a/SysManager/SysManager/Services/AudioMixerService.cs
+++ b/SysManager/SysManager/Services/AudioMixerService.cs
@@ -460,17 +460,20 @@ public sealed class AudioMixerService : IAudioMixerService, IDisposable
     private object? _policyConfig; // IAudioPolicyConfig (undocumented)
 
     /// <inheritdoc/>
-    public string GetSessionOutputDevice(string sessionId)
+    public string? GetSessionOutputDevice(string sessionId)
     {
         lock (_gate)
         {
-            if (_disposed || !ProbeRoutingLocked() || _policyConfig is null) return string.Empty;
-            if (!_routingKeys.TryGetValue(sessionId, out var key)) return string.Empty;
+            // null, not string.Empty, on every path that means "we do not know". Empty is reserved for a
+            // successful read that found no override; conflating the two is what made the picker assert the
+            // default device for apps it knew nothing about.
+            if (_disposed || !ProbeRoutingLocked() || _policyConfig is null) return null;
+            if (!_routingKeys.TryGetValue(sessionId, out var key)) return null;
             try
             {
-                return AudioPolicyConfigFactory.GetPersistedDefaultEndpoint(_policyConfig, key.Pid) ?? string.Empty;
+                return AudioPolicyConfigFactory.GetPersistedDefaultEndpoint(_policyConfig, key.Pid);
             }
-            catch (COMException ex) { Log.Debug("GetSessionOutputDevice failed: {Error}", ex.Message); return string.Empty; }
+            catch (COMException ex) { Log.Debug("GetSessionOutputDevice failed: {Error}", ex.Message); return null; }
         }
     }
 

--- a/SysManager/SysManager/Services/IAudioMixerService.cs
+++ b/SysManager/SysManager/Services/IAudioMixerService.cs
@@ -70,10 +70,20 @@ public interface IAudioMixerService
     bool IsRoutingSupported { get; }
 
     /// <summary>
-    /// Reads the endpoint id this session is currently routed to, or an empty string for
-    /// "follow the system default" (or when routing can't be read). Best-effort.
+    /// Reads the endpoint id this session is currently routed to.
     /// </summary>
-    string GetSessionOutputDevice(string sessionId);
+    /// <returns>
+    /// The endpoint id when the app has an override; <see cref="string.Empty"/> when the read succeeded and
+    /// there is no override, so the app follows the system default; <c>null</c> when the route could not be
+    /// read at all.
+    /// </returns>
+    /// <remarks>
+    /// Three states, not two. The old contract folded "could not read" into the empty string alongside
+    /// "follows the default", and the caller turned an empty string into the default device's name — so a
+    /// failed read was displayed as a confident claim about the user's system. Callers must render
+    /// <c>null</c> as unknown.
+    /// </remarks>
+    string? GetSessionOutputDevice(string sessionId);
 
     /// <summary>
     /// Routes a session's app to a specific output device (empty <paramref name="deviceId"/> =

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.3</Version>
-    <FileVersion>1.76.3.0</FileVersion>
-    <AssemblyVersion>1.76.3.0</AssemblyVersion>
+    <Version>1.76.4</Version>
+    <FileVersion>1.76.4.0</FileVersion>
+    <AssemblyVersion>1.76.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AudioSessionRowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AudioSessionRowViewModel.cs
@@ -68,6 +68,17 @@ public sealed partial class AudioSessionRowViewModel : ObservableObject
     [ObservableProperty] private AudioDevice? _selectedOutputDevice;
 
     /// <summary>
+    /// True when SysManager could not read which device this app is currently routed to. Drives the picker's
+    /// placeholder, so an unknown route reads as unknown instead of as the system default.
+    /// </summary>
+    /// <remarks>
+    /// Not derived from <see cref="SelectedOutputDevice"/> being null, although today the two agree. A user
+    /// who opens the picker and closes it without choosing leaves the selection null, and that is not the
+    /// same claim: this flag says the SERVICE could not tell us, which is what the placeholder is about.
+    /// </remarks>
+    [ObservableProperty] private bool _outputRouteUnknown;
+
+    /// <summary>
     /// True when true in-app routing is available for THIS row (the device picker is shown). False
     /// for the system-sounds pseudo-session (never routable) and when the OS lacks the routing
     /// interface. Set by the parent VM.
@@ -227,18 +238,38 @@ public sealed partial class AudioSessionRowViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Sets the current output-device selection from the service snapshot without writing back
-    /// (used on refresh). Matches by endpoint id; a null/empty id selects the default device.
+    /// Sets the current output-device selection from the service snapshot without writing back (used on
+    /// refresh), and records whether the route is actually known.
     /// </summary>
-    public void SetOutputDeviceFromService(string endpointId)
+    /// <param name="endpointId">
+    /// <c>null</c> when SysManager could not read the route at all, <see cref="string.Empty"/> when it read
+    /// successfully and there is no override, or the endpoint id the app is routed to.
+    /// </param>
+    /// <remarks>
+    /// The three cases used to be two, and the missing one was a lie. Anything falsy selected the entry
+    /// flagged <see cref="AudioDevice.IsDefault"/>, so a failed read and "this app follows the default" both
+    /// rendered as the default device's NAME — and since the read is currently a stub that always returns
+    /// null (see <c>AudioPolicyConfigFactory.GetPersistedDefaultEndpoint</c>), every picker claimed the app
+    /// was on the default device whatever Windows was really doing with it.
+    /// <para>An id that matches no device in the list is unknown too, not the default. If Windows persisted a
+    /// route to an endpoint that is unplugged or gone, the app is routed somewhere this list cannot name;
+    /// showing the default there is the same lie in a rarer case.</para>
+    /// </remarks>
+    public void SetOutputDeviceFromService(string? endpointId)
     {
         _suppressPropagation = true;
         try
         {
-            SelectedOutputDevice = string.IsNullOrEmpty(endpointId)
-                ? OutputDevices.FirstOrDefault(d => d.IsDefault)
-                : OutputDevices.FirstOrDefault(d => string.Equals(d.Id, endpointId, StringComparison.OrdinalIgnoreCase))
-                  ?? OutputDevices.FirstOrDefault(d => d.IsDefault);
+            var device = endpointId switch
+            {
+                null => null,
+                "" => OutputDevices.FirstOrDefault(d => d.IsDefault),
+                _ => OutputDevices.FirstOrDefault(
+                    d => string.Equals(d.Id, endpointId, StringComparison.OrdinalIgnoreCase)),
+            };
+
+            SelectedOutputDevice = device;
+            OutputRouteUnknown = device is null;
         }
         finally { _suppressPropagation = false; }
     }

--- a/SysManager/SysManager/Views/AudioMixerView.xaml
+++ b/SysManager/SysManager/Views/AudioMixerView.xaml
@@ -117,11 +117,26 @@
                                                            Foreground="{DynamicResource TextMuted}"/>
                                                 <TextBlock Text="Output:" Style="{StaticResource Caption}"
                                                            VerticalAlignment="Center" Margin="0,0,6,0"/>
-                                                <ComboBox ItemsSource="{Binding OutputDevices}"
-                                                          SelectedItem="{Binding SelectedOutputDevice, Mode=TwoWay}"
-                                                          DisplayMemberPath="FriendlyName" MinWidth="160" FontSize="12"
-                                                          VerticalContentAlignment="Center"
-                                                          AutomationProperties.Name="{Binding DisplayName, StringFormat='Output device for {0}'}"/>
+                                                <!-- The placeholder overlay exists because an unread route must
+                                                     not render as a device name. SysManager can SET an app's
+                                                     output device but cannot yet read back which one Windows
+                                                     is using, and the picker used to fill that gap with the
+                                                     system default — a confident claim about the user's
+                                                     machine that was frequently wrong. IsHitTestVisible=False
+                                                     so the text never swallows a click meant for the box. -->
+                                                <Grid>
+                                                    <ComboBox ItemsSource="{Binding OutputDevices}"
+                                                              SelectedItem="{Binding SelectedOutputDevice, Mode=TwoWay}"
+                                                              DisplayMemberPath="FriendlyName" MinWidth="160" FontSize="12"
+                                                              VerticalContentAlignment="Center"
+                                                              ToolTip="SysManager can send this app to a specific device, but Windows does not report which one it is using now."
+                                                              AutomationProperties.Name="{Binding DisplayName, StringFormat='Output device for {0}'}"/>
+                                                    <TextBlock Text="Choose a device" FontSize="12"
+                                                               Margin="10,0,0,0" VerticalAlignment="Center"
+                                                               IsHitTestVisible="False"
+                                                               Foreground="{DynamicResource TextMuted}"
+                                                               Visibility="{Binding OutputRouteUnknown, Converter={StaticResource FlexVis}}"/>
+                                                </Grid>
                                             </StackPanel>
                                             <Button Margin="0,8,0,0" HorizontalAlignment="Left"
                                                     Style="{StaticResource GhostButton}" Padding="8,4"


### PR DESCRIPTION
Closes #1585.

## What was wrong

`IAudioMixerService.GetSessionOutputDevice` returned two states where it needed three. An empty id meant both
"this app follows the system default" and "the route could not be read", and `SetOutputDeviceFromService`
turned either into the entry flagged `IsDefault` — by **name**, because the picker holds real endpoints only
and has no "System default" item.

`AudioPolicyConfigFactory.GetPersistedDefaultEndpoint` is a documented stub whose whole body is
`_ = policyConfig; _ = processId; return null;`. So on every build where routing *is* supported, every
picker asserted the app was on the default device whatever Windows was really doing with it.

The order of events that makes it worst: route an app to a headset, and the write really does persist
(`SetPersistedDefaultAudioEndpoint` for both the Multimedia and Console roles). The picker shows the headset,
because `MergeInto` only calls `SetOutputDeviceFromService` for **new** rows and surviving rows take the
`ApplyUpdate` branch, which never touches the selection. Then the app closes and reopens, the row is new
again, the read fails, and the picker says "Speakers" — while the headset override is still in force in
Windows.

## The contract, now three states

| return | meaning | picker |
|---|---|---|
| an endpoint id | the app has this override | that device, by name |
| `string.Empty` | read succeeded, no override | the `IsDefault` entry — it genuinely follows the default |
| `null` | the route could not be read | empty, with a "Choose a device" placeholder |

Every path in `AudioMixerService` that means "we do not know" now returns `null`: disposed, routing
unsupported, no policy-config object, no routing key, or a `COMException`. The `?? string.Empty` that
collapsed them is gone.

An id matching no device in the list is unknown too. A route to an unplugged endpoint means the app **is**
routed somewhere this list cannot name, and showing the default there is the same false claim in a rarer
case.

The placeholder is a `TextBlock` overlaid on the `ComboBox` with `IsHitTestVisible="False"`, bound through
the existing `FlexVis` converter — no new converter, no new control. The `ComboBox` gains a tooltip saying
Windows does not report the current device, so the reason is available without cluttering the row.

**Writing is untouched.** Choosing a device still writes that id; choosing the `IsDefault` entry still sends
empty, which is what clears an override and remains the only way a user can stop routing an app.

## Scope: option (a), not (b)

The issue offers both. Option (b) — implementing the read — means adding a slot to an **undocumented COM
vtable**, which is exactly why the original author skipped it, and it can only be runtime-verified on the
workstation that runs the app. Shipping it unrun would mean claiming a COM round-trip works
without ever having seen it work. Filed separately.

Option (a) is also correct *independently* of (b): a read that cannot answer must not be rendered as an
answer, whatever the read eventually becomes. And the issue's third clause — "call
`SetOutputDeviceFromService` for surviving rows on refresh, not just new ones" — belongs strictly with (b).
With the read stubbed it would be actively harmful: every reconcile pass, at 1 Hz, would overwrite whatever
the user had just picked with `null`.

## Two problems in the tests

**A theory pinned the bug.** `ARouteTheServiceCannotResolve_SelectsTheDefaultEntry_AndWritesNothing` asserted
that an unresolvable route selects the default entry, and one of its own data rows read "the route-read stub
returns empty, so nothing is known about this app's route" — while asserting the default was displayed. It is
now `TheReadMirror_ShowsWhatIsKnown_AndWritesNothing`, covering all three states, keeping the no-write
assertion unchanged because that is the half which catches a live regression: a refresh echoing its own
snapshot would re-assert a route every pass and, on the failure branch, report a routing error the user never
caused.

**A test for null was not testing null.** `RoutableService` did `if (route is not null) service.GetSession
OutputDevice("s1").Returns(route);` — and an unconfigured NSubstitute member returning `string` hands back
`string.Empty`, not `null`. So the "could not read" case silently exercised the "no override" case. It is
always configured now, including with null. This is why the null row failed on first run with
`Expected: True, Actual: False` rather than passing quietly.

A neighbouring comment also went stale and was corrected:
`PuttingAnAppBackOnTheDefaultDevice_ClearsTheOverride` explained that it goes headset-then-default because
"the row is built with the default already selected". It no longer is.

## New guard

`TheAudioRouteRead_ReportsUnknownRatherThanTheDefault` holds three things that can each break alone, which is
why they are one test: the interface keeps the nullable return that lets "unknown" be expressed, the
implementation does not collapse it with `?? string.Empty`, and **the view actually binds the flag**.

That last one is this codebase's most repeated defect — a property implemented, unit-tested, and bound by
nothing, invisible to both the compiler and the view-model tests.
`EveryViewModelCommand_IsReachableFromTheUi` catches it for commands; a bool is not a command.

Red/green proof, four mutations, each rebuilt and run:

| Mutation | What went red |
|---|---|
| an unresolvable route falls back to `IsDefault` again | theory row `{unplugged}`: expected unknown, got known |
| the service collapses unknown back into `string.Empty` | guard: `?? string.Empty` found in the method body |
| the view stops binding the placeholder | guard: `OutputRouteUnknown` not found after the picker binding |
| the placeholder loses `IsHitTestVisible` | guard: `IsHitTestVisible="False"` not found before the binding |

All three files restored byte-for-byte by SHA, 4 green afterwards. The proof's own first run reported
`BUILD FAILED` on mutation A (the injected fallback landed after the switch arm's trailing comma) and
`anchor appears 2 times` on D (`IsHitTestVisible="False"` occurs twice in that view); both anchors are now
located by walking the file rather than typed.

## Regression sweep

- All four projects build, 0 warnings and 0 errors.
- `ArchitectureTests`: 85 green (84 plus the new guard), plus the two known runner-only failures.
- Audio suites: 61 green, 0 red — including every write-path test, so routing still writes what it always did.
- The guard's `?? string.Empty` check is scoped to the method body, because that file legitimately uses the
  expression elsewhere and the guard's own prose names the expression it forbids.
- Every touched file confirmed `w/crlf`, so none of the diffs is a whole-file rewrite.

## Docs

`README.md` said "each app keeps the destination you picked for it", which was true of Windows and misleading
about the UI; it now says Windows does not report the current device and that the picker will not claim to
know it after a restart. `ARCHITECTURE.md` records the three-state contract next to the existing note that the
routing SET path is laptop-verifiable only.
