### PR TITLE
refactor: put the Cleanup pre-scan behind a seam so its test stops timing the disk

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -221,6 +221,11 @@ Key services:
 - `DeepCleanupService` — scan-first safe cleanup (vendor caches, gaming
   launcher caches, Windows caches). Per-file try/catch so locked files
   are skipped, not forced.
+- `CleanupPreScanService` (`ICleanupPreScanService`) — sizes the temp folders and the current user's
+  Recycle Bin for the two labels Quick Cleanup shows before the user asks for anything. Behind an
+  interface because the work used to sit inline in `CleanupViewModel`, whose constructor fires it and
+  forgets it: building the view-model started a recursive walk of both locations, 30 times over in one
+  unit-test file, and one test then asserted the walk finished inside fifteen seconds.
 - `LargeFileScanner` — read-only biggest-files discovery; skips WinSxS,
   pagefile, hiberfil, System Volume Information.
 - `UpdateService` — GitHub Releases API client with explicit

--- a/SysManager/SysManager.IntegrationTests/AdminElevationVmTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AdminElevationVmTests.cs
@@ -31,14 +31,14 @@ public class AdminElevationVmTests
     [Fact]
     public void CleanupVm_ExposesIsElevated()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         Assert.Equal(Helpers.AdminHelper.IsElevated(), vm.IsElevated);
     }
 
     [Fact]
     public void CleanupVm_HasRelaunchCommand()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         Assert.NotNull(vm.RelaunchAsAdminCommand);
     }
 
@@ -60,7 +60,7 @@ public class AdminElevationVmTests
     public void AllElevationVms_Report_SameElevationFlag()
     {
         var a = new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService()).IsElevated;
-        var b = new CleanupViewModel(new PowerShellRunner()).IsElevated;
+        var b = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService()).IsElevated;
         var c = new AppUpdatesViewModel(new WingetService(new PowerShellRunner())).IsElevated;
         Assert.Equal(a, b);
         Assert.Equal(b, c);

--- a/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AllViewModelsSweepTests.cs
@@ -36,7 +36,7 @@ public class AllViewModelsSweepTests
     [Fact] public void AppUpdates_Constructs() => Assert.NotNull(new AppUpdatesViewModel(new WingetService(new PowerShellRunner())));
     [Fact] public void WindowsUpdate_Constructs() => Assert.NotNull(new WindowsUpdateViewModel(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService()));
     [Fact] public void SystemHealth_Constructs() => Assert.NotNull(new SystemHealthViewModel(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService()));
-    [Fact] public void Cleanup_Constructs() => Assert.NotNull(new CleanupViewModel(new PowerShellRunner()));
+    [Fact] public void Cleanup_Constructs() => Assert.NotNull(new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService()));
     [Fact] public void DeepCleanup_Constructs() => Assert.NotNull(new DeepCleanupViewModel(new DeepCleanupService(), new LargeFileScanner(), new FixedDriveService()));
     [Fact] public void Drivers_Constructs() => Assert.NotNull(new DriversViewModel(new PowerShellRunner()));
     [Fact] public void Logs_Constructs() => Assert.NotNull(new LogsViewModel(new EventLogService()));

--- a/SysManager/SysManager.IntegrationTests/CleanupViewModelExtendedTests.cs
+++ b/SysManager/SysManager.IntegrationTests/CleanupViewModelExtendedTests.cs
@@ -12,70 +12,70 @@ public class CleanupViewModelExtendedTests
     [Fact]
     public void IsTempRunning_DefaultsFalse()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         Assert.False(vm.IsTempRunning);
     }
 
     [Fact]
     public void IsBinRunning_DefaultsFalse()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         Assert.False(vm.IsBinRunning);
     }
 
     [Fact]
     public void IsSfcRunning_DefaultsFalse()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         Assert.False(vm.IsSfcRunning);
     }
 
     [Fact]
     public void IsDismRunning_DefaultsFalse()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         Assert.False(vm.IsDismRunning);
     }
 
     [Fact]
     public void IsAnyRunning_FalseByDefault()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         Assert.False(vm.IsAnyRunning);
     }
 
     [Fact]
     public void IsAnyRunning_TrueWhenSfcRuns()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner()) { IsSfcRunning = true };
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService()) { IsSfcRunning = true };
         Assert.True(vm.IsAnyRunning);
     }
 
     [Fact]
     public void IsAnyRunning_TrueWhenDismRuns()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner()) { IsDismRunning = true };
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService()) { IsDismRunning = true };
         Assert.True(vm.IsAnyRunning);
     }
 
     [Fact]
     public void IsAnyRunning_TrueWhenTempRuns()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner()) { IsTempRunning = true };
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService()) { IsTempRunning = true };
         Assert.True(vm.IsAnyRunning);
     }
 
     [Fact]
     public void IsAnyRunning_TrueWhenBinRuns()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner()) { IsBinRunning = true };
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService()) { IsBinRunning = true };
         Assert.True(vm.IsAnyRunning);
     }
 
     [Fact]
     public void IsAnyRunning_RaisesPropertyChanged()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         var fired = false;
         vm.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(vm.IsAnyRunning)) fired = true; };
         vm.IsSfcRunning = true;
@@ -85,21 +85,21 @@ public class CleanupViewModelExtendedTests
     [Fact]
     public void SfcStatus_DefaultsIdle()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         Assert.Equal("Idle", vm.SfcStatus);
     }
 
     [Fact]
     public void DismStatus_DefaultsIdle()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         Assert.Equal("Idle", vm.DismStatus);
     }
 
     [Fact]
     public void CancelCommand_DoesNotThrow()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         var ex = Record.Exception(() => vm.CancelCommand.Execute(null));
         Assert.Null(ex);
     }
@@ -113,7 +113,7 @@ public class CleanupViewModelExtendedTests
     [InlineData("RelaunchAsAdminCommand")]
     public void CommandExists(string propName)
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         var p = vm.GetType().GetProperty(propName);
         Assert.NotNull(p);
         Assert.NotNull(p!.GetValue(vm));
@@ -122,14 +122,14 @@ public class CleanupViewModelExtendedTests
     [Fact]
     public void Console_Present()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         Assert.NotNull(vm.Console);
     }
 
     [Fact]
     public void ToggleStates_Independently()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         vm.IsSfcRunning = true;
         vm.IsDismRunning = true;
         Assert.True(vm.IsSfcRunning && vm.IsDismRunning);
@@ -141,7 +141,7 @@ public class CleanupViewModelExtendedTests
     [Fact]
     public void IsElevated_IsBoolean()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         Assert.IsType<bool>(vm.IsElevated);
     }
 }

--- a/SysManager/SysManager.IntegrationTests/LightTouchViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/LightTouchViewModelTests.cs
@@ -19,7 +19,7 @@ public class LightTouchViewModelTests
     [Fact]
     public void CleanupVm_Ctor_IsSafe()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         Assert.NotNull(vm.Console);
         Assert.False(vm.IsBusy);
     }
@@ -27,7 +27,7 @@ public class LightTouchViewModelTests
     [Fact]
     public void CleanupVm_AllCommandsExist()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         Assert.NotNull(vm.CleanTempCommand);
         Assert.NotNull(vm.EmptyRecycleBinCommand);
         Assert.NotNull(vm.RunSfcCommand);
@@ -38,7 +38,7 @@ public class LightTouchViewModelTests
     [Fact]
     public void CleanupVm_CancelBeforeStart_IsSafe()
     {
-        var vm = new CleanupViewModel(new PowerShellRunner());
+        var vm = new CleanupViewModel(new PowerShellRunner(), new CleanupPreScanService());
         var ex = Record.Exception(() => vm.CancelCommand.Execute(null));
         Assert.Null(ex);
     }

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -235,6 +235,16 @@ public partial class ArchitectureTests
     /// Walks up from the test binary to the directory holding this project's sources. The build copies
     /// no .cs files to the output, so the assembly location alone cannot answer this.
     /// </summary>
+    /// <summary>
+    /// Locates the <c>SysManager.Tests</c> source directory.
+    /// </summary>
+    /// <remarks>
+    /// Walks up from the output folder first, which is how it works under <c>dotnet test</c>. That walk fails
+    /// whenever the tests are hosted from somewhere else in the tree, and then every guard that reads test
+    /// source throws instead of running. The sibling fallback covers it: the app project is found by the same
+    /// upward walk looking for a SUBPATH, which succeeds from anywhere under the repository, and the test
+    /// project is its sibling.
+    /// </remarks>
     private static string FindTestSourceDirectory()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
@@ -243,6 +253,10 @@ public partial class ArchitectureTests
             if (File.Exists(Path.Combine(dir.FullName, "SysManager.Tests.csproj"))) return dir.FullName;
             dir = dir.Parent;
         }
+
+        var sibling = Path.Combine(
+            Directory.GetParent(FindAppProjectDir())!.FullName, "SysManager.Tests");
+        if (File.Exists(Path.Combine(sibling, "SysManager.Tests.csproj"))) return sibling;
 
         throw new DirectoryNotFoundException(
             "Could not locate the SysManager.Tests source directory from " + AppContext.BaseDirectory);
@@ -385,6 +399,65 @@ public partial class ArchitectureTests
             "ViewModel invokes them, so a user cannot reach the feature they implement. Either bind " +
             "them in the View or remove them — shipping an unreachable command means the CHANGELOG " +
             "can announce a feature that does not exist:\n  " + string.Join("\n  ", unreachable));
+    }
+
+    /// <summary>
+    /// No test in the blocking suite may wait by sleeping.
+    /// </summary>
+    /// <remarks>
+    /// <c>await Task.Delay(...)</c> in a test is a guess about how fast the machine is. Two lived here and
+    /// both were wrong in the same way: <c>PreScan_EventuallyPopulatesLabels</c> polled 30 x 500&#160;ms and
+    /// then asserted a recursive walk of the temp folders and the Recycle Bin had finished — which failed on a
+    /// normally-used desktop and passed on a CI runner with an empty profile (#2084) — and five waits in
+    /// <c>StartupViewModelTests</c> sampled <c>IsBusy</c> on the same 15-second budget. Every one of them was
+    /// waiting for a fire-and-forget constructor task that <see cref="ViewModelBase.InitializationComplete"/>
+    /// already exposes.
+    /// <para>A bounded wait is a different thing and stays allowed: <c>Task.WhenAny(work, Task.Delay(5s))</c>
+    /// fails a hang instead of hanging, and it is the delay that is never awaited on its own. The rule is
+    /// therefore about <c>await Task.Delay</c> specifically, not about the method.</para>
+    /// <para>Comment lines are stripped before searching. The prose above names the very expression it
+    /// forbids, and several test files explain in comments why they do NOT use it — matching those would make
+    /// this guard fail on the files that already got it right.</para>
+    /// </remarks>
+    [Fact]
+    public void NoTestWaitsBySleeping()
+    {
+        var testDir = FindTestSourceDirectory();
+        var offenders = new List<string>();
+        var scanned = 0;
+
+        // Split so the needles do not appear literally in this file, which the scan also reads: written whole
+        // they matched these very lines and the guard reported ITSELF as the offender.
+        var sleepingAwait = "await Task." + "Delay(";
+        var blockingSleep = "Thread." + "Sleep(";
+
+        foreach (var file in Directory.GetFiles(testDir, "*.cs"))
+        {
+            var lines = File.ReadAllLines(file);
+            scanned++;
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i].Trim();
+                if (line.StartsWith("//", StringComparison.Ordinal)
+                    || line.StartsWith("///", StringComparison.Ordinal)
+                    || line.StartsWith("*", StringComparison.Ordinal)) continue;
+
+                if (line.Contains(sleepingAwait, StringComparison.Ordinal)
+                    || line.Contains(blockingSleep, StringComparison.Ordinal))
+                    offenders.Add($"{Path.GetFileName(file)}:{i + 1}  {line}");
+            }
+        }
+
+        Assert.True(scanned >= 200,
+            $"only {scanned} test source files were scanned — the source directory lookup is wrong and this "
+            + "guard is reading almost nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "These tests wait by sleeping, which makes them assert how fast the machine is rather than what "
+            + "the code does. Await the thing itself: ViewModelBase.InitializationComplete for a "
+            + "fire-and-forget constructor task, a TaskCompletionSource the test completes for anything else. "
+            + "A bounded Task.WhenAny(work, Task.Delay(...)) timeout is fine and is not matched here:\n  "
+            + string.Join("\n  ", offenders));
     }
 
     /// <summary>

--- a/SysManager/SysManager.Tests/CleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CleanupViewModelTests.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Reflection;
+using NSubstitute;
 using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
@@ -23,7 +24,26 @@ namespace SysManager.Tests;
 [Collection("ProcessWideStatics")]
 public class CleanupViewModelTests
 {
-    private static CleanupViewModel NewVm() => new(new PowerShellRunner());
+    /// <summary>
+    /// A pre-scan that answers instantly with fixed numbers.
+    /// </summary>
+    /// <remarks>
+    /// Every test in this file builds a view-model, and the constructor fires the pre-scan. While that work
+    /// was inline it meant 30 recursive walks of both temp folders and every per-SID Recycle Bin folder per
+    /// run of this file, and one test asserted the walk finished inside fifteen seconds — a claim about the
+    /// machine, not the code, which duly failed on a normally-used desktop while passing on a CI runner with
+    /// an empty profile.
+    /// </remarks>
+    private static ICleanupPreScanService StubPreScan(
+        string temp = "12.3 MB can be freed", string bin = "4.5 MB in Recycle Bin")
+    {
+        var preScan = Substitute.For<ICleanupPreScanService>();
+        preScan.MeasureAsync().Returns(Task.FromResult(new CleanupPreScan(temp, bin)));
+        return preScan;
+    }
+
+    private static CleanupViewModel NewVm(ICleanupPreScanService? preScan = null) =>
+        new(new PowerShellRunner(), preScan ?? StubPreScan());
 
     // ---------- construction & defaults ----------
 
@@ -260,7 +280,7 @@ public class CleanupViewModelTests
     public void RunnerLineReceived_AppendsToConsole()
     {
         var runner = new PowerShellRunner();
-        var vm = new CleanupViewModel(runner);
+        var vm = new CleanupViewModel(runner, StubPreScan());
         var before = vm.Console.Lines.Count;
 
         // Simulate the runner emitting a line. The VM subscribes in its
@@ -280,7 +300,7 @@ public class CleanupViewModelTests
     public void RunnerProgressChanged_UpdatesProgressProperty()
     {
         var runner = new PowerShellRunner();
-        var vm = new CleanupViewModel(runner);
+        var vm = new CleanupViewModel(runner, StubPreScan());
 
         var ev = typeof(PowerShellRunner)
             .GetField(nameof(PowerShellRunner.ProgressChanged), BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
@@ -347,41 +367,44 @@ public class CleanupViewModelTests
 
     // ---------- pre-scan labels (added in v0.12.2) ----------
 
+    /// <summary>
+    /// Both size labels read "Scanning…" until the measurement lands, then hold what it measured.
+    /// </summary>
+    /// <remarks>
+    /// One test where there were three, and it asserts more than they did.
+    /// <para><c>TempSizeLabel_DefaultIsScanning</c> and <c>RecycleBinLabel_DefaultIsScanning</c> read the
+    /// label straight after construction and were only ever right by luck: the pre-scan is fire-and-forget,
+    /// so they were racing it and would have flipped the moment the measurement got fast.</para>
+    /// <para><c>PreScan_EventuallyPopulatesLabels</c> polled <c>Task.Delay(500)</c> thirty times and then
+    /// asserted the labels had changed — which is the assertion "this machine can enumerate the whole temp
+    /// tree and Recycle Bin in fifteen seconds". A property of the machine, not the code. It failed on a
+    /// normally-used desktop and passed on a CI runner with an empty profile (#2084).</para>
+    /// <para>The gate replaces the clock: the measurement completes exactly when this test says so, and
+    /// <c>InitializationComplete</c> — which <see cref="ViewModelBase"/> exposes for precisely this — replaces
+    /// the polling. It also asserts the labels hold the MEASURED values, where the old test only asserted
+    /// they were no longer "Scanning…" and would have passed on any garbage.</para>
+    /// </remarks>
     [Fact]
-    public void TempSizeLabel_DefaultIsScanning()
+    public async Task SizeLabels_ReadScanning_UntilTheMeasurementLands()
     {
-        // The constructor fires PreScanAsync which sets "Scanning…" initially.
-        var vm = NewVm();
+        var gate = new TaskCompletionSource<CleanupPreScan>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var preScan = Substitute.For<ICleanupPreScanService>();
+        preScan.MeasureAsync().Returns(gate.Task);
+        var vm = NewVm(preScan);
+
         Assert.Equal("Scanning…", vm.TempSizeLabel);
-    }
-
-    [Fact]
-    public void RecycleBinLabel_DefaultIsScanning()
-    {
-        var vm = NewVm();
         Assert.Equal("Scanning…", vm.RecycleBinLabel);
-    }
 
-    [Fact]
-    public async Task PreScan_EventuallyPopulatesLabels()
-    {
-        var vm = NewVm();
-        // PreScanAsync runs on construction via fire-and-forget.
-        // Poll until labels change or timeout (up to 15s for slow CI).
-        for (int i = 0; i < 30; i++)
-        {
-            await Task.Delay(500);
-            if (vm.TempSizeLabel != "Scanning…" && vm.RecycleBinLabel != "Scanning…")
-                break;
-        }
-        // After scan, labels should no longer be "Scanning…"
-        Assert.NotEqual("Scanning…", vm.TempSizeLabel);
-        Assert.NotEqual("Scanning…", vm.RecycleBinLabel);
+        gate.SetResult(new CleanupPreScan("412.7 MB can be freed", "18.0 MB in Recycle Bin"));
+        await vm.InitializationComplete;
+
+        Assert.Equal("412.7 MB can be freed", vm.TempSizeLabel);
+        Assert.Equal("18.0 MB in Recycle Bin", vm.RecycleBinLabel);
     }
 
     // A "…_CanBeSetDirectly" round-trip was removed here: it set a bare [ObservableProperty]
     // and read it straight back, so only the source generator could fail it. The labels' real
-    // behaviour is covered by …_DefaultIsScanning and PreScan_EventuallyPopulatesLabels above.
+    // behaviour is covered by SizeLabels_ReadScanning_UntilTheMeasurementLands above.
     // ---------- progress feedback (regression) ----------
     // CleanupView.xaml binds a progress bar to IsBusy and the sidebar spinner reads the same flag,
     // but this VM never assigned it — so nothing appeared while SFC or DISM ran, which is minutes of

--- a/SysManager/SysManager.Tests/StartupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/StartupViewModelTests.cs
@@ -56,12 +56,8 @@ public class StartupViewModelTests
     public async Task ScanAsync_PopulatesEntries()
     {
         var vm = new StartupViewModel(new Services.StartupService());
-        // Constructor fires auto-scan. Poll until it completes (up to 15s).
-        for (int i = 0; i < 30; i++)
-        {
-            await Task.Delay(500);
-            if (!vm.IsBusy) break;
-        }
+        // The constructor fires the scan and forgets it; this is the task it started.
+        await vm.InitializationComplete;
         // On any Windows machine there should be at least 1 startup item.
         Assert.True(vm.Entries.Count > 0, "Expected at least one startup entry");
         Assert.True(vm.TotalCount > 0);
@@ -71,12 +67,8 @@ public class StartupViewModelTests
     public async Task ScanAsync_UpdatesScanSummary()
     {
         var vm = new StartupViewModel(new Services.StartupService());
-        // Constructor fires auto-scan. Poll until it completes (up to 15s).
-        for (int i = 0; i < 30; i++)
-        {
-            await Task.Delay(500);
-            if (!vm.IsBusy) break;
-        }
+        // The constructor fires the scan and forgets it; this is the task it started.
+        await vm.InitializationComplete;
         // After scan, summary should contain counts if entries were found
         if (vm.TotalCount > 0)
             Assert.Contains("enabled", vm.ScanSummary, StringComparison.OrdinalIgnoreCase);
@@ -86,11 +78,8 @@ public class StartupViewModelTests
     public async Task ScanAsync_CountsAreConsistent()
     {
         var vm = new StartupViewModel(new Services.StartupService());
-        for (int i = 0; i < 30; i++)
-        {
-            await Task.Delay(500);
-            if (!vm.IsBusy) break;
-        }
+        // The constructor fires the scan and forgets it; this is the task it started.
+        await vm.InitializationComplete;
         Assert.Equal(vm.Entries.Count, vm.TotalCount);
         Assert.Equal(vm.EnabledCount + vm.DisabledCount, vm.TotalCount);
     }
@@ -140,8 +129,9 @@ public class StartupViewModelTests
         // and adds boot time, so it must ask first. Declining must short-circuit BEFORE any
         // write — proven here by the entry staying disabled (SetEnabledAsync is never reached).
         var vm = new StartupViewModel(new StartupService());
-        // Let the ctor's auto-scan settle so it can't overwrite our seeded entry mid-test.
-        for (int i = 0; i < 30 && vm.IsBusy; i++) await Task.Delay(200);
+        // Wait for the ctor's auto-scan to finish before seeding, so it cannot overwrite the seeded
+        // entry mid-test. The task itself, not a sampled IsBusy flag.
+        await vm.InitializationComplete;
 
         vm.Entries.Clear();
         var disabled = new StartupEntry { Name = "Seeded", Command = "c:\\x.exe", IsEnabled = false };
@@ -169,7 +159,9 @@ public class StartupViewModelTests
     {
         // Nothing to enable → no confirmation dialog (and no write). Guards against nagging.
         var vm = new StartupViewModel(new StartupService());
-        for (int i = 0; i < 30 && vm.IsBusy; i++) await Task.Delay(200);
+        // Wait for the ctor's auto-scan to finish before seeding, so it cannot overwrite the seeded
+        // entry mid-test. The task itself, not a sampled IsBusy flag.
+        await vm.InitializationComplete;
 
         vm.Entries.Clear();
         vm.Entries.Add(new StartupEntry { Name = "On", Command = "c:\\y.exe", IsEnabled = true });

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -38,6 +38,7 @@ public static class ServiceRegistration
         services.AddSingleton<AppAlertService>();
         services.AddSingleton<IAppBlockerService, AppBlockerService>();
         services.AddSingleton<DeepCleanupService>();
+        services.AddSingleton<ICleanupPreScanService, CleanupPreScanService>();
         services.AddSingleton<DiskAnalyzerService>();
         services.AddSingleton<DiskScanHistoryService>();
         services.AddSingleton<DuplicateFileService>();

--- a/SysManager/SysManager/Services/CleanupPreScanService.cs
+++ b/SysManager/SysManager/Services/CleanupPreScanService.cs
@@ -1,0 +1,81 @@
+// SysManager · CleanupPreScanService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Globalization;
+using System.IO;
+using SysManager.Helpers;
+
+namespace SysManager.Services;
+
+/// <inheritdoc cref="ICleanupPreScanService"/>
+public sealed class CleanupPreScanService : ICleanupPreScanService
+{
+    /// <inheritdoc/>
+    public Task<CleanupPreScan> MeasureAsync() =>
+        Task.Run(() => new CleanupPreScan(MeasureTemp(), MeasureRecycleBin()));
+
+    // The two measure methods are instance methods deliberately, and must stay that way.
+    // ArchitectureTests.StaticPathMethods_AcceptARedirect reflects over SysManager.Services and INVOKES every
+    // parameterless static method that returns a string, to see whether it resolves a path under the user's
+    // profile with no override. As statics these two were called for real, walking the entire temp tree and
+    // every per-SID Recycle Bin folder, and that guard sat there for twenty minutes. They return a size LABEL
+    // rather than a path, so it was not even reporting anything — pure collateral cost.
+    private string MeasureTemp()
+    {
+        long bytes = 0;
+        var paths = new[]
+        {
+            Environment.GetEnvironmentVariable("TEMP") ?? "",
+            Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Temp"),
+        };
+
+        foreach (var path in paths.Where(p => !string.IsNullOrEmpty(p) && Directory.Exists(p)))
+        {
+            try
+            {
+                foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+                {
+                    try { bytes += new FileInfo(file).Length; }
+                    catch (IOException) { /* skip inaccessible file */ }
+                    catch (UnauthorizedAccessException) { /* skip protected file */ }
+                }
+            }
+            catch (IOException) { /* skip inaccessible directory */ }
+            catch (UnauthorizedAccessException) { /* skip protected directory */ }
+        }
+
+        return Describe(bytes, "can be freed");
+    }
+
+    private string MeasureRecycleBin()
+    {
+        try
+        {
+            long bytes = 0;
+            // The Recycle Bin lives in a hidden $Recycle.Bin folder on EVERY fixed drive, one per-SID
+            // subfolder per user. Empty (SHEmptyRecycleBin) only clears the CURRENT user's bin, so size only
+            // THIS user's per-SID folders — summing the whole tree over-reports what emptying can actually
+            // free on a multi-user box.
+            foreach (var path in RecycleBinHelper.CurrentUserBinPaths())
+            {
+                if (!Directory.Exists(path)) continue;
+                foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+                {
+                    try { bytes += new FileInfo(file).Length; }
+                    catch (IOException) { /* skip inaccessible file */ }
+                    catch (UnauthorizedAccessException) { /* skip protected file */ }
+                }
+            }
+
+            return Describe(bytes, "in Recycle Bin");
+        }
+        catch (IOException) { return "Unable to scan"; }
+        catch (UnauthorizedAccessException) { return "Unable to scan"; }
+    }
+
+    private static string Describe(long bytes, string suffix) =>
+        bytes > 0
+            ? string.Create(CultureInfo.InvariantCulture, $"{bytes / 1024.0 / 1024.0:F1} MB {suffix}")
+            : "Empty";
+}

--- a/SysManager/SysManager/Services/ICleanupPreScanService.cs
+++ b/SysManager/SysManager/Services/ICleanupPreScanService.cs
@@ -1,0 +1,35 @@
+// SysManager · ICleanupPreScanService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Services;
+
+/// <summary>The two headline numbers Quick Cleanup shows before the user asks for anything.</summary>
+/// <param name="TempLabel">
+/// A finished, user-facing phrase for the temp folders — "412.7 MB can be freed", "Empty", or
+/// "Unable to scan".
+/// </param>
+/// <param name="RecycleBinLabel">The same for the current user's Recycle Bin.</param>
+public sealed record CleanupPreScan(string TempLabel, string RecycleBinLabel);
+
+/// <summary>
+/// Measures what the temp folders and the Recycle Bin currently hold.
+/// </summary>
+/// <remarks>
+/// A seam, and it exists for a reason beyond tidiness. This work used to sit inline in
+/// <c>CleanupViewModel.PreScanAsync</c>, which the constructor fires and forgets — so building the view-model
+/// started a recursive walk of both temp folders and every per-SID Recycle Bin folder. In the unit suite that
+/// happened 30 times in one file, and one test asserted that the walk finished within fifteen seconds, which
+/// is a claim about the machine rather than about the code. It failed on a normally-used desktop while passing
+/// on CI, where the profile is nearly empty.
+/// <para>Behind an interface, a test states what the numbers are and never touches a disk.</para>
+/// </remarks>
+public interface ICleanupPreScanService
+{
+    /// <summary>
+    /// Measures both locations off the calling thread. Never throws for an inaccessible file or folder —
+    /// individual failures are skipped, and a wholesale failure yields "Unable to scan" for that location, so
+    /// a caller always gets two displayable phrases.
+    /// </summary>
+    Task<CleanupPreScan> MeasureAsync();
+}

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -18,6 +18,11 @@ public sealed partial class CleanupViewModel : ViewModelBase
 {
     private readonly IPowerShellRunner _runner;
 
+    // The temp/Recycle-Bin sizing, behind a seam. It used to be inline here, which meant constructing this
+    // view-model kicked off a recursive walk of both temp folders and every per-SID Recycle Bin folder — 30
+    // times over in one unit-test file, one of which then asserted the walk finished inside fifteen seconds.
+    private readonly ICleanupPreScanService _preScan;
+
     private readonly EtaCalculator _sfcEta = new();
     private readonly EtaCalculator _dismEta = new();
 
@@ -63,9 +68,10 @@ public sealed partial class CleanupViewModel : ViewModelBase
     /// <summary>True whenever any background task is running — for a small badge.</summary>
     public bool IsAnyRunning => IsTempRunning || IsBinRunning || IsSfcRunning || IsDismRunning;
 
-    public CleanupViewModel(IPowerShellRunner runner)
+    public CleanupViewModel(IPowerShellRunner runner, ICleanupPreScanService preScan)
     {
         _runner = runner;
+        _preScan = preScan;
         _runner.LineReceived += OnRunnerLineReceived;
         _runner.ProgressChanged += OnRunnerProgressChanged;
         IsElevated = AdminHelper.IsElevated();
@@ -142,57 +148,11 @@ public sealed partial class CleanupViewModel : ViewModelBase
         }
         try
         {
-            var (tempLabel, binLabel) = await Task.Run(() =>
-            {
-                // Measure temp folders
-                long tempBytes = 0;
-                var tempPaths = new[] { Environment.GetEnvironmentVariable("TEMP") ?? "", System.IO.Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Temp") };
-                foreach (var p in tempPaths.Where(x => !string.IsNullOrEmpty(x) && System.IO.Directory.Exists(x)))
-                {
-                    try
-                    {
-                        foreach (var f in System.IO.Directory.EnumerateFiles(p, "*", System.IO.SearchOption.AllDirectories))
-                        {
-                            try { tempBytes += new System.IO.FileInfo(f).Length; }
-                            catch (IOException) { /* skip inaccessible file */ }
-                            catch (UnauthorizedAccessException) { /* skip protected file */ }
-                        }
-                    }
-                    catch (IOException) { /* skip inaccessible directory */ }
-                    catch (UnauthorizedAccessException) { /* skip protected directory */ }
-                }
-                var tLabel = tempBytes > 0 ? string.Create(CultureInfo.InvariantCulture, $"{tempBytes / 1024.0 / 1024.0:F1} MB can be freed") : "Empty";
+            var measured = await _preScan.MeasureAsync();
 
-                // Measure recycle bin (rough estimate via shell folder)
-                string bLabel;
-                try
-                {
-                    long binBytes = 0;
-                    // The Recycle Bin lives in a hidden $Recycle.Bin folder on EVERY fixed drive,
-                    // one per-SID subfolder per user. Empty (SHEmptyRecycleBin) only clears the
-                    // CURRENT user's bin, so size only THIS user's per-SID folders — summing the
-                    // whole tree over-reports what emptying can actually free on a multi-user box.
-                    foreach (var recyclePath in RecycleBinHelper.CurrentUserBinPaths())
-                    {
-                        if (!Directory.Exists(recyclePath)) continue;
-                        foreach (var f in Directory.EnumerateFiles(recyclePath, "*", SearchOption.AllDirectories))
-                        {
-                            try { binBytes += new FileInfo(f).Length; }
-                            catch (IOException) { /* skip inaccessible file */ }
-                            catch (UnauthorizedAccessException) { /* skip protected file */ }
-                        }
-                    }
-                    bLabel = binBytes > 0 ? string.Create(CultureInfo.InvariantCulture, $"{binBytes / 1024.0 / 1024.0:F1} MB in Recycle Bin") : "Empty";
-                }
-                catch (IOException) { bLabel = "Unable to scan"; }
-                catch (UnauthorizedAccessException) { bLabel = "Unable to scan"; }
-
-                return (tLabel, bLabel);
-            });
-
-            // Update on the calling (UI) thread so PropertyChanged fires correctly
-            TempSizeLabel = tempLabel;
-            RecycleBinLabel = binLabel;
+            // Assigned on the calling (UI) thread so PropertyChanged fires correctly.
+            TempSizeLabel = measured.TempLabel;
+            RecycleBinLabel = measured.RecycleBinLabel;
         }
         catch (IOException ex) { Log.Debug("Pre-scan failed: {Error}", ex.Message); }
         catch (UnauthorizedAccessException ex) { Log.Debug("Pre-scan access denied: {Error}", ex.Message); }

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -438,7 +438,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(AppUpdatesViewModel)] = new AppUpdatesViewModel(winget),
             [typeof(WindowsUpdateViewModel)] = new WindowsUpdateViewModel(runner, new WindowsUpdateService(), new WindowsUpdatePolicyService()),
             [typeof(SystemHealthViewModel)] = new SystemHealthViewModel(sysInfo, diskHealth, new MemoryTestService(), fixedDrives, runner, new BiosService()),
-            [typeof(CleanupViewModel)] = new CleanupViewModel(runner),
+            [typeof(CleanupViewModel)] = new CleanupViewModel(runner, new CleanupPreScanService()),
             [typeof(DeepCleanupViewModel)] = new DeepCleanupViewModel(new DeepCleanupService(), new LargeFileScanner(), fixedDrives),
             [typeof(DuplicateFileViewModel)] = new DuplicateFileViewModel(new DuplicateFileService()),
             [typeof(DiskAnalyzerViewModel)] = new DiskAnalyzerViewModel(new DiskAnalyzerService(), new DiskScanHistoryService()),


### PR DESCRIPTION
Closes #2084.

`refactor:` — behaviour is identical, so there is no release and no CHANGELOG entry. What changes is where the
work lives and what the tests are allowed to assume.

## What was wrong

`CleanupViewModel.PreScanAsync` sized the temp folders and the Recycle Bin inline, and the constructor fires it
and forgets it. So **building the view-model started a recursive walk of both temp folders and every per-SID
Recycle Bin folder** — and `CleanupViewModelTests` builds one 30 times.

One test then asserted the walk finished in time:

```csharp
for (int i = 0; i < 30; i++)
{
    await Task.Delay(500);
    if (vm.TempSizeLabel != "Scanning…" && vm.RecycleBinLabel != "Scanning…") break;
}
Assert.NotEqual("Scanning…", vm.TempSizeLabel);
```

That is the assertion *this machine can enumerate the whole temp tree and Recycle Bin inside fifteen seconds*.
It failed on a normally-used desktop and passes on a CI runner with a nearly empty profile, which is why it has
never been seen red in CI. It is also in the suite that blocks every pull request.

## The seam

`ICleanupPreScanService.MeasureAsync()` returns a `CleanupPreScan(TempLabel, RecycleBinLabel)` record.
`CleanupPreScanService` holds the moved code verbatim — same paths, same per-file `try`/`catch`, same
"Empty"/"Unable to scan" phrasing, same per-SID Recycle Bin reasoning. Registered in DI; the designer graph in
`MainWindowViewModel` constructs it directly like its neighbours.

The view-model's `PreScanAsync` is now the two assignments and nothing else, which also moves a filesystem walk
out of a view-model — the dependency direction the architecture is supposed to have.

## The test, rewritten to assert more

Three tests became one:

```csharp
var gate = new TaskCompletionSource<CleanupPreScan>(TaskCreationOptions.RunContinuationsAsynchronously);
preScan.MeasureAsync().Returns(gate.Task);
var vm = NewVm(preScan);

Assert.Equal("Scanning…", vm.TempSizeLabel);          // before
gate.SetResult(new CleanupPreScan("412.7 MB can be freed", "18.0 MB in Recycle Bin"));
await vm.InitializationComplete;
Assert.Equal("412.7 MB can be freed", vm.TempSizeLabel);   // after
```

The gate replaces the clock, and `ViewModelBase.InitializationComplete` — which already exists for exactly this
— replaces the polling. It is strictly stronger than what it replaces: the old test only checked the labels
were no longer `"Scanning…"` and would have passed on any garbage, and the two `…_DefaultIsScanning` tests read
the label straight after construction while racing the fire-and-forget scan, so they were right by luck and
would have flipped the moment the measurement got fast.

**Measured: 118 test cases across the two touched files now run in 1.8 seconds.**

## Fixing the class, not the instance

Grepping the rule rather than the symptom turned up five more sleeping waits in `StartupViewModelTests`, all
polling `IsBusy` on the same 15-second budget, all waiting for a constructor task that
`InitializationComplete` already exposes. All five are now `await vm.InitializationComplete`, which is both
deterministic and stronger — it waits for the task rather than sampling a flag.

`await Task.Delay(` in the unit project: **5 → 0**.

So the rule can now be mechanical rather than remembered. `NoTestWaitsBySleeping` fails any
`await Task.Delay(` or `Thread.Sleep(` in a test source file, with a floor of 200 files scanned so it cannot
pass on an empty directory listing. A *bounded* wait stays allowed and is not matched:
`Task.WhenAny(work, Task.Delay(5s))` fails a hang instead of hanging, and there the delay is never awaited
alone — two of those exist and stay.

The needles are built by concatenation (`"await Task." + "Delay("`), because the guard reads its own file too:
written whole, they matched the detector's own lines and it reported itself as the offender on first run.

## A helper fixed, and one fewer local blind spot

`FindTestSourceDirectory()` walked up from the output folder looking for `SysManager.Tests.csproj` in the
current directory, which only succeeds under `dotnet test`. Hosted from anywhere else in the tree it threw, so
every guard reading test source threw instead of running — including the new one. It now falls back to the
sibling of the app project, found by the upward SUBPATH walk `FindAppProjectDir` already uses, which succeeds
from anywhere in the repository.

`ProcessWideStaticUsers_AreInTheSerializedCollection` was the other casualty of that gap and is green locally
for the first time.

## Red/green proof

| Mutation | What went red |
|---|---|
| `await Task.Delay(50)` added to a test | `NoTestWaitsBySleeping`, naming `CleanupViewModelTests.cs:201` |
| `Thread.Sleep(10)` instead | same guard, proving the second needle is live |
| the view-model drops the Recycle Bin assignment | the label test: expected `"18.0 MB in Recycle Bin"`, got `"Scanning…"` |
| the labels are assigned *before* the await | the same test from the other end: expected `"Scanning…"`, got `""` |

The last two matter together: a test that only checked the labels end up non-empty would pass under the
fourth, which is exactly what the old test did. Both files restored byte-for-byte by SHA, 2 green afterwards.

## Regression sweep

- All four projects build, 0 warnings and 0 errors — including `SysManager.IntegrationTests`, where the
  constructor change needed threading through **24 sites** across 4 files. Those get the real
  `CleanupPreScanService`: that project exists for real system dependencies, and CI compile-checks it without
  executing it, so a missed site is a red build rather than a slow test.
- `CleanupViewModelTests` + `StartupViewModelTests`: 118 green, 0 red, 1.8s.
- Every touched file confirmed `w/crlf`.

## Noted, not fixed

`StartupViewModelTests` still asserts "at least one startup entry" against the machine's real registry, via a
concrete `StartupService` with no interface. That is a different defect (a machine-dependent assertion, not a
timing one) and needs an `IStartupService` seam, so it is out of scope here rather than half-done.
