### PR TITLE
fix: give a custom theme the same legibility path as a preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.6] - 2026-09-03
+
+A theme you build yourself in the appearance panel is now kept readable the same way the built-in ones are.
+Before, it was the one kind of theme the app applied exactly as typed, so four unlucky colour choices could
+leave text you could not read — with no way back except deleting a file by hand.
+
+### Fixed
+- **A custom theme now gets the same readability protection as a built-in one.** Every built-in theme goes
+  through a step that nudges its text until it stands out from the panels behind it. A custom theme skipped
+  that step entirely and was applied exactly as typed, so white text on a white background was accepted. It
+  goes through the same step now. Applying a custom theme also used to throw away the background-shade slider's
+  position; it keeps it.
+- **Green and mid-grey backgrounds no longer get the wrong warning colours.** Whether a custom background
+  counted as dark was decided by adding its red, green and blue values together, which treats all three as
+  equally bright when the eye does not. A pure green background was called dark, so the app installed the
+  colours meant for dark backgrounds and its amber warning text landed on bright green — effectively invisible.
+  Mid-grey had the same problem. Brightness is now measured the way the accessibility standard measures it.
+
 ## [1.76.5] - 2026-09-03
 
 Small grey labels — the "DEFAULT" tag in Tweaks Hub, the administrator badge, and similar — were too faint to

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -402,6 +402,59 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Every way of setting a theme goes through the one path that keeps its text legible.
+    /// </summary>
+    /// <remarks>
+    /// <c>ApplyShade</c> is where <c>Shade</c> runs, and <c>Shade</c> is where the text ramp is corrected
+    /// against its surfaces. <c>SetPreset</c> and <c>SetAccent</c> both call it; <c>SetCustom</c> built
+    /// <c>CurrentTheme</c> itself and called <c>Apply</c> directly, so a custom theme was the only kind that
+    /// never went through the correction at all — four typed hex values could produce white on white while
+    /// every shipped preset was held to a contrast floor. It also silently discarded the shade slider's
+    /// position.
+    /// <para>Asserted on the source rather than by calling the method, because <c>SetCustom</c> ends in
+    /// <c>Save()</c>, which writes the user's real theme file.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryThemeEntryPoint_GoesThroughTheLegibilityCorrection()
+    {
+        var service = File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "Services", "ThemeService.cs"));
+
+        foreach (var entry in new[] { "SetPreset", "SetAccent", "SetCustom" })
+        {
+            var at = service.IndexOf($"public void {entry}(", StringComparison.Ordinal);
+            Assert.True(at > 0, $"ThemeService.{entry} was renamed — update this guard, don't drop it.");
+
+            // To the next method declaration, so the slice is this method and nothing after it.
+            var end = service.IndexOf("\n    public ", at + 1, StringComparison.Ordinal);
+            if (end < 0) end = service.IndexOf("\n    private ", at + 1, StringComparison.Ordinal);
+            Assert.True(end > at, $"could not bound {entry}'s body.");
+            var body = service[at..end];
+
+            Assert.Contains("ApplyShade();", body, StringComparison.Ordinal);
+            Assert.DoesNotContain("CurrentTheme = new ThemePreset", body, StringComparison.Ordinal);
+        }
+
+        // The channel-sum heuristic: two or more channels added on one line. Matching ".R +" alone is too
+        // broad — Lerp legitimately writes (byte)(a.R + (b.R - a.R) * t), one channel per line — so the shape
+        // that identifies a sum is several channels meeting in a single expression.
+        var summing = service.Split('\n')
+            .Select((line, i) => (Line: line.Trim(), Number: i + 1))
+            .Where(l => l.Line.Contains(".R +", StringComparison.Ordinal)
+                        && l.Line.Contains(".G +", StringComparison.Ordinal))
+            .Select(l => $"line {l.Number}: {l.Line}")
+            .ToArray();
+
+        Assert.True(summing.Length == 0,
+            "a background's brightness is being judged by adding its channels, which weights them equally "
+            + "where the eye does not: #00FF00 sums to 255 and was called DARK on a relative luminance of "
+            + "0.715, so the dark arm of the status palette went onto bright green at 1.05:1. Use "
+            + "IsDarkBackground, which asks RelativeLuminance:\n  " + string.Join("\n  ", summing));
+
+        Assert.Contains("RelativeLuminance(background) < 0.18", service, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// No test in the blocking suite may wait by sleeping.
     /// </summary>
     /// <remarks>

--- a/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
+++ b/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
@@ -481,4 +481,58 @@ public class ThemeStatusBrushTests
     [Fact]
     public void TextOnDanger_DiffersBetweenModes()
         => Assert.NotEqual(ThemeService.TextOnDanger(true), ThemeService.TextOnDanger(false));
+
+    /// <summary>
+    /// Which arm of the palette a custom background gets is decided by perceived brightness, not by adding
+    /// the three channels together.
+    /// </summary>
+    /// <remarks>
+    /// <c>SetCustom</c> used <c>background.R + background.G + background.B &lt; 384</c>, which weights every
+    /// channel equally where the eye does not. <c>#00FF00</c> sums to 255 and was called DARK on a relative
+    /// luminance of 0.715, so this file's whole subject — the per-mode status palette — was installed the
+    /// wrong way round: the dark arm's <c>WarningText #FCD34D</c> landed on bright green at 1.05:1.
+    /// <c>#7F7F7F</c> sums to 381 and was mis-called dark for the same reason.
+    /// <para>Both boundary rows are here on purpose. Navy passing and mid-grey failing is what distinguishes
+    /// a luminance test from a channel-sum test; a data set of only obvious blacks and whites cannot tell the
+    /// two apart and would pass against the defect.</para>
+    /// <para><paramref name="armIsLegible"/> is false for one row, and that is a real limitation rather than
+    /// an exemption. The palette has two arms, calibrated for dark and for light surfaces. On a mid-grey
+    /// background NEITHER is legible — the light arm measures 1.77:1 on <c>#7F7F7F</c> — because a background
+    /// of middling luminance is not what either arm was built for. Classifying it correctly is still strictly
+    /// better than classifying it wrongly, but the honest assertion here is about the classification, not
+    /// about an outcome the palette cannot produce.</para>
+    /// </remarks>
+    [Theory]
+    [InlineData("#00FF00", false, true, "saturated green: sum 255 says dark, luminance 0.715 says light")]
+    [InlineData("#7F7F7F", false, false, "mid grey: sum 381 says dark, luminance 0.212 says light")]
+    [InlineData("#FFFF00", false, true, "yellow, light on both readings")]
+    [InlineData("#000080", true, true, "navy: dark on both readings, so the fix must not over-correct")]
+    [InlineData("#070A0F", true, true, "the default preset's own background")]
+    [InlineData("#FFFFFF", false, true, "white")]
+    public void ACustomBackground_IsClassifiedByLuminance(
+        string hex, bool expectedDark, bool armIsLegible, string why)
+    {
+        var background = (Color)ColorConverter.ConvertFromString(hex)!;
+
+        Assert.Equal(expectedDark, ThemeService.IsDarkBackground(background));
+
+        // The consequence, not just the flag: where an arm can serve the background at all, the one this
+        // picks has to be the legible one.
+        var warning = Lookup(ThemeService.StatusPalette(expectedDark), "WarningText");
+        var ratio = ContrastRatio(warning, background);
+        if (armIsLegible)
+        {
+            Assert.True(ratio >= 4.5,
+                $"{hex} ({why}): the {(expectedDark ? "dark" : "light")} arm's WarningText is {ratio:F2}:1 "
+                + "on it.");
+        }
+        else
+        {
+            // Pinned rather than skipped: if a future palette change made mid-grey legible, this row should
+            // be revisited and promoted, not left quietly claiming a limitation that no longer exists.
+            Assert.True(ratio < 4.5,
+                $"{hex} is now legible on the arm it selects ({ratio:F2}:1). The two-arm limitation this row "
+                + "documents has been fixed — flip armIsLegible to true and delete this branch.");
+        }
+    }
 }

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -119,6 +119,17 @@ public sealed class ThemeService
         return timer;
     }
 
+    /// <summary>
+    /// Builds and applies a theme from the four colours the appearance popup collects.
+    /// </summary>
+    /// <remarks>
+    /// Goes through <see cref="ApplyShade"/> like <see cref="SetPreset"/> and <see cref="SetAccent"/> do,
+    /// rather than assigning <see cref="CurrentTheme"/> itself. It used to do the latter, with two
+    /// consequences: the shade slider's position was silently discarded whenever a custom theme was applied,
+    /// and — more importantly — a custom theme was the ONLY kind that never went through the text-legibility
+    /// correction inside <see cref="Shade"/>. Four typed hex values could therefore produce white on white,
+    /// while every shipped preset was held to a contrast floor. Same machinery for both now.
+    /// </remarks>
     public void SetCustom(Color accent, Color background, Color surface, Color text)
     {
         CurrentMode = "custom";
@@ -126,7 +137,7 @@ public sealed class ThemeService
         _baseTheme = new ThemePreset(
             Id: "custom",
             Name: "Custom",
-            IsDark: background.R + background.G + background.B < 384,
+            IsDark: IsDarkBackground(background),
             Accent: accent,
             Background: background,
             Surface: surface,
@@ -135,21 +146,25 @@ public sealed class ThemeService
             TextPrimary: text,
             TextSecondary: Lerp(text, background, 0.3),
             TextMuted: Lerp(text, background, 0.55));
-        CurrentTheme = new ThemePreset(
-            Id: "custom",
-            Name: "Custom",
-            IsDark: background.R + background.G + background.B < 384,
-            Accent: accent,
-            Background: background,
-            Surface: surface,
-            Surface2: Lerp(surface, background, 0.5),
-            Border: Lerp(surface, text, 0.15),
-            TextPrimary: text,
-            TextSecondary: Lerp(text, background, 0.3),
-            TextMuted: Lerp(text, background, 0.55));
-        Apply(CurrentTheme);
+        ApplyShade();
         Save();
     }
+
+    /// <summary>
+    /// Whether a background counts as dark, for choosing which arm of the status palette to install.
+    /// </summary>
+    /// <remarks>
+    /// Perceptual luminance, not the sum of the channels. The sum treats every channel as equally bright, so
+    /// <c>#00FF00</c> summed to 255 and was classified DARK despite a relative luminance of 0.715 — the dark
+    /// status palette then put <c>WarningText #FCD34D</c> on bright green at 1.05:1. <c>#7F7F7F</c> summed to
+    /// 381 and was mis-called dark for the same reason. 0.18 is the midpoint used by the same WCAG formula
+    /// the contrast tests apply, so the classification and the assertions agree on what "dark" means.
+    /// </remarks>
+    /// <remarks>
+    /// <c>internal</c> for the same reason <see cref="Shade"/> is: it is pure, and the alternative way to
+    /// exercise it is to call <see cref="SetCustom"/>, which persists to the user's real theme file.
+    /// </remarks>
+    internal static bool IsDarkBackground(Color background) => RelativeLuminance(background) < 0.18;
 
     private void ApplyShade()
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.5</Version>
-    <FileVersion>1.76.5.0</FileVersion>
-    <AssemblyVersion>1.76.5.0</AssemblyVersion>
+    <Version>1.76.6</Version>
+    <FileVersion>1.76.6.0</FileVersion>
+    <AssemblyVersion>1.76.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Advances #1561 — part (1) of three, plus a defect found next to it. Parts (2) and (3) are UI and need a mockup
first; the issue stays open with those as the remainder.

## Two bugs in one method

`SetPreset` and `SetAccent` both end in `ApplyShade()`. `SetCustom` built `CurrentTheme` itself and called
`Apply` directly, which meant:

1. **Applying a custom theme silently discarded the shade slider's position.** `ApplyShade` is what reads it.
2. **A custom theme was the only kind that never went through the text-legibility correction.** That correction
   lives in `Shade`, which only `ApplyShade` calls. So four typed hex values could produce white on white,
   while every shipped preset was held to a contrast floor by the same machinery.

The second is what this issue is about — "accepts any 4 colours with no contrast check" — and it turns out the
check already existed and was simply not on this path. Routing through `ApplyShade` also collapses a verbatim
eleven-field duplication: the whole `ThemePreset` was constructed twice, once for `_baseTheme` and once for
`CurrentTheme`, with the `IsDark` expression repeated in both.

## The dark/light heuristic

```csharp
IsDark: background.R + background.G + background.B < 384
```

Adding channels weights them equally where the eye does not. Verified arithmetically:

| background | channel sum | says | relative luminance | says |
|---|---|---|---|---|
| `#00FF00` | 255 | **dark** | 0.715 | light |
| `#7F7F7F` | 381 | **dark** | 0.212 | light |
| `#FFFF00` | 510 | light | 0.928 | light |
| `#000080` | 128 | dark | 0.016 | dark |

So a pure-green background installed the **dark** arm of the status palette, putting `WarningText #FCD34D` on
bright green at **1.05:1**. It is now `RelativeLuminance(background) < 0.18`, using the function already
present in that file, so the classification and the contrast assertions agree on what "dark" means — which is
what the issue asked for.

## Something the first guard found

On a **mid-grey** background *neither* arm of the status palette is legible: the light arm measures 1.77:1 on
`#7F7F7F`. A two-arm palette calibrated for dark and light surfaces has nothing for a background of middling
luminance. Classifying it correctly is still strictly better than classifying it wrongly, so that data row
asserts the classification and **pins the limitation** — with a message telling a future reader to promote the
row if the palette ever grows to cover it — rather than claiming an outcome the palette cannot produce. My
first draft asserted legibility there and went red; the assertion was wrong, not the fix.

## Guards

`ACustomBackground_IsClassifiedByLuminance` — six backgrounds, checking the classification **and** its
consequence on the palette. Navy is in the set on purpose: it is dark on both readings, so a data set of only
obvious blacks and whites could not tell a luminance test from a channel-sum test and would pass against the
defect.

`EveryThemeEntryPoint_GoesThroughTheLegibilityCorrection` — all three entry points call `ApplyShade`, none
assigns `CurrentTheme` itself, no line adds two colour channels together, and the luminance threshold is
present. Asserted on the source rather than by calling the methods, because `SetCustom` ends in `Save()`, which
writes the user's real theme file.

The channel-sum check matches "two channels in one expression", not `.R +` alone: `Lerp` legitimately writes
`(byte)(a.R + (b.R - a.R) * t)`, one channel per line, and the broader needle flagged it on the first run.

## Red/green proof

| Mutation | What went red |
|---|---|
| the channel-sum heuristic comes back | the guard, naming `line 140` and the summing expression |
| `SetCustom` applies directly again | the guard: `ApplyShade();` not found in its body |
| the luminance threshold moves to 0.20 | the guard's positive assertion |

All aimed at the **source**. Weakening an assertion inside a test can only make it pass, so mutating the test
would prove nothing — the first draft of this proof did that and was discarded. `ThemeService.cs` restored
byte-for-byte, 7 green afterwards.

## Regression sweep

- All four projects build, 0 warnings and 0 errors.
- Every theme, contrast, dark-mode and chart-theme test: **207 green, 0 red** across 65 methods.
- `ArchitectureTests`: 88 green, plus the one known runner-only failure.
- Every touched file confirmed `w/crlf`.

## What remains on #1561

- **(2) the inline contrast warning in the popup.** Much less pressing now — a custom theme can no longer
  produce unreadable text, because the correction runs. Still worth telling the user their choice was adjusted,
  which is copy plus a visual treatment, so it wants a mockup.
- **(3) "Reset to default theme".** The issue specifies the mechanism exactly (a `GhostButton` calling
  `SetPreset("midnight-indigo")`); placement and label are a design call.
