### PR TITLE
fix: route Quick Cleanup's temp sweep through the service that excludes the extraction root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.8] - 2026-09-03
+
+Quick Cleanup's "Clean TEMP" could delete files that other running programs were relying on, and the amount it
+reported freeing counted files it had not actually deleted. Both are fixed by having it use the same cleanup
+engine the rest of the app already uses.
+
+### Fixed
+- **Clean TEMP no longer touches the folder running programs unpack themselves into.** Modern single-file
+  Windows programs — including SysManager itself — unpack part of themselves into a folder inside Temp while
+  they run. Two of the app's three cleanup paths already left that folder alone; this one did not, so cleaning
+  temp files could break a program that was open at the time, or SysManager itself. It now shares the cleanup
+  engine the other two use, which skips that folder by design.
+- **"Freed X MB" now counts only what was actually deleted.** The old count added a file's size before trying
+  to delete it, so a file that was locked and skipped still counted toward the total — on the same screen whose
+  confirmation says files in use may be skipped. Skipped files are now reported separately, as a count.
+
 ## [1.76.7] - 2026-09-03
 
 Two things that went wrong in yesterday's last two updates. A theme you built yourself drifted a little every

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -5447,9 +5447,42 @@ public partial class ArchitectureTests
     [Fact]
     public void EveryTempTreeWalkerCall_PassesBothExtractionExclusions()
     {
-        var servicesDir = Path.Combine(FindAppProjectDir(), "Services");
+        var appDir = FindAppProjectDir();
+        var servicesDir = Path.Combine(appDir, "Services");
         string[] sweepers = ["TuneUpService.cs", "DeepCleanupService.cs"];
         var callsChecked = 0;
+
+        // A THIRD sweeper existed for a long time and this guard could not see it: CleanupViewModel swept
+        // %TEMP% with an inline PowerShell string, which is neither of the two filenames below and is not a
+        // C# call at all. It passed no exclusions of any kind. So before checking the known walkers, assert
+        // that nobody has grown a new temp sweep outside them — a directory walk over %TEMP% or
+        // %SystemRoot%\Temp anywhere in ViewModels/ or in a script string is out of bounds by construction,
+        // because the exclusions live behind the two services' walkers.
+        var strays = new List<string>();
+        foreach (var file in Directory.GetFiles(appDir, "*.cs", SearchOption.AllDirectories)
+                     .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                                             StringComparison.Ordinal)
+                                 && !sweepers.Contains(Path.GetFileName(f))))
+        {
+            var text = WithoutComments(File.ReadAllText(file));
+            var sweepsTemp = text.Contains("$env:TEMP", StringComparison.Ordinal)
+                             || text.Contains(@"$env:SystemRoot\Temp", StringComparison.Ordinal);
+            if (!sweepsTemp) continue;
+
+            // A sweep is a walk plus a delete. Reading or reporting a temp path is fine.
+            var deletes = text.Contains("Remove-Item", StringComparison.Ordinal)
+                          || text.Contains("Directory]::Delete", StringComparison.Ordinal)
+                          || text.Contains(".Delete()", StringComparison.Ordinal);
+            if (deletes) strays.Add(Path.GetFileName(file));
+        }
+
+        Assert.True(strays.Count == 0,
+            "these files walk and delete inside %TEMP% without going through TuneUpService or "
+            + "DeepCleanupService, so they cannot be passing SystemPaths.BundleExtractionRoot and "
+            + "SystemPaths.OwnExtractionDirectory — which means they can delete the .NET single-file "
+            + "extraction root of this app and of every other running single-file app. Route the work through "
+            + $"TuneUpService.CleanTempFilesAsync instead of writing a third sweeper:\n  "
+            + string.Join("\n  ", strays));
 
         foreach (var file in sweepers)
         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.7</Version>
-    <FileVersion>1.76.7.0</FileVersion>
-    <AssemblyVersion>1.76.7.0</AssemblyVersion>
+    <Version>1.76.8</Version>
+    <FileVersion>1.76.8.0</FileVersion>
+    <AssemblyVersion>1.76.8.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -219,42 +219,28 @@ public sealed partial class CleanupViewModel : ViewModelBase
         _tempCts = new CancellationTokenSource();
         try
         {
-            await _runner.RunScriptViaPwshAsync(@"
-                $paths = @($env:TEMP, ""$env:SystemRoot\Temp"")
-                $script:totalBytes = 0
-                $reparse = [IO.FileAttributes]::ReparsePoint
-                # Windows PowerShell 5.1's Get-ChildItem -Recurse FOLLOWS junctions and
-                # symbolic links, so a reparse point inside %TEMP% pointing elsewhere
-                # could let Remove-Item delete real user data outside the temp tree.
-                # Walk manually with an explicit stack and never descend into a reparse
-                # point; delete a reparse point itself WITHOUT -Recurse (removes the link,
-                # not its target).
-                function Clear-TempDir([string]$root) {
-                    $stack = New-Object System.Collections.Stack
-                    $stack.Push($root)
-                    while ($stack.Count -gt 0) {
-                        $cur = $stack.Pop()
-                        try { $children = Get-ChildItem -LiteralPath $cur -Force -ErrorAction SilentlyContinue } catch { continue }
-                        foreach ($c in $children) {
-                            $isReparse = ($c.Attributes -band $reparse) -eq $reparse
-                            if ($c.PSIsContainer) {
-                                if ($isReparse) {
-                                    try { [IO.Directory]::Delete($c.FullName, $false) } catch {}
-                                } else {
-                                    $stack.Push($c.FullName)
-                                }
-                            } else {
-                                try { $script:totalBytes += $c.Length } catch {}
-                                try { Remove-Item -LiteralPath $c.FullName -Force -ErrorAction SilentlyContinue } catch {}
-                            }
-                        }
-                    }
-                }
-                foreach ($p in $paths) {
-                    if (Test-Path $p) { Clear-TempDir $p }
-                }
-                ""Freed approximately $([Math]::Round($script:totalBytes/1MB,1)) MB""
-            ", cancellationToken: _tempCts.Token);
+            // Delegated to TuneUpService rather than kept as a third temp sweeper. The inline PowerShell this
+            // replaces walked %TEMP% with no exclusions at all, while both C# sweepers pass
+            // SystemPaths.BundleExtractionRoot and SystemPaths.OwnExtractionDirectory — so this command could
+            // delete the .NET single-file extraction root, its own and that of every other running single-file
+            // app, which is the failure SystemPaths documents (an app whose payload is extracted but not yet
+            // loaded cannot be detected as in use).
+            //
+            // It also fixes the reported total. The script did `$totalBytes += $c.Length` BEFORE
+            // `Remove-Item -ErrorAction SilentlyContinue`, and SilentlyContinue makes a locked file a
+            // non-terminating error, so the empty catch never fired and a file it failed to delete was still
+            // counted as freed — while the confirmation dialog above says "Files in use may be skipped".
+            // CleanTempFiles captures the size, deletes, and only then adds, counting failures separately.
+            Console.Append(PowerShellLine.Output("Cleaning user and Windows Temp folders..."));
+            var (bytesFreed, filesDeleted, errors) = await TuneUpService.CleanTempFilesAsync(_tempCts.Token);
+            Console.Append(PowerShellLine.Output(string.Create(CultureInfo.InvariantCulture,
+                $"Freed {bytesFreed / 1024.0 / 1024.0:F1} MB across {filesDeleted} file(s).")));
+            if (errors > 0)
+            {
+                Console.Append(PowerShellLine.Output(string.Create(CultureInfo.InvariantCulture,
+                    $"{errors} file(s) were in use or protected and were skipped.")));
+            }
+
             StatusMessage = "Temp cleanup done";
             Log.Information("Temp cleanup completed");
             ActivityLogService.Instance.Log("Quick Cleanup", "Cleared temporary files");


### PR DESCRIPTION
Closes #2094. Two pre-existing defects in one inline script, both removed by deleting the script.

## The destructive one

`CleanupViewModel.CleanTempAsync` was a **third** temp sweeper. Both C# sweepers pass
`SystemPaths.BundleExtractionRoot, SystemPaths.OwnExtractionDirectory` (`TuneUpService.cs:188`,
`DeepCleanupService.cs:206/363/385`). The PowerShell passed nothing.

`SystemPaths.cs:193-206` spells out the consequence: `BundleExtractionRoot` resolves to `<temp>\.net`, a **direct
child** of the swept root, so a walk over `$env:TEMP` descends straight into it. Every single-file .NET app
unpacks under that root, so this could delete not just SysManager's own payload but that of **any other
single-file app running at the time** — including the case no in-use check can catch, a payload extracted but not
yet loaded.

## The dishonest one

```powershell
try { $script:totalBytes += $c.Length } catch {}
try { Remove-Item -LiteralPath $c.FullName -Force -ErrorAction SilentlyContinue } catch {}
```

`+= $c.Length` runs **before** the delete, and `SilentlyContinue` makes a locked file a non-terminating error, so
the `catch {}` never fires and the bytes stay counted. "Freed approximately X MB" therefore included space it did
not free — on the same command whose confirmation dialog says "Files in use may be skipped".

## One fix for both

Delegated to `TuneUpService.CleanTempFilesAsync`, which is already `public static`, already sweeps the same two
paths, already skips reparse points, already passes both exclusions, and already returns
`(BytesFreed, FilesDeleted, Errors)`. `TuneUpService.cs:193-200` gets the order right: capture the size,
`Delete()`, then `freed += size`, with `catch (IOException) { errors++; }`.

The console now reports the real figure plus a separate skipped count, rather than folding failures into the
total. Net effect on the diff: 58 lines of PowerShell replaced by the call and its reporting.

## Why the guard was green the whole time

`EveryTempTreeWalkerCall_PassesBothExtractionExclusions` hardcoded
`string[] sweepers = ["TuneUpService.cs", "DeepCleanupService.cs"]` — it never read a ViewModel and never read a
script string, so a third sweeper in a third shape was invisible to it. That is the more important half of this
PR: the rule existed and could not see the violation.

It now also asserts that **no file outside those two both references `%TEMP%`/`%SystemRoot%\Temp` and deletes**.
A sweep is a walk plus a delete, so reading or reporting a temp path stays allowed.

Proven both ways:

| Mutation | Result |
|---|---|
| a PowerShell temp sweep put back into the ViewModel | red, naming `CleanupViewModel.cs` |
| a known walker call drops its exclusions | red, `SystemPaths.BundleExtractionRoot` not found in `"dir, ct"` |

Both files restored byte-for-byte, green after. The second case matters because widening a guard is a chance to
break its original half.

## Regression sweep

- All four projects build, 0 warnings and 0 errors; `dotnet format --verify-no-changes` clean on both projects
  (a formatting slip cost the previous PR a CI run).
- `ArchitectureTests`: 88 green, plus the one known runner-only failure.

## Not verifiable here

The command deletes real files, so its behaviour cannot be exercised without deleting real files. What this PR
rests on is that the code path is now the same one `TuneUpService` has always used and that its exclusion
arguments are asserted by a guard which now covers this file too — not on a live run.
