### PR TITLE
fix: hold muted text to WCAG AA on the derived surfaces too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.5] - 2026-09-03
+
+Small grey labels — the "DEFAULT" tag in Tweaks Hub, the administrator badge, and similar — were too faint to
+read comfortably on six of the twelve colour themes, including the one the app starts with. They are slightly
+clearer now.
+
+### Fixed
+- **Faint small text on layered panels.** The app builds two lighter panel shades out of each theme rather
+  than picking them by hand, and it turned out the check that guards text legibility skipped exactly those two
+  shades — on the reasoning that they were the safe ones, when they are the hardest. Measured across all
+  twelve themes, small grey text fell below the accessibility standard on half of them, worst on Midnight
+  Indigo, which is the default. The shade slider made it worse: on Warm Sand it dropped below the standard
+  from the slider's own default position outward, and at the far end of the range some themes were down to
+  3.84 against a 4.5 requirement. Six themes now use a slightly clearer grey, the slider's automatic
+  correction covers those two panel shades as well, and the check that failed to notice any of it now looks
+  at them.
+
+### Changed
+- **Six themes have a slightly clearer grey for small labels.** Midnight Indigo, Deep Ocean, Violet Night,
+  Clean Indigo, Sky Breeze and Mint Fresh only — the smallest change that clears the standard on every panel
+  shade, along the colour each theme already used. Sky Breeze's mid-grey moved too. The other six themes are
+  untouched, and no layout, wording or behaviour changed anywhere.
+
 ## [1.76.4] - 2026-09-03
 
 Volume Control no longer claims to know which speakers or headset an app is playing through when it does not.

--- a/SysManager/SysManager.Tests/ThemeTextContrastTests.cs
+++ b/SysManager/SysManager.Tests/ThemeTextContrastTests.cs
@@ -22,38 +22,70 @@ public class ThemeTextContrastTests
     public static IEnumerable<object[]> AllPresets =>
         ThemePreset.Defaults.Values.Select(p => new object[] { p.Id });
 
-    // TextMuted is body/label text — WCAG AA for normal text is 4.5:1. It must clear that against
-    // the WORST-CASE (lowest-contrast) layered surface it renders on. Surface3/Surface4 are derived
-    // by Lerp toward TextPrimary (higher contrast for muted, so not the worst case); the seeded
-    // Surface2 is the worst common case, so we assert against Background, Surface, and Surface2.
+    // TextMuted is body/label text — WCAG AA for normal text is 4.5:1 — and it must clear that on the
+    // WORST-CASE layered surface it renders on, which is Surface4, not Surface2.
+    //
+    // This check used to stop at Surface2 on the reasoning that "Surface3/Surface4 are derived by Lerp
+    // toward TextPrimary (higher contrast for muted, so not the worst case)". That is backwards.
+    // Lerping the SURFACE toward the text colour moves the surface CLOSER to the text, so contrast
+    // DROPS: Surface4 is the lowest-contrast surface in the ramp, and it was the one left unasserted.
+    // Six of twelve presets were sub-AA there — including midnight-indigo, the default — while this
+    // theory reported the ramp clean (#1555). Fourteen places in the app put muted text on those two
+    // surfaces, among them the Tweaks Hub "DEFAULT" badge at FontSize 10 and the elevation badge.
+    //
+    // The derived surfaces are computed here with the same Lerp factors ThemeService.Apply uses, so the
+    // test and the service cannot drift to different definitions of the same colour.
     [Theory]
     [MemberData(nameof(AllPresets))]
     public void TextMuted_MeetsWcagAa_OnEveryLayeredSurface(string presetId)
     {
         var p = ThemePreset.Defaults[presetId];
+        var surface3 = Lerp(p.Surface2, p.TextPrimary, 0.05);
+        var surface4 = Lerp(p.Surface2, p.TextPrimary, 0.10);
+
+        // Non-vacuity floor. If the lerp factors were ever zeroed here, the two rows below would silently
+        // become repeats of Surface2 and this theory would go back to covering nothing above it — passing,
+        // which is exactly how the gap survived the first time.
+        Assert.NotEqual(p.Surface2, surface3);
+        Assert.NotEqual(surface3, surface4);
+
         foreach (var (label, surface) in new[]
                  {
                      ("Background", p.Background),
                      ("Surface", p.Surface),
                      ("Surface2", p.Surface2),
+                     ("Surface3 (derived)", surface3),
+                     ("Surface4 (derived)", surface4),
                  })
         {
             var ratio = ContrastRatio(p.TextMuted, surface);
             Assert.True(ratio >= 4.5,
-                $"Preset '{presetId}': TextMuted must meet WCAG AA (4.5:1) on {label}; got {ratio:F2}:1.");
+                $"Preset '{presetId}': TextMuted must meet WCAG AA (4.5:1) on {label}; got {ratio:F2}:1. "
+                + "Surface3 and Surface4 are DERIVED by lerping Surface2 toward TextPrimary, which lowers "
+                + "contrast — so a muted colour that only just clears 4.5:1 on Surface2 will fail here. "
+                + "Move TextMuted away from the surface (lighter on a dark preset, darker on a light one) "
+                + "rather than adjusting the lerp, which is what gives the ramp its elevation.");
         }
     }
 
     // TextSecondary is the next tier up and should comfortably clear AA everywhere; assert it too so
-    // a future palette tweak can't quietly regress it below the muted tier.
+    // a future palette tweak can't quietly regress it below the muted tier. Held to Surface4 for the
+    // same reason as the muted tier above — sky-breeze sat at 4.39:1 there while passing on Surface2.
     [Theory]
     [MemberData(nameof(AllPresets))]
     public void TextSecondary_MeetsWcagAa_OnSurface2(string presetId)
     {
         var p = ThemePreset.Defaults[presetId];
-        var ratio = ContrastRatio(p.TextSecondary, p.Surface2);
-        Assert.True(ratio >= 4.5,
-            $"Preset '{presetId}': TextSecondary must meet WCAG AA (4.5:1) on Surface2; got {ratio:F2}:1.");
+        foreach (var (label, surface) in new[]
+                 {
+                     ("Surface2", p.Surface2),
+                     ("Surface4 (derived)", Lerp(p.Surface2, p.TextPrimary, 0.10)),
+                 })
+        {
+            var ratio = ContrastRatio(p.TextSecondary, surface);
+            Assert.True(ratio >= 4.5,
+                $"Preset '{presetId}': TextSecondary must meet WCAG AA (4.5:1) on {label}; got {ratio:F2}:1.");
+        }
     }
 
     // TextPrimary is the highest tier — hold it to the stricter AAA bar (7:1) on the base background,
@@ -141,11 +173,18 @@ public class ThemeTextContrastTests
             var shaded = ThemeService.Shade(seeded, position);
             positionsChecked++;
 
+            // Includes the DERIVED surfaces, for the same reason the seeded check above does: they are the
+            // lowest-contrast rungs of the ramp, and the slider shifts Surface2 underneath them.
+            var shadedSurface3 = Lerp(shaded.Surface2, shaded.TextPrimary, 0.05);
+            var shadedSurface4 = Lerp(shaded.Surface2, shaded.TextPrimary, 0.10);
+
             foreach (var (label, surface) in new[]
                      {
                          ("Background", shaded.Background),
                          ("Surface", shaded.Surface),
                          ("Surface2", shaded.Surface2),
+                         ("Surface3 (derived)", shadedSurface3),
+                         ("Surface4 (derived)", shadedSurface4),
                      })
             {
                 var muted = ContrastRatio(shaded.TextMuted, surface);
@@ -153,9 +192,16 @@ public class ThemeTextContrastTests
                     offenders.Add($"shade {position:F2}: TextMuted on {label} = {muted:F2}:1");
             }
 
-            var secondary = ContrastRatio(shaded.TextSecondary, shaded.Surface2);
-            if (secondary < 4.5)
-                offenders.Add($"shade {position:F2}: TextSecondary on Surface2 = {secondary:F2}:1");
+            foreach (var (label, surface) in new[]
+                     {
+                         ("Surface2", shaded.Surface2),
+                         ("Surface4 (derived)", shadedSurface4),
+                     })
+            {
+                var secondary = ContrastRatio(shaded.TextSecondary, surface);
+                if (secondary < 4.5)
+                    offenders.Add($"shade {position:F2}: TextSecondary on {label} = {secondary:F2}:1");
+            }
 
             var primary = ContrastRatio(shaded.TextPrimary, shaded.Background);
             if (primary < 7.0)
@@ -195,13 +241,21 @@ public class ThemeTextContrastTests
     [Fact]
     public void TheCorrection_EngagesWhereTheSliderWouldOtherwiseBreachTheFloor()
     {
-        // midnight-indigo at the top of the range is the worst measured case: 3.94:1 before the fix.
+        // Measured against the DERIVED Surface4, because that is the rung the slider actually breaches.
+        //
+        // This test used to point at Surface2, where midnight-indigo measured 3.94:1 uncorrected. #1555
+        // re-seeded that preset's muted colour for the derived surfaces, which lifted Surface2 to 5.11:1 —
+        // so the example stopped breaching, the correction stopped engaging for the reason being asserted,
+        // and the test's own third assertion fired to say it no longer proved anything. It was right. The
+        // breach did not go away, it just moved down the ramp: the same preset at the same slider position
+        // measures 3.84:1 on Surface4.
         var seeded = ThemePreset.Defaults["midnight-indigo"];
         var shaded = ThemeService.Shade(seeded, 1.0);
+        var shadedSurface4 = Lerp(shaded.Surface2, shaded.TextPrimary, 0.10);
 
         Assert.NotEqual(seeded.TextMuted, shaded.TextMuted);
-        Assert.True(ContrastRatio(shaded.TextMuted, shaded.Surface2) >= 4.5);
-        Assert.True(ContrastRatio(seeded.TextMuted, shaded.Surface2) < 4.5,
+        Assert.True(ContrastRatio(shaded.TextMuted, shadedSurface4) >= 4.5);
+        Assert.True(ContrastRatio(seeded.TextMuted, shadedSurface4) < 4.5,
             "the uncorrected ramp was expected to fail against the shifted surface — if it now passes, "
             + "this test no longer proves the correction does anything.");
     }

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -188,15 +188,29 @@ public sealed class ThemeService
             Border = ShiftLightness(baseTheme.Border, offset)
         };
 
+        // TextPrimary is corrected first because the two DERIVED surfaces are lerped toward it, so they
+        // cannot be computed until it is final. Derived here with the same factors Apply uses, from the
+        // shaded Surface2 and the corrected primary — which is exactly the pair Apply will be handed.
+        var primary = Legible(shaded.TextPrimary, baseTheme.IsDark, 7.0, shaded.Background);
+        var surface3 = Lerp(shaded.Surface2, primary, 0.05);
+        var surface4 = Lerp(shaded.Surface2, primary, 0.10);
+
         // The floors and the surfaces each one is measured against mirror ThemeTextContrastTests exactly:
         // this correction enforces the same contract those assertions check, rather than a second opinion
         // about what "legible" means.
+        //
+        // Surface3/Surface4 were missing from both sides of that mirror until #1555. Measured across all
+        // twelve presets and twenty-one slider positions, the slider pushed muted text as low as 3.84:1 on
+        // Surface4 — and on warm-sand it did so from the DEFAULT position outward, so this was reachable
+        // without the user touching anything. Correcting against only the seeded rungs left the two rungs
+        // that actually carry the worst contrast unprotected.
         return shaded with
         {
-            TextPrimary = Legible(shaded.TextPrimary, baseTheme.IsDark, 7.0, shaded.Background),
-            TextSecondary = Legible(shaded.TextSecondary, baseTheme.IsDark, 4.5, shaded.Surface2),
+            TextPrimary = primary,
+            TextSecondary = Legible(shaded.TextSecondary, baseTheme.IsDark, 4.5,
+                                    shaded.Surface2, surface4),
             TextMuted = Legible(shaded.TextMuted, baseTheme.IsDark, 4.5,
-                                shaded.Background, shaded.Surface, shaded.Surface2)
+                                shaded.Background, shaded.Surface, shaded.Surface2, surface3, surface4)
         };
     }
 
@@ -579,10 +593,10 @@ public sealed record ThemePreset(
     {
         ["midnight-indigo"] = new("midnight-indigo", "Midnight Indigo", true,
             C("#6366F1"), C("#070A0F"), C("#0E1218"), C("#151A23"), C("#1F2633"),
-            C("#F1F3F7"), C("#A3ADBF"), C("#7B8396")), // muted: WCAG AA on Surface2 (was #6B7489, 3.72)
+            C("#F1F3F7"), C("#A3ADBF"), C("#9097A7")), // muted: WCAG AA on the DERIVED Surface3/Surface4 too (was #7B8396, 4.09 / 3.53)
         ["deep-ocean"] = new("deep-ocean", "Deep Ocean", true,
             C("#3B82F6"), C("#050D1A"), C("#0A1628"), C("#0F1D33"), C("#1A2D4D"),
-            C("#E2E8F0"), C("#94A3B8"), C("#78879B")), // muted: WCAG AA on Surface2 (was #64748B, 3.55)
+            C("#E2E8F0"), C("#94A3B8"), C("#8D9AAC")), // muted: WCAG AA on the DERIVED Surface3/Surface4 too (was #78879B, 4.11 / 3.59)
         ["dark-forest"] = new("dark-forest", "Dark Forest", true,
             C("#10B981"), C("#020F0A"), C("#021A12"), C("#03261A"), C("#0A3D2A"),
             C("#D1FAE5"), C("#6EE7B7"), C("#34D399")),
@@ -591,22 +605,23 @@ public sealed record ThemePreset(
             C("#FDF2F8"), C("#F9A8D4"), C("#F472B6")),
         ["violet-night"] = new("violet-night", "Violet Night", true,
             C("#A855F7"), C("#0A0515"), C("#0F0A1A"), C("#160F26"), C("#2D1B4E"),
-            C("#F3E8FF"), C("#C4B5FD"), C("#8E60F6")), // muted: WCAG AA on Surface2 (was #8B5CF6, 4.39)
+            C("#F3E8FF"), C("#C4B5FD"), C("#A078F7")), // muted: WCAG AA on the DERIVED Surface3/Surface4 too (was #8E60F6, 4.14 / 3.62)
         ["warm-ember"] = new("warm-ember", "Warm Ember", true,
             C("#F59E0B"), C("#0F0A04"), C("#1A1008"), C("#24180C"), C("#3D2A12"),
             C("#FEF3C7"), C("#FCD34D"), C("#FBBF24")),
         ["clean-indigo"] = new("clean-indigo", "Clean Indigo", false,
             C("#6366F1"), C("#FFFFFF"), C("#F8FAFC"), C("#F1F5F9"), C("#E2E8F0"),
-            C("#1E1B4B"), C("#4338CA"), C("#5D5FE2")), // muted: WCAG AA on Surface2 (was #6366F1, 4.08)
+            C("#1E1B4B"), C("#4338CA"), C("#5153C6")), // muted: WCAG AA on the DERIVED Surface3/Surface4 too (was #5D5FE2, 4.14 / 3.74)
         ["sky-breeze"] = new("sky-breeze", "Sky Breeze", false,
             C("#0EA5E9"), C("#F8FAFC"), C("#F0F9FF"), C("#E0F2FE"), C("#BAE6FD"),
-            C("#0C4A6E"), C("#0369A1"), C("#0572AB")), // muted: WCAG AA on Surface2 (was #0284C7, 3.57)
+            // The only preset needing BOTH tiers re-seeded: secondary was 4.39 on Surface4 (was #0369A1).
+            C("#0C4A6E"), C("#02669D"), C("#04679A")), // muted: WCAG AA on the DERIVED Surface3/Surface4 too (was #0572AB, 4.20 / 3.88)
         ["warm-sand"] = new("warm-sand", "Warm Sand", false,
             C("#D97706"), C("#FFFBEB"), C("#FEF3C7"), C("#FDE68A"), C("#FCD34D"),
             C("#451A03"), C("#78350F"), C("#92400E")),
         ["mint-fresh"] = new("mint-fresh", "Mint Fresh", false,
             C("#16A34A"), C("#F0FDF4"), C("#DCFCE7"), C("#BBF7D0"), C("#86EFAC"),
-            C("#14532D"), C("#166534"), C("#15783A")), // muted: WCAG AA on Surface2 (was #15803D, 4.14)
+            C("#14532D"), C("#166534"), C("#136C34")), // muted: WCAG AA on the DERIVED Surface3/Surface4 too (was #15783A, 4.22 / 3.91)
         ["soft-blossom"] = new("soft-blossom", "Soft Blossom", false,
             C("#DB2777"), C("#FDF2F8"), C("#FCE7F3"), C("#FBCFE8"), C("#F9A8D4"),
             C("#500724"), C("#831843"), C("#9D174D")),

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.4</Version>
-    <FileVersion>1.76.4.0</FileVersion>
-    <AssemblyVersion>1.76.4.0</AssemblyVersion>
+    <Version>1.76.5</Version>
+    <FileVersion>1.76.5.0</FileVersion>
+    <AssemblyVersion>1.76.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #1555.

## What was wrong

`Surface3` and `Surface4` are not seeded. `ThemeService.Apply` derives them:

```csharp
SetBrush(res, "Surface3", Lerp(theme.Surface2, theme.TextPrimary, 0.05));
SetBrush(res, "Surface4", Lerp(theme.Surface2, theme.TextPrimary, 0.10));
```

The contrast guard skipped both, with this reasoning in a comment: *"Surface3/Surface4 are derived by Lerp
toward TextPrimary (higher contrast for muted, so not the worst case)"*. Backwards — lerping the **surface**
toward the text moves the surface **closer** to the text, so contrast **drops**. Surface4 is the
lowest-contrast rung in the ramp and it was the one left unasserted.

Recomputed from current source with the service's own `Lerp` (not from the numbers in the issue), `TextMuted`
was sub-AA on **both** derived surfaces in **6 of 12 presets**:

| preset | Surface2 | Surface3 | Surface4 |
|---|---|---|---|
| **midnight-indigo** (default) | 4.59 | 4.09 | **3.53** |
| deep-ocean | 4.61 | 4.11 | **3.59** |
| violet-night | 4.56 | 4.14 | **3.62** |
| clean-indigo | 4.56 | 4.14 | **3.74** |
| sky-breeze | 4.57 | 4.20 | **3.88** |
| mint-fresh | 4.58 | 4.22 | **3.91** |

The root cause is visible in that first column: those six clear Surface2 by 0.06 to 0.11, so the ramp has no
headroom left for elevation. `sky-breeze`'s `TextSecondary` was also 4.39 on Surface4. Fourteen places in the
app put muted text on those surfaces, among them the Tweaks Hub "DEFAULT" badge at `FontSize="10"` and the
elevation badge.

## Seven colours re-seeded

Each the **smallest** nudge along the palette's existing hue that clears 4.55:1 on both derived surfaces —
searched for, not picked. The direction is forced: in every failing preset the muted colour sits on the far
side of Surface4, so contrast rises only by moving it **away** from the surface, which is lighter on a dark
preset and darker on a light one. (The issue's prose says the opposite.)

| preset | from | to | S3 | S4 | step |
|---|---|---|---|---|---|
| midnight-indigo | `#7B8396` | `#9097A7` | 4.09 → 5.30 | 3.53 → 4.58 | 18% |
| deep-ocean | `#78879B` | `#8D9AAC` | 4.11 → 5.26 | 3.59 → 4.59 | 20% |
| violet-night | `#8E60F6` | `#A078F7` | 4.14 → 5.23 | 3.62 → 4.59 | 18% |
| clean-indigo | `#5D5FE2` | `#5153C6` | 4.14 → 5.11 | 3.74 → 4.62 | 12% |
| sky-breeze | `#0572AB` | `#04679A` | 4.20 → 4.93 | 3.88 → 4.55 | 10% |
| mint-fresh | `#15783A` | `#136C34` | 4.22 → 4.95 | 3.91 → 4.59 | 10% |
| sky-breeze *secondary* | `#0369A1` | `#02669D` | — | 4.39 → 4.58 | — |

`dark-forest`, `neon-rose`, `warm-ember`, `warm-sand`, `soft-blossom` and `lavender` already clear AA on every
rung and are untouched. Previewed as a mockup at the real surface colours before landing.

## Two more instances of the same omission

Extending the guard turned both up, and both are fixed here rather than left as half a migration.

**The shade-slider sweep also stopped at Surface2.** With the derived surfaces included it went red on six
presets — and on `warm-sand` it breached **from the slider's own default position outward**, so this was
reachable without the user touching anything. `midnight-indigo` bottomed out at **3.84:1** at the top of the
range.

**`Shade`'s correction only measured the seeded rungs**, while its own comment claimed to "mirror
ThemeTextContrastTests exactly". It now derives Surface3/Surface4 from the **corrected** `TextPrimary` — which
is the pair `Apply` will actually be handed, since the derivation lerps toward it — and corrects against them.
`TextPrimary` therefore has to be resolved first, which is why the `with` expression became three statements.

## The test that fired its own tripwire

`TheCorrection_EngagesWhereTheSliderWouldOtherwiseBreachTheFloor` exists so the correction mechanism cannot be
deleted unnoticed, and it went red with exactly the message it was written to produce: *"the uncorrected ramp
was expected to fail against the shifted surface — if it now passes, this test no longer proves the correction
does anything."*

It was right. Re-seeding lifted `midnight-indigo`'s Surface2 from 3.94 to 5.11 at slider position 1.0, so the
example stopped breaching. I checked whether the correction had become unreachable altogether — sweeping all
12 presets × 21 positions, the uncorrected worst case against Surface2 is now 4.68:1, so at that rung it has —
but the breach did not go away, it moved **down the ramp**: the same preset at the same position measures
3.84:1 on Surface4. The test now measures there.

## Non-vacuity floor

The seeded theory asserts `Surface2 != Surface3 != Surface4` before using them. Zeroing the lerp factors would
otherwise turn those rows into silent repeats of Surface2 and the theory would pass while covering nothing
above it — which is precisely how the original gap survived.

## Red/green proof

| Mutation | What went red |
|---|---|
| midnight-indigo's muted colour reverts | muted theory: "on Surface3 (derived); got 4.09:1" |
| sky-breeze's secondary colour reverts | secondary theory: "on Surface4 (derived); got 4.39:1" |
| the test's Surface3 lerp is zeroed | the non-vacuity floor, on every preset |

Both files restored byte-for-byte by SHA, 24 green afterwards.

## Regression sweep

- All four projects build, 0 warnings and 0 errors.
- Every theme, contrast and dark-mode test: **201 green, 0 red** across 64 test methods — including the
  ToggleSwitch track checks, which read Surface4 and so are sensitive to this change.
- `ArchitectureTests`: 87 green, plus the one known runner-only failure.
- Independently re-verified with a separate harness that reads `ThemePreset.Defaults` and derives the surfaces
  itself: **zero** presets fail AA on Surface2, Surface3 or Surface4, and zero `TextSecondary` failures.
- Every touched file confirmed `w/crlf`.

## One correction to my own working

The first version of the mockup had the palettes typed by hand and put each preset's `Border` where `Surface2`
belongs — adjacent fields in the record's constructor — so four of six rows on that page computed against the
wrong surface. The colours are unaffected: they came from the C# harness, which reads `p.Surface2` directly.
The page now has its palette emitted from the source rather than typed.
