### PR TITLE
fix: report an unreadable disk as unread rather than degrading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.11] - 2026-09-04
+
+If Windows cannot report your drive's health — common on desktop SATA and NVMe drives, and always the case in
+a virtual machine — the Landing tab said "Disk health degrading" and showed a warning. Nothing was degrading.
+It now says the health could not be read, which is what actually happened.
+
+### Fixed
+- **A drive whose health cannot be read is no longer reported as degrading.** SysManager scores an unmeasured
+  drive cautiously on purpose, so it can never be called healthy without evidence. But that cautious score was
+  then read as a verdict, and the warning band starts just below it — so a machine that reported no drive
+  health at all was told its disk was on the way out. The tab now distinguishes "could not read this" from "we
+  read it and it looks worse than it should", and only the second one warns. A machine with one readable drive
+  and one unreadable one still reports the readable drive's verdict, so a genuinely failing disk is never
+  hidden behind a "could not read" message.
+
 ## [1.76.10] - 2026-09-04
 
 The "can be freed" and "in Recycle Bin" figures on the Cleanup tab could stop counting partway through a

--- a/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
+++ b/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
@@ -298,6 +298,56 @@ public class HealthScoreServiceTests
 
         Assert.Equal(80, HealthScoreService.ComputeDiskScore(disks));
     }
+
+    // ---------- UnavailableComponents ----------
+
+    [Fact]
+    public void UnavailableComponents_DrivesPresentButNoneReadable_MarksTheDiskUnavailable()
+    {
+        // The score alone cannot carry this. Two drives with no SMART data score the deliberate unknown 80,
+        // and ClassifySmartHealth reads 80 with unavailable=false through its `>= 60` branch as "Disk health
+        // degrading" — a claim about failing hardware on a machine where nothing was measured. The test
+        // directly below UnknownComponentScore_StaysBelowEveryGreenBranch asserts that intent in prose
+        // ("must not read as degrading either — nothing was measured") while this path delivered exactly that.
+        var disks = new List<DiskHealthReport>
+        {
+            new() { FriendlyName = "Samsung SSD", HealthStatus = "" },
+            new() { FriendlyName = "WDC HDD", HealthStatus = "" }
+        };
+        Assert.All(disks, d => Assert.Null(d.HealthPercent));   // the premise, not an assumption
+
+        var unavailable = HealthScoreService.UnavailableComponents(disks, null);
+
+        Assert.Contains(HealthScoreService.DiskComponent, unavailable);
+    }
+
+    [Fact]
+    public void UnavailableComponents_OneReadableDriveAmongUnreadable_KeepsTheDiskAvailable()
+    {
+        // The negative half, and the reason the rule is All rather than Any: marking the component
+        // unavailable here would replace "Disk health critical" with "could not be read" and hide a drive
+        // Windows has already flagged as failing.
+        var disks = new List<DiskHealthReport>
+        {
+            new() { FriendlyName = "Failing drive", HealthStatus = "Unhealthy" },
+            new() { FriendlyName = "Unreadable drive", HealthStatus = "" }
+        };
+
+        var unavailable = HealthScoreService.UnavailableComponents(disks, null);
+
+        Assert.DoesNotContain(HealthScoreService.DiskComponent, unavailable);
+        Assert.Equal(20, HealthScoreService.ComputeDiskScore(disks));   // and the failing verdict survives
+    }
+
+    [Fact]
+    public void UnavailableComponents_NoDrivesAtAll_StillMarksTheDiskUnavailable()
+    {
+        Assert.Contains(HealthScoreService.DiskComponent,
+            HealthScoreService.UnavailableComponents([], null));
+        Assert.Contains(HealthScoreService.DiskComponent,
+            HealthScoreService.UnavailableComponents(null, null));
+    }
+
     [Fact]
     public void UnknownComponentScore_StaysBelowEveryGreenBranch()
     {

--- a/SysManager/SysManager/Services/HealthScoreService.cs
+++ b/SysManager/SysManager/Services/HealthScoreService.cs
@@ -93,13 +93,7 @@ public sealed class HealthScoreService
         // Recorded so a consumer can say "could not read this" instead of reading a verdict out of a
         // fallback number. The scores above already refuse to claim health; this is what makes the reason
         // visible.
-        List<string> unavailable = [];
-        if (disks is null || disks.Count == 0) unavailable.Add(DiskComponent);
-        if (snapshot is null)
-        {
-            unavailable.Add(MemoryComponent);
-            unavailable.Add(UptimeComponent);
-        }
+        var unavailable = UnavailableComponents(disks, snapshot);
 
         return new HealthScoreResult
         {
@@ -112,6 +106,40 @@ public sealed class HealthScoreService
             Recommendations = recommendations,
             UnavailableComponents = unavailable
         };
+    }
+
+    /// <summary>
+    /// Which components produced no usable evidence, so a consumer can say "could not read this" instead of
+    /// reading a verdict out of a fallback number. The scores already refuse to claim health; this is what
+    /// makes the reason visible.
+    /// </summary>
+    /// <remarks>
+    /// Pure and internal for the same reason <see cref="ComputeDiskScore"/> is: the decision is worth
+    /// asserting, and asserting it through <see cref="ComputeAsync"/> would mean querying WMI.
+    /// <para>Drives present but none readable is the same absence of evidence as no drives at all, and it is
+    /// the common case — plenty of consumer SATA and NVMe disks expose nothing through
+    /// <c>MSFT_StorageReliabilityCounter</c>, and a VM exposes nothing whatever. Testing only for an empty
+    /// list left that machine scored at the deliberate unknown 80, which
+    /// <c>DashboardViewModel.ClassifySmartHealth</c> then reads through its <c>&gt;= 60</c> branch as "Disk
+    /// health degrading" — the outcome that method's own remarks rule out, because nothing is degrading when
+    /// nothing was measured.</para>
+    /// <para>Deliberately <c>All</c>, not <c>Any</c>. With one readable drive at 30% and one unreadable,
+    /// <c>Any</c> would mark the component unavailable and replace a critical-disk warning with "could not be
+    /// read", hiding a failing drive. A mixed read keeps the worst measured verdict. <c>All</c> also covers
+    /// the empty list, which is why that case is no longer spelled out.</para>
+    /// </remarks>
+    internal static List<string> UnavailableComponents(
+        IReadOnlyList<DiskHealthReport>? disks, SystemSnapshot? snapshot)
+    {
+        List<string> unavailable = [];
+        if (disks is null || disks.All(d => d.HealthPercent is null)) unavailable.Add(DiskComponent);
+        if (snapshot is null)
+        {
+            unavailable.Add(MemoryComponent);
+            unavailable.Add(UptimeComponent);
+        }
+
+        return unavailable;
     }
 
     /// <summary>Component names used in <see cref="HealthScoreResult.UnavailableComponents"/>.</summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.10</Version>
-    <FileVersion>1.76.10.0</FileVersion>
-    <AssemblyVersion>1.76.10.0</AssemblyVersion>
+    <Version>1.76.11</Version>
+    <FileVersion>1.76.11.0</FileVersion>
+    <AssemblyVersion>1.76.11.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #2099.

## What was wrong

`HealthScoreService` marked the disk component unavailable only when the list was empty:

```csharp
if (disks is null || disks.Count == 0) unavailable.Add(DiskComponent);
```

A drive with no SMART data still produces a `DiskHealthReport` — `HealthPercent` is documented to return null in that case — so the list is non-empty, the component is not marked unavailable, `ComputeDiskScore` returns the deliberate unknown 80, and `ClassifySmartHealth(80, unavailable: false)` lands in the `>= 60` branch: **"Disk health degrading — check System Health"**, yellow.

The codebase already ruled that outcome out in two places:

- `DashboardViewModel.ClassifySmartHealth`'s remarks: *"Scoring it as unknown instead would put it in the 'degrading' branch, which is a different wrong answer: nothing is degrading, nothing was measured."*
- `UnknownComponentScore_StaysBelowEveryGreenBranch` asserts `>= 60` with the comment *"and must not read as degrading either — nothing was measured"* — an intent this path did not deliver.

Not rare: consumer SATA and NVMe drives frequently expose nothing through `MSFT_StorageReliabilityCounter`, and a VM exposes nothing at all.

## The fix

`disks.All(d => d.HealthPercent is null)` — drives present but none readable is the same absence of evidence as no drives at all.

The decision moved into a pure `internal static UnavailableComponents(disks, snapshot)`, for the same reason `ComputeDiskScore` is one: it is worth asserting, and asserting it through `ComputeAsync` would mean querying WMI.

**`All`, not `Any`, deliberately.** With one drive readable at 20% and one unreadable, `Any` would mark the component unavailable and replace "Disk health critical" with "could not be read" — hiding a drive Windows has already flagged as failing. A mixed read keeps the worst measured verdict.

## Verification

Two mutations, restored byte-for-byte and re-hashed:

| Mutation | Result |
|---|---|
| back to `disks.Count == 0` | **RED** on the new all-unreadable test — `Collection: ["Memory", "Uptime"] / Not found: "Disk"` |
| `All` → `Any` | **RED** on the mixed-read test (`Collection: ["Disk", …] / Found: "Disk"`) **and** on the empty-list test |

That second row corrected my own prediction and is worth recording: `[].All(…)` is vacuously **true** while `[].Any(…)` is vacuously **false**, so `All` covers the no-drives case for free and `Any` would have silently broken it. Both reasons point the same way.

Baseline and post-restore: 4 green, 0 red. Regression sweep: 230 named tests across `HealthScoreServiceTests`, `DashboardViewModelTests`, `DiskHealthReport*`, `SystemHealthViewModelTests` and `ArchitectureTests` — 350 cases green, plus the harness-only author-header case for the throwaway runner. Builds 0 errors / 0 warnings, `dotnet format --verify-no-changes` clean on both projects, version consistency csproj 1.76.11 = CHANGELOG 1.76.11 = SECURITY 1.76.x.

## Docs

No README change: the tab's behaviour is described in terms of what it reports, and the README does not name the degrading wording. CHANGELOG entry included.
