### PR TITLE
fix: show the sidebar progress bar on the five slowest tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.13] - 2026-09-04
+
+Five of the slowest screens never showed the thin progress line under their name in the left-hand list, so if
+you started something and switched away, nothing told you it was still going. Speed Test, Traceroute, Network
+Repair, DNS &amp; Hosts and the update download in About now show it like every other screen.
+
+### Fixed
+- **The progress line appears on the five screens that were missing it.** Each of them already kept track of
+  whether it was working — it just never passed that on to the window frame, which is what draws the line. So
+  the tabs where you are most likely to walk away mid-job were the ones that looked idle: a speed test takes
+  up to a minute, a traceroute walks up to thirty hops, a network repair runs three resets in a row, and the
+  update download in About is around 85&#160;MB. A check now fails the build if a screen tracks its own
+  working state without passing it on, so the next one cannot be added without it.
+
 ## [1.76.12] - 2026-09-04
 
 Two pieces of background work the app was doing for no reason. Nothing looks different; the app just asks

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -5452,6 +5452,70 @@ public partial class ArchitectureTests
 
 
     /// <summary>
+    /// A view-model that tracks its own "running" state must forward it to <c>IsBusy</c>.
+    /// </summary>
+    /// <remarks>
+    /// <c>NavItem</c> forwards <c>ViewModelBase.IsBusy</c> to the slim progress bar under the tab's name in
+    /// the sidebar — the only indication, while the user is looking at another tab, that this one is working.
+    /// A view-model that keeps a private running flag and never assigns <c>IsBusy</c> gets no bar at all.
+    /// <para>Five tabs were in that state, and they were the slowest ones in the app: Speed Test (a full
+    /// up/down test), Traceroute (up to thirty hops), Network Repair (three netsh resets), About (an ~85&#160;MB
+    /// update download) and DNS &amp; Hosts. README promised the bar for "any long-running operation", so the
+    /// documentation was describing four view-models' behaviour as if it were all of them.</para>
+    /// <para>The flag is the single source of truth: the fix is a generated <c>On…Changed</c> hook assigning
+    /// <c>IsBusy</c>, never a second flag set alongside the first. Whether the assignment goes through the hook
+    /// or happens inline in the command is left open — several tabs predate the hook idiom and set it directly,
+    /// which is equally correct.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryViewModelThatTracksRunningState_ForwardsItToIsBusy()
+    {
+        // Not a tab: a row inside the Volume Control list, with no sidebar entry to draw a bar under. Its
+        // flag means "the user is dragging this slider", which is not background work.
+        var notTabs = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["AudioSessionRowViewModel.cs"] = "a row inside Volume Control, not a tab; IsUserAdjusting is a "
+                                              + "drag gesture rather than work in progress",
+        };
+
+        var vmDir = Path.Combine(FindAppProjectDir(), "ViewModels");
+        var withFlags = 0;
+        var missing = new List<string>();
+
+        foreach (var file in Directory.GetFiles(vmDir, "*ViewModel.cs"))
+        {
+            var name = Path.GetFileName(file);
+            var code = WithoutComments(File.ReadAllText(file));
+            var flags = RunningStateFlag().Matches(code).Select(m => m.Groups["flag"].Value).ToList();
+            if (flags.Count == 0) continue;
+
+            withFlags++;
+            if (notTabs.ContainsKey(name)) continue;
+            if (code.Contains("IsBusy =", StringComparison.Ordinal)) continue;
+
+            missing.Add($"{name} tracks {string.Join(", ", flags)} but never assigns IsBusy");
+        }
+
+        // Vacuity floor: fourteen view-models carry such a flag today. A collapse means the pattern stopped
+        // matching the declaration shape, and this guard would pass having read nothing.
+        Assert.True(withFlags >= 12,
+            $"only {withFlags} view-models with a running-state flag were found — the declaration pattern no "
+            + "longer matches, so this guard proves nothing. Re-derive it before trusting a pass.");
+
+        Assert.True(missing.Count == 0,
+            "these view-models track whether they are working and never tell the shell, so their tab shows no "
+            + "progress bar while the user is on another tab. Forward the existing flag — "
+            + "`partial void OnIsXChanged(bool value) => IsBusy = value;` — rather than adding a second flag. "
+            + "If the type is not a tab, add it to the exclusion list in this test WITH its reason:\n  "
+            + string.Join("\n  ", missing));
+    }
+
+    /// <summary>An observable bool whose name says work is in progress.</summary>
+    [GeneratedRegex(@"\[ObservableProperty\][^;]{0,200}?private bool _(?<flag>is\w+(?:ing|Running|Loading));",
+                    RegexOptions.Singleline)]
+    private static partial Regex RunningStateFlag();
+
+    /// <summary>
     /// The snapshot cache lock may hold only the one-time cached queries, never a per-poll one.
     /// </summary>
     /// <remarks>

--- a/SysManager/SysManager.Tests/NetworkRepairViewModelTests.cs
+++ b/SysManager/SysManager.Tests/NetworkRepairViewModelTests.cs
@@ -35,6 +35,26 @@ public class NetworkRepairViewModelTests
     }
 
     [Fact]
+    public void Repairing_DrivesIsBusy_SoTheSidebarShowsProgress()
+    {
+        // NavItem forwards ViewModelBase.IsBusy to the slim progress bar under the tab's name, which is the
+        // only sign — while the user is looking at another tab — that this one is working. Five tabs kept a
+        // running flag and never assigned IsBusy, so their bar never appeared; this asserts the generated
+        // On…Changed hook actually fires, which the source-shape guard in ArchitectureTests cannot.
+        //
+        // One behaviour test for the mechanism rather than five identical ones: the other four are the same
+        // one-line shape, and EveryViewModelThatTracksRunningState_ForwardsItToIsBusy is what keeps them there.
+        var vm = new NetworkRepairViewModel(NewShared());
+        Assert.False(vm.IsBusy);
+
+        vm.IsRepairing = true;
+        Assert.True(vm.IsBusy, "a repair is running and the shell was never told");
+
+        vm.IsRepairing = false;
+        Assert.False(vm.IsBusy, "the bar has to clear when the work finishes, or the tab looks stuck");
+    }
+
+    [Fact]
     public async Task FlushDns_WhenUserDeclinesConfirm_DoesNothing()
     {
         var vm = new NetworkRepairViewModel(NewShared());

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.12</Version>
-    <FileVersion>1.76.12.0</FileVersion>
-    <AssemblyVersion>1.76.12.0</AssemblyVersion>
+    <Version>1.76.13</Version>
+    <FileVersion>1.76.13.0</FileVersion>
+    <AssemblyVersion>1.76.13.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -927,6 +927,8 @@ public sealed partial class AboutViewModel : ViewModelBase
         catch (UnauthorizedAccessException ex) { Log.Debug(ex, "About: access denied reading build date"); }
         return string.Empty;
     }
+    // Forward any running state to IsBusy so the sidebar progress indicator works
+    partial void OnIsDownloadingChanged(bool value) => IsBusy = value;
 }
 
 /// <summary>Single release entry in the "What's new" history.</summary>

--- a/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
@@ -614,4 +614,6 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
         }
         base.Dispose(disposing);
     }
+    // Forward any running state to IsBusy so the sidebar progress indicator works
+    partial void OnIsDnsApplyingChanged(bool value) => IsBusy = value;
 }

--- a/SysManager/SysManager/ViewModels/NetworkRepairViewModel.cs
+++ b/SysManager/SysManager/ViewModels/NetworkRepairViewModel.cs
@@ -111,4 +111,7 @@ public sealed partial class NetworkRepairViewModel : ViewModelBase
         { RepairStatus = $"✗ Error: {ex.Message}"; }
         finally { IsRepairing = false; }
     }
+
+    // Forward any running state to IsBusy so the sidebar progress indicator works
+    partial void OnIsRepairingChanged(bool value) => IsBusy = value;
 }

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -245,4 +245,7 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
         }
         base.Dispose(disposing);
     }
+
+    // Forward any running state to IsBusy so the sidebar progress indicator works
+    partial void OnIsSpeedTestingChanged(bool value) => IsBusy = value;
 }

--- a/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TracerouteViewModel.cs
@@ -136,4 +136,7 @@ public sealed partial class TracerouteViewModel : ViewModelBase
         }
         base.Dispose(disposing);
     }
+
+    // Forward any running state to IsBusy so the sidebar progress indicator works
+    partial void OnIsTracingChanged(bool value) => IsBusy = value;
 }


### PR DESCRIPTION
Closes the behaviour half of #2108 — the one claim the docs PR (#2113) deliberately left in place, because weakening the sentence would have documented a gap instead of closing it.

## What was wrong

`NavItem` forwards `ViewModelBase.IsBusy` to the slim progress bar under a tab's name in the sidebar. It is the only sign, while the user is looking at a different tab, that this one is still working.

Five view-models kept their own running flag and never assigned `IsBusy`, so their bar never appeared — and they are the slowest screens in the app:

| Tab | Flag | How long it runs |
|---|---|---|
| Speed Test | `IsSpeedTesting` | a full up/down test, up to a minute |
| Traceroute | `IsTracing` | up to thirty hops, each with a timeout |
| Network Repair | `IsRepairing` | three netsh resets in sequence |
| About | `IsDownloading` | an ~85 MB update download |
| DNS & Hosts | `IsDnsApplying` | netsh, seconds |

## The fix

One generated hook per view-model, copying the idiom `DeepCleanupViewModel` already uses:

```csharp
// Forward any running state to IsBusy so the sidebar progress indicator works
partial void OnIsRepairingChanged(bool value) => IsBusy = value;
```

The existing flag stays the single source of truth — no second flag set alongside the first.

## How the scope was decided, and a correction to my own first pass

My first measurement looked for `On…Changed` hooks assigning `IsBusy` and reported **16** unforwarded flags. That was wrong: several tabs predate the hook idiom and assign `IsBusy` inline in the command body, which is equally correct. Re-measured as "does this view-model assign `IsBusy` anywhere at all", the real list was **three**, plus two more found by widening the flag pattern to `Running`/`Loading` suffixes — the five above.

The one remaining match is excluded with a reason: `AudioSessionRowViewModel.IsUserAdjusting` is a row inside the Volume Control list with no sidebar entry to draw a bar under, and the flag means "the user is dragging this slider", not work in progress.

## The guard

`EveryViewModelThatTracksRunningState_ForwardsItToIsBusy` — a view-model declaring an `[ObservableProperty] bool _is…ing/Running/Loading` must assign `IsBusy` somewhere. Deliberately indifferent to *how*, so the tabs that set it inline keep passing. Vacuity floor at 12 (fourteen such view-models exist today), and the exclusion list carries its reason inline.

## Verification

Mutation proof, all five files restored byte-for-byte and re-hashed. Removing any one hook:

- **the guard reds and names that file** — five for five, so it is reading every view-model rather than a fixed list
- **the behaviour test reds for the right reason** — `TrueException: a repair is running and the shell was never told` — proving the generated hook actually fires, which a source-shape guard cannot show

Baseline and post-restore green in both proofs. Regression sweep: 184 named tests across `ArchitectureTests` and the five tabs' test files — 213 cases green. The two reds in that run are a `Dispose` method my name-extraction grep picked up and the harness-only author-header case for the throwaway runner.

Builds 0 errors / 0 warnings (app + tests), `dotnet format --verify-no-changes` clean on both, version consistency csproj 1.76.13 = CHANGELOG 1.76.13 = SECURITY 1.76.x.

**Not verified here:** that the bar renders correctly on those five tabs. That needs the app running, which this machine does not do. The binding path is unchanged and shared with the 41 tabs already using it, so the risk is in the flag wiring — which is what the two proofs cover.
