### PR TITLE
refactor: make the unreachable-surface guard see every observable property

### DIFF
--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1844,9 +1844,13 @@ public partial class ArchitectureTests
             }
         }
 
-        Assert.True(checkedProperties >= 40,
-            $"only {checkedProperties} model properties were inspected — the detection is probably no "
-            + "longer matching the [ObservableProperty] declarations.");
+        // Measured: 187 today. The floor is set just under that rather than at a token value, because the
+        // defect it has to catch is precisely a pattern that still matches MOST declarations — the previous
+        // prefix saw 164 of these 187 and its floor of 40 reported nothing wrong for as long as it shipped.
+        Assert.True(checkedProperties >= 180,
+            $"only {checkedProperties} model properties were inspected, out of 187 measured — the detection "
+            + "is no longer matching every [ObservableProperty] declaration. A pattern that matches most of "
+            + "them still leaves the rest unguarded, so fix this before trusting a pass.");
 
         Assert.True(dead.Count == 0,
             "these model properties are never written and never shown, so they can only ever present an "
@@ -1858,7 +1862,22 @@ public partial class ArchitectureTests
     private static partial Regex TypeDeclaration();
 
     /// <summary>An <c>[ObservableProperty]</c> backing field, capturing the field name without its underscore.</summary>
-    [GeneratedRegex(@"\[ObservableProperty\][^\n]*\n?\s*(?:private|internal)\s+[\w\?<>,\[\]\. ]+?\s+_(\w+)\s*[;=]",
+    /// <remarks>
+    /// The prefix was <c>[^\n]*\n?</c>, which is wrong in both directions.
+    /// <para>It let the match run to the end of the attribute's own line and then across ONE newline, so for
+    /// the single-line form followed by a plain field —
+    /// <c>[ObservableProperty] private string _label = "";</c> then <c>private string? _target;</c> — it walked
+    /// past <c>_label</c> and captured <c>_target</c>, a field that is not observable at all. Four such
+    /// mis-captures exist in <c>ViewModels/</c> today.</para>
+    /// <para>And one newline is not enough for the multi-attribute form, so every property carrying a
+    /// <c>[NotifyPropertyChangedFor]</c> beside it was invisible: 23 of the 187 properties in
+    /// <c>Models/</c>, including six on <c>DiskHealthReport</c> alone. The guard's floor of 40 could never
+    /// reveal that, since 164 clears it comfortably.</para>
+    /// <para>Now: optional whitespace, then any number of further attributes, then the field. Nothing on the
+    /// attribute's own line can be skipped over.</para>
+    /// </remarks>
+    [GeneratedRegex(@"\[ObservableProperty\]\s*(?:\[[^\]]*\]\s*)*(?:private|internal)\s+"
+        + @"[\w\?<>,\[\]\. ]+?\s+_(\w+)\s*[;=]",
         RegexOptions.Compiled)]
     private static partial Regex ObservablePropertyField();
 

--- a/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
@@ -30,11 +30,13 @@ public class DiskAnalyzerViewModelTests
     [Fact]
     public void Constructor_InitialState_IsCorrect()
     {
+        // TotalFolders was asserted here too. It was computed from a full recursive
+        // Entries.Sum(e => e.FolderCount) on every scan and read by nothing — no binding, no other
+        // code — and this assertion on its default value is what made it look exercised.
         var vm = NewVm();
         Assert.False(vm.IsBusy);
         Assert.Equal(0, vm.TotalSize);
         Assert.Equal(0, vm.TotalFiles);
-        Assert.Equal(0, vm.TotalFolders);
         Assert.Equal(0, vm.EntryCount);
         Assert.Empty(vm.Entries);
         Assert.Contains("Select", vm.ScanSummary);

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -44,9 +44,7 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
     public bool HasTrend => !string.IsNullOrEmpty(TrendSummary);
     [ObservableProperty] private long _totalSize;
     [ObservableProperty] private int _totalFiles;
-    [ObservableProperty] private int _totalFolders;
     [ObservableProperty] private int _entryCount;
-    [ObservableProperty] private string _currentFolder = "";
 
     // Distinguishes the un-run state from a completed zero-result scan so the big empty-state overlay
     // doesn't tell the user to "pick a folder and analyze" right after they did exactly that. Set true
@@ -153,7 +151,6 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
         Entries.Clear();
         TotalSize = 0;
         TotalFiles = 0;
-        TotalFolders = 0;
         EntryCount = 0;
 
         UpdateDriveInfo();
@@ -162,7 +159,6 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
         {
             var progress = new Progress<DiskAnalyzerService.AnalysisProgress>(p =>
             {
-                CurrentFolder = p.CurrentFolder;
                 StatusMessage = $"Scanning folder {p.FoldersScanned}: {p.CurrentFolder}";
             });
 
@@ -173,7 +169,6 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
             EntryCount = Entries.Count;
             TotalSize = Entries.Sum(e => e.SizeBytes);
             TotalFiles = Entries.Sum(e => e.FileCount);
-            TotalFolders = Entries.Sum(e => e.FolderCount);
 
             ScanSummary = EntryCount == 0
                 ? "No subfolders found."
@@ -201,7 +196,6 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
         {
             IsBusy = false;
             IsProgressIndeterminate = false;
-            CurrentFolder = "";
         }
     }
 

--- a/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SpeedTestViewModel.cs
@@ -45,7 +45,6 @@ public sealed partial class SpeedTestViewModel : ViewModelBase
         "New York, US (ID: 10390)",
     };
     [ObservableProperty] private int _speedProgress;
-    [ObservableProperty] private string _speedStatus = "";
     [ObservableProperty] private string _httpStatus = "";
     [ObservableProperty] private string _ooklaStatus = "";
     [ObservableProperty] private bool _isSpeedTesting;


### PR DESCRIPTION
Part of #2100. `refactor:` — no behaviour change, no release.

## The guard for unreachable model surface could not see 12% of it

`EveryModelProperty_IsEitherWrittenOrShown` exists to catch a property that is never written and never shown. Its detection pattern was:

```
\[ObservableProperty\][^\n]*\n?\s*(?:private|internal)\s+[\w\?<>,\[\]\. ]+?\s+_(\w+)\s*[;=]
```

`[^\n]*\n?` is wrong in both directions.

**It skips forward.** For the single-line form followed by a plain field, the prefix consumes the attribute's own line, crosses the newline, and captures the *next* field:

```csharp
[ObservableProperty] private string _quickActionNavigateLabel = "";
private string? _quickActionNavigateTarget;      // <- this is what the pattern captured
```

Four such mis-captures exist in `ViewModels/` today (`_quickActionNavigateTarget`, `_suppressAllSelected`, `_blocker`, `_disposed`) — private fields reported as observable properties, while the real property beside each went unchecked.

**And one newline is not enough.** The multi-attribute form never matched at all:

```csharp
[ObservableProperty]
[NotifyPropertyChangedFor(nameof(HealthPercent))]
private double? _temperatureC;
```

That is **23 of the 187** `[ObservableProperty]` declarations in `Models/`, six of them on `DiskHealthReport` alone.

The pattern now allows whitespace and any number of further attributes between the marker and the field, and nothing on the attribute's own line can be walked past.

## The floor was the part that made it invisible

The old pattern saw 164 of 187 and the assertion was `checkedProperties >= 40`, so a 12% blind spot reported perfect health for as long as it shipped. Floor re-measured and raised to **180**.

Mutation proof, restored byte-for-byte:

| Mutation | Result |
|---|---|
| the prefix goes back to the greedy form | **RED** — `only 164 model properties were inspected, out of 187 measured` |
| greedy prefix **and** the old floor of 40 | **GREEN** |

The second row is the finding, not a footnote: with the old floor the old pattern is undetectable. The regex was the defect, the floor value is what let it live.

Re-running the corrected guard over all 187 properties finds **no new dead model surface** — so this is purely a coverage fix, not a bug hunt with a result.

## Three view-model properties removed

From the hand-measured list in #2100, the three that are redundant rather than a missing capability:

| Property | State |
|---|---|
| `SpeedTestViewModel.SpeedStatus` | declared, never assigned, never read; the literal `SpeedStatus` appeared exactly once in the whole app |
| `DiskAnalyzerViewModel.TotalFolders` | assigned from a full recursive `Entries.Sum(e => e.FolderCount)` on every scan, read nowhere |
| `DiskAnalyzerViewModel.CurrentFolder` | assigned and cleared on the scan path, read nowhere — and the next line already puts the same value into `StatusMessage`, which *is* bound |

`Constructor_InitialState_IsCorrect` asserted `TotalFolders == 0`, which is exactly what made it look exercised; the assertion went with the property and the reason is recorded where it was.

The other four in #2100 stay open, because each is a missing capability rather than dead weight — the active Menu Style preset, clickable release-history entries, free space on the chkdsk picker, release notes on About — and they need a mockup first.

## Not done here

Widening the guard to `ViewModels/` is still open on #2100. It needs a different rule: a model property's mere appearance in its own file proves use, but a view-model property is normally *assigned* there, so every write-only property looks alive. The rule has to distinguish a read from a write, and a first pass at it produced two false positives from same-name collisions across types — which is why it is not in this PR.

## Verification

Builds 0 errors / 0 warnings (app + tests), `dotnet format --verify-no-changes` clean on both, 143 cases green across `ArchitectureTests`, `DiskAnalyzerViewModelTests` and `SpeedTestViewModelTests`. No version bump and no CHANGELOG entry: nothing user-visible changed and `refactor:` does not release.
