### PR TITLE
fix: stop a custom theme drifting on restart and the audio picker re-guessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.7] - 2026-09-03
+
+Two things that went wrong in yesterday's last two updates. A theme you built yourself drifted a little every
+time you started the app, and the Volume Control output picker went back to naming a device it had not actually
+read, about ten seconds after you opened the tab. Both are fixed.
+
+### Fixed
+- **A custom theme no longer drifts on every restart.** The app saved the theme *after* applying its
+  readability adjustments, then read that adjusted version back as your starting point the next time — so each
+  launch adjusted an already-adjusted theme. With the background-shade slider off centre the panels crept
+  lighter or darker every time; even with the slider untouched the text colour walked, a little further on each
+  start. It now saves the colours you actually chose. If your custom theme has already drifted, re-picking your
+  colours once will fix it for good.
+- **The output picker in Volume Control stops re-claiming a device it never read.** 1.76.4 made the picker say
+  "Choose a device" rather than guessing your default, because Windows does not report which device an app is
+  using. But the app re-reads the device list every ten seconds, and that refresh treated "we do not know" as
+  "no preference set" — so the guess came back. It stays honest now.
+
 ## [1.76.6] - 2026-09-03
 
 A theme you build yourself in the appearance panel is now kept readable the same way the built-in ones are.

--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -255,6 +255,40 @@ public class AudioMixerViewModelTests
     // Calls are captured inside the stub rather than asserted with Received(n), for the reason the
     // neighbouring test gives: an NSubstitute substitute is not thread-safe.
 
+    /// <summary>
+    /// An unknown route must still be unknown after the device list is re-read.
+    /// </summary>
+    /// <remarks>
+    /// <c>RefreshDevicesAsync</c> snapshots each row's selection before <c>ReplaceWith</c> and re-applies it
+    /// afterwards, and it did so as <c>r.SelectedOutputDevice?.Id ?? string.Empty</c>. Under the three-state
+    /// contract the empty string means "read succeeded, no override", which resolves to the entry flagged
+    /// <c>IsDefault</c> and marks the row KNOWN — so the snapshot silently converted "we do not know" into "it
+    /// is on the default device". That refresh runs every tenth pass of the 1 Hz reconcile loop, so every
+    /// routable row reverted from the placeholder to naming a device about ten seconds after the tab opened,
+    /// undoing the fix that introduced the placeholder. The route read is still a stub returning null, so this
+    /// was every row on every machine, not an edge case.
+    /// <para>Twelve passes, not ten: the refresh fires ON the tenth, and stopping there would leave the
+    /// assertion sitting exactly on the boundary it is trying to cross.</para>
+    /// </remarks>
+    [Fact]
+    public async Task AnUnknownRoute_StaysUnknownAcrossADeviceRefresh()
+    {
+        var writes = new List<(string Session, string Device)>();
+        using var vm = NewVm(RoutableService(writes, route: null));
+        var row = vm.Sessions.Single();
+
+        Assert.True(row.OutputRouteUnknown, "the row should start unknown — the route read is a stub");
+        Assert.Null(row.SelectedOutputDevice);
+
+        for (var pass = 0; pass < 12; pass++) await vm.ReconcileAsync();
+
+        Assert.True(row.OutputRouteUnknown,
+            "after the device refresh the row claims to know its route. The placeholder is gone and the "
+            + "picker now names a device the app never read.");
+        Assert.Null(row.SelectedOutputDevice);
+        Assert.Empty(writes);   // and re-applying a snapshot must never write back
+    }
+
     private static IAudioMixerService RoutableService(
         List<(string Session, string Device)> writes, string? route = null)
     {

--- a/SysManager/SysManager.Tests/ThemeServiceTests.cs
+++ b/SysManager/SysManager.Tests/ThemeServiceTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.IO;
+using System.Windows.Media;
 using System.Text.Json;
 using SysManager.Services;
 
@@ -93,5 +94,56 @@ public class ThemeServiceTests : IDisposable
         reloaded.Initialize();
 
         Assert.Equal(0.8, reloaded.ShadePosition, precision: 3);
+    }
+
+    /// <summary>
+    /// Saving a custom theme and loading it back must be a fixed point: the file that comes out of a reload
+    /// has to be byte-identical to the one that went in.
+    /// </summary>
+    /// <remarks>
+    /// <c>CurrentTheme</c> is a pure function of <c>(_baseTheme, ShadePosition)</c>. <c>Save</c> persisted
+    /// <c>CurrentTheme</c> — the derived value — and <c>Load</c>'s custom branch hands those four colours back
+    /// to <c>SetCustom</c> as the new BASE. So every launch derived from an already-derived theme and a custom
+    /// theme degraded a little each time, silently, with the user never touching anything.
+    /// <para>Two independent drift channels, one per row here. At a non-default slider position the shade
+    /// offset re-applies to already-shifted surfaces. At the DEFAULT position the offset is zero, but
+    /// <c>Legible</c> still walks <c>TextPrimary</c> in 2% steps whenever it misses 7:1 against the
+    /// background — and the walked value was what got saved, so the text marched on every restart with the
+    /// slider untouched. A test at only one position would miss whichever channel it did not sit on.</para>
+    /// <para>Asserting the FILE rather than a property is deliberate: the file is what survives a restart, and
+    /// comparing generation 2 with generation 3 alone would pass even if generation 1 to 2 had already
+    /// shifted — a drift that stops after one step is still a drift.</para>
+    /// </remarks>
+    [Theory]
+    [InlineData(0.8, "#FF101418", "#FFF1F3F7", "off-centre slider: the shade offset re-shifts the surfaces")]
+    [InlineData(0.5, "#FF202020", "#FF606060", "default slider: Legible still walks a text colour under 7:1")]
+    public void ACustomTheme_SurvivesAReloadUnchanged(
+        double shade, string background, string text, string channel)
+    {
+        var first = new ThemeService(_dir);
+        first.SetShade(shade);
+        // SetCustom saves immediately, which also persists the shade SetShade only debounced.
+        first.SetCustom(
+            (Color)ColorConverter.ConvertFromString("#FF6366F1")!,
+            (Color)ColorConverter.ConvertFromString(background)!,
+            (Color)ColorConverter.ConvertFromString("#FF181C22")!,
+            (Color)ColorConverter.ConvertFromString(text)!);
+
+        var generation1 = File.ReadAllText(ThemeFile);
+
+        var second = new ThemeService(_dir);
+        second.Initialize();
+        var generation2 = File.ReadAllText(ThemeFile);
+
+        var third = new ThemeService(_dir);
+        third.Initialize();
+        var generation3 = File.ReadAllText(ThemeFile);
+
+        Assert.Equal(generation1, generation2);
+        Assert.Equal(generation2, generation3);
+        Assert.Equal("custom", third.CurrentPresetId);
+        Assert.True(generation1.Contains(text, StringComparison.OrdinalIgnoreCase),
+            $"{channel}: the saved file should hold the colour the user typed ({text}), not a value derived "
+            + $"from it. It holds:\n{generation1}");
     }
 }

--- a/SysManager/SysManager.Tests/ThemeServiceTests.cs
+++ b/SysManager/SysManager.Tests/ThemeServiceTests.cs
@@ -3,8 +3,8 @@
 // License: MIT
 
 using System.IO;
-using System.Windows.Media;
 using System.Text.Json;
+using System.Windows.Media;
 using SysManager.Services;
 
 namespace SysManager.Tests;

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -546,9 +546,16 @@ public sealed class ThemeService
         {
             var dir = Path.GetDirectoryName(_settingsPath)!;
             Directory.CreateDirectory(dir);
+            // _baseTheme, NOT CurrentTheme. CurrentTheme is a pure function of (_baseTheme, ShadePosition)
+            // and must never become an input to itself. Persisting the derived theme made a custom one
+            // degrade a little on every launch: Load's custom branch feeds these four colours back in as the
+            // new base, so the shade offset re-applied to already-shifted surfaces, and Legible() re-walked
+            // an already-walked TextPrimary. At a non-default slider position the surfaces drifted until
+            // IsDarkBackground flipped; even at the default position the text marched, because Legible walks
+            // whenever it misses 7:1 and the walked value was what got saved.
             var data = new ThemeSettings(CurrentPresetId, CurrentMode, ShadePosition,
-                CurrentTheme.Accent.ToString(), CurrentTheme.Background.ToString(),
-                CurrentTheme.Surface.ToString(), CurrentTheme.TextPrimary.ToString());
+                _baseTheme.Accent.ToString(), _baseTheme.Background.ToString(),
+                _baseTheme.Surface.ToString(), _baseTheme.TextPrimary.ToString());
             var json = JsonSerializer.Serialize(data, JsonDefaults.Indented);
             AtomicFile.WriteAllText(_settingsPath, json);
         }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.6</Version>
-    <FileVersion>1.76.6.0</FileVersion>
-    <AssemblyVersion>1.76.6.0</AssemblyVersion>
+    <Version>1.76.7</Version>
+    <FileVersion>1.76.7.0</FileVersion>
+    <AssemblyVersion>1.76.7.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AudioMixerViewModel.cs
@@ -286,8 +286,16 @@ public sealed partial class AudioMixerViewModel : ViewModelBase
         // rather than letting ReplaceWith's null-guard throw into the fire-and-forget init.
         var devices = await Task.Run(_service.GetRenderDevices).ConfigureAwait(true);
 
-        var chosen = Sessions.ToDictionary(r => r.SessionId, r => r.SelectedOutputDevice?.Id ?? string.Empty,
-                                           StringComparer.Ordinal);
+        // string?, carrying all three states. Collapsing an unknown route to string.Empty here undid the fix
+        // that introduced the placeholder: empty means "read succeeded, no override", which
+        // SetOutputDeviceFromService resolves to the IsDefault entry and marks as KNOWN. Since this runs every
+        // tenth reconcile pass, every routable row silently went from "Choose a device" back to naming the
+        // default device about ten seconds after the tab was opened — the exact false claim the placeholder
+        // exists to avoid.
+        var chosen = Sessions.ToDictionary(
+            r => r.SessionId,
+            r => r.OutputRouteUnknown ? null : (r.SelectedOutputDevice?.Id ?? string.Empty),
+            StringComparer.Ordinal);
         OutputDevices.ReplaceWith(devices ?? []);
         // Gated on the row's own routing capability, matching the construction-time gate in MergeInto: the
         // system-sounds pseudo-session shows no picker, so it must not be handed a destination it cannot use.


### PR DESCRIPTION
Closes #2092. Two regressions an audit found in the last two releases — both mine, both incomplete migrations
of changes made in the same session.

## 1. A custom theme drifted on every restart

`Save` persisted `CurrentTheme`, which is the OUTPUT of `Shade(_baseTheme, ShadePosition)`. `Load`'s custom
branch hands those four colours back to `SetCustom` as the new `_baseTheme`, so each launch derived from an
already-derived theme. Before #2091 `SetCustom` assigned `CurrentTheme` directly, so the round trip was a fixed
point; routing it through `ApplyShade` made `CurrentTheme` derived and turned that fixed point into a ratchet.

Two independent channels, which is why the test is a Theory with two rows:
- off-centre slider — the `(position - 0.5) * 0.12` offset re-shifts already-shifted surfaces
- **default slider** — the offset is zero, but `Legible` still walks `TextPrimary` in 2% steps whenever it
  misses 7:1, and the walked value was what got saved

Fix: persist `_baseTheme`. `CurrentTheme` must never be an input to itself.

## 2. The audio picker re-claimed a device it never read

`RefreshDevicesAsync` snapshotted each row as `r.SelectedOutputDevice?.Id ?? string.Empty`. That predates the
three-state contract from #2087, where empty means "read succeeded, no override" and resolves to the `IsDefault`
entry as a **known** route. The refresh fires every tenth pass of the 1 Hz loop, so every routable row reverted
from "Choose a device" to naming the default device about ten seconds after the tab opened — undoing #2087 in
practice, on every machine, since the route read is still a stub returning null.

Fix: the snapshot carries `string?`, so an unknown row is re-applied as unknown.

## Red ritual

Each mutation restores the **exact pre-fix expression**, so the tests redden for the real defect:

| Mutation | Result |
|---|---|
| `Save` persists `CurrentTheme` again | **both** theory rows red — `Background "#FF181C20"` vs `"#FF202428"` between generations, and separately the saved file no longer holds the typed `#FF606060` |
| the snapshot collapses unknown to empty again | the audio test red: "the picker now names a device the app never read" |

Row [0] failing on a *surface* and row [1] on the *text* is the point — one channel each. Both files restored
byte-for-byte, 3 green after.

The theme test asserts the FILE, not a property, and compares generation 1 → 2 → 3: comparing only 2 with 3
would pass even if the first load had already shifted, and a drift that stops after one step is still a drift.
The audio test drives **twelve** passes, not ten, so it does not sit on the boundary the refresh fires at.

## Why the existing guards missed both

`AudioMixerViewModelTests` covered `SetOutputDeviceFromService` in isolation and never reached it through
`RefreshDevicesAsync`. And no test loaded a custom theme twice — the persistence tests each did one round trip,
which is exactly one step too few to see a ratchet.

## Regression sweep

- All four projects build, 0 warnings and 0 errors.
- Theme, contrast, dark-mode, chart and audio suites together: **268 green, 0 red**.
- `ArchitectureTests`: 88 green, plus the one known runner-only failure.
- Every touched file confirmed `w/crlf`.

## Still open from the same audit

Two pre-existing blockers in Quick Cleanup's temp sweep, going out separately because they share one fix: the
inline PowerShell has no extraction-root exclusion (both C# siblings pass
`SystemPaths.BundleExtractionRoot, SystemPaths.OwnExtractionDirectory`, and the guard that enforces it
hardcodes only those two filenames), and its "Freed approximately X MB" total counts files it failed to delete
because `+= $c.Length` runs before `Remove-Item -ErrorAction SilentlyContinue`.
