### PR TITLE
fix: stop holding the snapshot lock across a WMI call, and stop rebuilding pruned lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.12] - 2026-09-04
+
+Two pieces of background work the app was doing for no reason. Nothing looks different; the app just asks
+Windows fewer questions and does less writing while you use it.
+
+### Fixed
+- **Reading the system's vitals no longer makes other parts of the app wait.** The Landing tab reads CPU and
+  memory three times a second. That read held a lock for the whole trip out to Windows and back, so anything
+  else asking for the same information at that moment queued behind it, even though it had no interest in the
+  part being locked. The lock now covers only the details that are read once per session.
+- **Trimming the history files no longer rebuilds every line it keeps.** Both the resource-usage and bandwidth
+  histories drop entries older than the retention window. Doing so rebuilt every surviving line from scratch,
+  and the result was thrown away whenever nothing needed dropping — which is almost every time, since a trim
+  only has work to do once entries age out. Surviving lines are now kept exactly as they were read.
+
 ## [1.76.11] - 2026-09-04
 
 If Windows cannot report your drive's health — common on desktop SATA and NVMe drives, and always the case in

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4333,6 +4333,28 @@ public partial class ArchitectureTests
     private static partial Regex BlockComment();
 
     /// <summary>
+    /// The body of the block that <paramref name="opener"/> introduces, delimited by counting braces, or ""
+    /// when the opener is absent. Unlike <see cref="MemberSlice"/> this cannot run past its block, so a
+    /// caller asserting "X does not appear in here" cannot be fooled by X appearing further down the file.
+    /// </summary>
+    private static string BalancedBlock(string source, string opener)
+    {
+        var at = source.IndexOf(opener, StringComparison.Ordinal);
+        if (at < 0) return "";
+        var open = source.IndexOf('{', at + opener.Length);
+        if (open < 0) return "";
+
+        var depth = 0;
+        for (var i = open; i < source.Length; i++)
+        {
+            if (source[i] == '{') depth++;
+            else if (source[i] == '}' && --depth == 0) return source[(open + 1)..i];
+        }
+
+        return "";   // unbalanced: report nothing rather than the rest of the file
+    }
+
+    /// <summary>
     /// A member's text from its declaration up to the next member at the same indentation — enough to
     /// assert what one method does without matching an identical call elsewhere in the file.
     /// </summary>
@@ -5428,6 +5450,47 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"NativeMethods\.NtQueryTimerResolution\(\s*out uint (?<p1>\w+),\s*out uint (?<p2>\w+),\s*out uint (?<p3>\w+)\s*\)")]
     private static partial Regex TimerQueryCall();
 
+
+    /// <summary>
+    /// The snapshot cache lock may hold only the one-time cached queries, never a per-poll one.
+    /// </summary>
+    /// <remarks>
+    /// <c>SystemInfoService.Capture</c> takes <c>_cacheLock</c> to serialise four <c>??=</c> caches, each of
+    /// which runs its WMI query once per process. <c>QueryCpuLoad</c> ran inside that block too, so every
+    /// concurrent <c>CaptureAsync</c> queued behind a WMI round-trip it had no interest in — and the Dashboard
+    /// polls this at 300 ms, so the queue was rarely empty.
+    /// <para>The rule is expressed as a shape rather than as two method names: inside the block, a
+    /// <c>Query…</c> call must sit on a line that also caches its result with <c>??=</c>. That catches a
+    /// third dynamic query added later, which a name list could not.</para>
+    /// </remarks>
+    [Fact]
+    public void TheSnapshotCacheLock_HoldsOnlyCachedQueries()
+    {
+        var source = WithoutComments(File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "Services", "SystemInfoService.cs")));
+        var block = BalancedBlock(source, "lock (_cacheLock)");
+
+        // Vacuity floor. An empty or mis-sliced block would satisfy every assertion below without reading
+        // the code, and the four caches are what identify this block as the right one.
+        var cached = block.Split('\n').Count(l => l.Contains("??=", StringComparison.Ordinal));
+        Assert.True(cached >= 4,
+            $"only {cached} cached queries were found inside lock (_cacheLock) (block length "
+            + $"{block.Length}) — the slice is not the cache block, so this guard proves nothing.");
+
+        var offenders = block.Split('\n')
+            .Where(l => QueryCallInLock().IsMatch(l) && !l.Contains("??=", StringComparison.Ordinal))
+            .Select(l => l.Trim())
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "these queries run while holding _cacheLock, so every other CaptureAsync caller waits for them. "
+            + "The lock exists for the ??= caches; a per-poll query belongs after the block, beside "
+            + "QueryDynamicOs:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>A call to one of the service's own Query* methods.</summary>
+    [GeneratedRegex(@"\bQuery[A-Z]\w*\(")]
+    private static partial Regex QueryCallInLock();
 
     /// <summary>
     /// Every call into a temp-tree walker must pass the own-extraction exclusion.

--- a/SysManager/SysManager.Tests/BandwidthHistoryTests.cs
+++ b/SysManager/SysManager.Tests/BandwidthHistoryTests.cs
@@ -60,6 +60,30 @@ public class BandwidthHistoryTests
     }
 
     [Fact]
+    public void Prune_HandsBackTheLinesItRead_WithoutReserialisingThem()
+    {
+        // The sibling of the same assertion in ResourceHistoryServiceTests. Both services carried the same
+        // Prune shape, so both were rebuilding every kept line through Serialize for a result PruneAsync
+        // discards whenever nothing was dropped. Pinned in both places rather than in whichever one was
+        // touched first.
+        //
+        // The variant line is the canonical one with a leading space: JSON ignores it, Serialize never writes
+        // it. Derived from the serialiser so it cannot drift from the model's naming policy.
+        var now = new DateTime(2026, 7, 22, 12, 0, 0);
+        var spaced = " " + BandwidthHistoryService.Serialize(S(now.AddHours(-1), 2, 2));
+        Assert.True(BandwidthHistoryService.TryParse(spaced, out var parsed), "the fixture must parse");
+        Assert.NotEqual(spaced, BandwidthHistoryService.Serialize(parsed!));   // the premise of this test
+
+        var lines = new[]
+        {
+            BandwidthHistoryService.Serialize(S(now.AddDays(-10), 1, 1)),   // expired, forces the drop path
+            spaced,
+        };
+
+        Assert.Equal([spaced], BandwidthHistoryService.Prune(lines, now, TimeSpan.FromDays(7)));
+    }
+
+    [Fact]
     public void Downsample_AtOrBelowCap_ReturnsUnchanged()
     {
         var now = new DateTime(2026, 7, 22, 12, 0, 0);

--- a/SysManager/SysManager.Tests/ResourceHistoryServiceTests.cs
+++ b/SysManager/SysManager.Tests/ResourceHistoryServiceTests.cs
@@ -88,6 +88,35 @@ public class ResourceHistoryServiceTests
     public void Prune_EmptyInput_ReturnsEmpty()
         => Assert.Empty(ResourceHistoryService.Prune([], DateTime.Now, TimeSpan.FromDays(7)));
 
+    [Fact]
+    public void Prune_HandsBackTheLinesItRead_WithoutReserialisingThem()
+    {
+        // Prune used to rebuild every kept line through Serialize, and PruneAsync then threw the whole result
+        // away whenever nothing had been dropped — which is almost every call, since a prune only has work to
+        // do once samples pass the retention window. The kept lines are now the exact text that was read.
+        //
+        // Asserted with a line that parses to the right sample but is NOT byte-identical to what Serialize
+        // emits, because comparing against Serialize's own output would pass either way — Serialize is
+        // TryParse's inverse. The variant is the canonical line with one leading space: JSON ignores it,
+        // Serialize never writes it. Derived from the serialiser rather than typed, so it cannot drift from
+        // the model's naming policy.
+        var now = new DateTime(2026, 6, 29, 12, 0, 0);
+        var spaced = " " + ResourceHistoryService.Serialize(Sample(now.AddHours(-1)));
+        Assert.True(ResourceHistoryService.TryParse(spaced, out var parsed), "the fixture must parse");
+        Assert.Equal(now.AddHours(-1), parsed!.Timestamp);
+        Assert.NotEqual(spaced, ResourceHistoryService.Serialize(parsed));   // the premise of this test
+
+        var lines = new[]
+        {
+            ResourceHistoryService.Serialize(Sample(now.AddDays(-10))),   // expired, forces the drop path
+            spaced,
+        };
+
+        var kept = ResourceHistoryService.Prune(lines, now, TimeSpan.FromDays(7));
+
+        Assert.Equal([spaced], kept);
+    }
+
     // ── Downsample ────────────────────────────────────────────────────────
 
     [Fact]

--- a/SysManager/SysManager/Services/BandwidthHistoryService.cs
+++ b/SysManager/SysManager/Services/BandwidthHistoryService.cs
@@ -131,12 +131,17 @@ public sealed class BandwidthHistoryService
     public static List<string> Prune(IEnumerable<string> lines, DateTime now, TimeSpan retention)
     {
         var cutoff = now - retention;
-        var kept = new List<BandwidthSample>();
+
+        // Timestamp paired with the ORIGINAL line, not with the parsed sample. Sorting pairs keeps the
+        // oldest-first contract while handing back the exact text that was read, so a prune no longer
+        // re-serialises every line it keeps -- work the caller discards outright whenever nothing was
+        // dropped, which is almost every call.
+        var kept = new List<(DateTime Stamp, string Line)>();
         foreach (var line in lines)
             if (TryParse(line, out var s) && s!.Timestamp >= cutoff)
-                kept.Add(s);
-        kept.Sort((a, b) => a.Timestamp.CompareTo(b.Timestamp));
-        return kept.Select(Serialize).ToList();
+                kept.Add((s!.Timestamp, line));
+        kept.Sort((a, b) => a.Stamp.CompareTo(b.Stamp));
+        return kept.ConvertAll(k => k.Line);
     }
 
     /// <summary>

--- a/SysManager/SysManager/Services/ResourceHistoryService.cs
+++ b/SysManager/SysManager/Services/ResourceHistoryService.cs
@@ -285,12 +285,17 @@ public sealed class ResourceHistoryService : IDisposable
     public static List<string> Prune(IEnumerable<string> lines, DateTime now, TimeSpan retention)
     {
         var cutoff = now - retention;
-        var kept = new List<ResourceSample>();
+
+        // Timestamp paired with the ORIGINAL line, not with the parsed sample. Sorting pairs keeps the
+        // oldest-first contract while handing back the exact text that was read, so a prune no longer
+        // re-serialises every line it keeps -- work the caller discards outright whenever nothing was
+        // dropped, which is almost every call.
+        var kept = new List<(DateTime Stamp, string Line)>();
         foreach (var line in lines)
             if (TryParse(line, out var s) && s!.Timestamp >= cutoff)
-                kept.Add(s);
-        kept.Sort((a, b) => a.Timestamp.CompareTo(b.Timestamp));
-        return kept.Select(Serialize).ToList();
+                kept.Add((s!.Timestamp, line));
+        kept.Sort((a, b) => a.Stamp.CompareTo(b.Stamp));
+        return kept.ConvertAll(k => k.Line);
     }
 
     /// <summary>

--- a/SysManager/SysManager/Services/SystemInfoService.cs
+++ b/SysManager/SysManager/Services/SystemInfoService.cs
@@ -27,7 +27,7 @@ public sealed class SystemInfoService
     private SystemSnapshot Capture()
     {
         OsInfo osStatic;
-        CpuInfo cpu;
+        CpuInfo cpuStatic;
         List<DiskInfo> disks;
         IReadOnlyList<MemoryModule> modules;
 
@@ -45,7 +45,7 @@ public sealed class SystemInfoService
 
             // CPU name/cores/threads/clock are static; only LoadPercentage is dynamic.
             _cachedCpuStatic ??= QueryCpuStatic();
-            cpu = (_cachedCpuStatic ?? new CpuInfo("Unknown", 0, 0, 0, 0)) with { LoadPercent = QueryCpuLoad() };
+            cpuStatic = _cachedCpuStatic ?? new CpuInfo("Unknown", 0, 0, 0, 0);
 
             // Disk info is static (models don't change at runtime).
             _cachedDisks ??= QueryDisks();
@@ -57,6 +57,11 @@ public sealed class SystemInfoService
             _cachedModules ??= QueryMemoryModules();
             modules = _cachedModules ?? [];
         }
+
+        // Outside the lock, with QueryDynamicOs below. The lock exists to serialise the ??= caches, and a
+        // dynamic query needs none of it — while it was inside, every concurrent CaptureAsync waited on a WMI
+        // round-trip it had no interest in. The Dashboard polls this at 300 ms, so the wait was frequent.
+        var cpu = cpuStatic with { LoadPercent = QueryCpuLoad() };
 
         // One Win32_OperatingSystem query for BOTH the dynamic uptime and memory totals —
         // previously two separate round-trips (QueryUptime + QueryMemory) to the same class.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.11</Version>
-    <FileVersion>1.76.11.0</FileVersion>
-    <AssemblyVersion>1.76.11.0</AssemblyVersion>
+    <Version>1.76.12</Version>
+    <FileVersion>1.76.12.0</FileVersion>
+    <AssemblyVersion>1.76.12.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Part of #2104 — the two contained items. The two that need new P/Invoke (replacing the 300 ms WMI round-trips with `GetSystemTimes` / `GlobalMemoryStatusEx`, and resolving process window handles once per refresh instead of twice per process) stay open on that issue.

## 1. A WMI round-trip no longer runs while holding the snapshot cache lock

`SystemInfoService.Capture()` takes `_cacheLock` to serialise four `??=` caches, each of which queries WMI once per process. `QueryCpuLoad()` — a per-poll query — was called inside that block, so every concurrent `CaptureAsync` queued behind a round-trip it had no interest in. The Dashboard polls this at 300 ms, so the queue was rarely empty. It now sits after the block, beside `QueryDynamicOs`, which was already outside for the same reason.

Guarded by `TheSnapshotCacheLock_HoldsOnlyCachedQueries`, and the rule is a shape rather than a name list: inside the block, a `Query…` call must sit on a line that also caches its result with `??=`. A third dynamic query added later is caught; a name list could not have been.

The guard slices the block by counting braces (new `BalancedBlock` helper) rather than reusing `MemberSlice`, which runs to the end of the file when it cannot find the next member — a "does not appear in here" assertion cannot be built on a slice that might be the whole file.

## 2. A prune no longer rebuilds every line it keeps

`Prune` parsed each line, then re-serialised **every kept sample**, and `PruneAsync` discards the whole result when nothing was dropped:

```csharp
var kept = Prune(lines, DateTime.Now, TimeSpan.FromDays(_retentionDays));
if (kept.Count == lines.Length) return;
```

So the common case — nothing aged out yet — paid a full parse *and* a full re-serialise for no output. Both history services had the identical shape; both are fixed, so this is the class rather than the instance.

The sort is preserved exactly: pairs of `(timestamp, original line)` are sorted, and the original text is handed back. Same count, same order, and the kept lines are byte-identical to what was read instead of normalised through `Serialize`.

## Verification

Mutation proof, both files restored byte-for-byte and re-hashed:

| Mutation | Result |
|---|---|
| `QueryCpuLoad` moves back inside `lock (_cacheLock)` | **RED** on `TheSnapshotCacheLock_HoldsOnlyCachedQueries`, and only that test |
| `Prune` re-serialises its kept lines | **RED** on `Prune_HandsBackTheLinesItRead_WithoutReserialisingThem`, and only that test |

Baseline and post-restore 4 green, 0 red.

The new behaviour test is worth a note on how it is built: it asserts against a line that parses to the right sample but is **not** what `Serialize` emits, since comparing to `Serialize`'s own output would pass either way. The variant is the canonical line with one leading space, derived from the serialiser rather than typed — the first attempt used hand-written JSON and went red, because the model serialises to short keys (`"t"`, `"c"`, `"r"`) rather than property names.

Regression sweep: 192 named tests across `ArchitectureTests`, both history suites, `SystemInfo*`, `DashboardViewModelTests` and `BandwidthMonitorViewModelTests` — 294 cases green. The three reds in that run are two non-test helpers my name-extraction grep picked up (`Dispose`, `ReleaseSample`) and the harness-only author-header case for the throwaway runner.

Builds 0 errors / 0 warnings (app + tests), `dotnet format --verify-no-changes` clean on both, version consistency csproj 1.76.12 = CHANGELOG 1.76.12 = SECURITY 1.76.x.

**Not measured here.** This is a contention and allocation fix reasoned from the call shape, not a benchmark. #2104 asks for the perf budget to be checked properly — idle CPU% with the Landing tab open, and the wall-clock of one Process Manager refresh on a machine with 300+ processes — and that belongs with the syscall work, on a machine that runs the app.
