### PR TITLE
fix: stop report cells accepting typing that goes nowhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.14] - 2026-09-04
+
+Double-clicking a cell in the App Updates or Windows Update list used to put a cursor in it, as if you could
+change what it said. You could type — and the app threw the change away. Those lists are reports now, and
+behave like it.
+
+### Fixed
+- **Report cells no longer pretend to be editable.** Ten cells across App Updates and Windows Update accepted
+  typing that went nowhere. One of them was the app's internal Id for a package, which is what gets handed to
+  Windows' installer — retyping it turned a row that would have updated into a row that reports an error, for
+  no reason the user could see. The tick boxes for choosing rows are untouched and still work.
+
 ## [1.76.13] - 2026-09-04
 
 Five of the slowest screens never showed the thin progress line under their name in the left-hand list, so if

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -5471,6 +5471,90 @@ public partial class ArchitectureTests
 
 
     /// <summary>
+    /// A text column in a report grid must not accept typing.
+    /// </summary>
+    /// <remarks>
+    /// Ten cells across App Updates and Windows Update entered edit mode on a double-click. Typing there
+    /// changed the in-memory row and nothing else, so the app appeared to accept an edit it silently discarded
+    /// — and one of them was App Updates' <c>Id</c>, the value <c>WingetService.UpgradeAsync</c> builds
+    /// <c>winget upgrade --id "…"</c> from, which turns a working row into an error row.
+    /// <para>Per-column, not grid-level. Both grids carry a <c>DataGridCheckBoxColumn</c> for row selection,
+    /// and <c>DataGrid.IsReadOnly="True"</c> renders those checkboxes untickable — it would break "Upgrade
+    /// selected" outright. The 20 views that DO set it grid-wide have no checkbox column, which is why they
+    /// can. Reading the omission as forgetfulness and setting it globally would have been the wrong fix.</para>
+    /// <para>Nothing reaches a command line through an edited cell: <c>WingetId.IsValid</c> rejects the value
+    /// and <c>AppUpdatesViewModel</c> catches the <c>ArgumentException</c> per row. This is a UI-honesty rule,
+    /// not a security one.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryReportTextColumn_IsReadOnly()
+    {
+        // view -> the column Header allowed to be editable, and why.
+        var editors = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["EnvironmentVariablesView.xaml"] =
+                "Value — this tab is an editor, not a report: Apply / Discard / Restore backup sit beside the "
+                + "grid and UpdateSourceTrigger=PropertyChanged carries each keystroke to the view-model",
+        };
+
+        var viewsDir = Path.Combine(FindAppProjectDir(), "Views");
+        var columnsChecked = 0;
+        var typeable = new List<string>();
+
+        foreach (var file in Directory.GetFiles(viewsDir, "*.xaml"))
+        {
+            var name = Path.GetFileName(file);
+            var text = File.ReadAllText(file);
+
+            // Every grid in the file must be read-only for the grid-level form to count for any column in it.
+            var grids = DataGridOpeningTag().Matches(text).Select(m => m.Value).ToList();
+            if (grids.Count == 0) continue;
+            var gridReadOnly = grids.TrueForAll(g => g.Contains("IsReadOnly=\"True\"", StringComparison.Ordinal));
+
+            foreach (var column in ReportTextColumn().Matches(text).Select(m => m.Value))
+            {
+                columnsChecked++;
+                if (gridReadOnly || column.Contains("IsReadOnly", StringComparison.Ordinal)) continue;
+
+                var header = ColumnHeader().Match(column).Groups["header"].Value;
+                if (editors.TryGetValue(name, out var allowed)
+                    && allowed.StartsWith(header + " ", StringComparison.Ordinal)) continue;
+
+                typeable.Add($"{name}: {header}");
+            }
+        }
+
+        // Vacuity floor: 125 text columns across the views today, measured with this exact pattern. The
+        // count matters twice over — a first pass at this used a pattern that also matched
+        // <DataGridTextColumn.CellStyle>, a property element rather than a column. There are 43 of those, so
+        // the population read as 168 and every per-view "typeable cells" number was inflated with it.
+        Assert.True(columnsChecked >= 118,
+            $"only {columnsChecked} report text columns were parsed out of 125 measured — the pattern no "
+            + "longer matches the column shape, so this guard proves nothing.");
+
+        Assert.True(typeable.Count == 0,
+            "these report cells enter edit mode on a double-click, and the edit goes nowhere. Add "
+            + "IsReadOnly=\"True\" to the column — NOT to the DataGrid, which would also stop the user "
+            + "ticking a DataGridCheckBoxColumn. If the cell is genuinely meant to be edited, name it in the "
+            + "exception list in this test WITH its reason:\n  " + string.Join("\n  ", typeable));
+    }
+
+    /// <summary>A <c>DataGrid</c> opening tag.</summary>
+    [GeneratedRegex(@"<DataGrid(?![.\w])[^>]*?>", RegexOptions.Singleline)]
+    private static partial Regex DataGridOpeningTag();
+
+    /// <summary>
+    /// A <c>DataGridTextColumn</c> element. The negative lookahead keeps
+    /// <c>&lt;DataGridTextColumn.CellStyle&gt;</c> — a property element, not a column — out of the match.
+    /// </summary>
+    [GeneratedRegex(@"<DataGridTextColumn(?![.\w])[^>]*?/?>", RegexOptions.Singleline)]
+    private static partial Regex ReportTextColumn();
+
+    /// <summary>A column's <c>Header</c> attribute value.</summary>
+    [GeneratedRegex(@"Header=""(?<header>[^""]*)""")]
+    private static partial Regex ColumnHeader();
+
+    /// <summary>
     /// A view-model that tracks its own "running" state must forward it to <c>IsBusy</c>.
     /// </summary>
     /// <remarks>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.13</Version>
-    <FileVersion>1.76.13.0</FileVersion>
-    <AssemblyVersion>1.76.13.0</AssemblyVersion>
+    <Version>1.76.14</Version>
+    <FileVersion>1.76.14.0</FileVersion>
+    <AssemblyVersion>1.76.14.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -88,12 +88,12 @@
                             </Style>
                         </DataGridCheckBoxColumn.EditingElementStyle>
                     </DataGridCheckBoxColumn>
-                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*" MinWidth="120" SortMemberPath="Name"/>
-                    <DataGridTextColumn Header="Id" Binding="{Binding Id}" Width="2*" MinWidth="120" SortMemberPath="Id"/>
-                    <DataGridTextColumn Header="Current" Binding="{Binding CurrentVersion}" Width="*" MinWidth="80" SortMemberPath="CurrentVersion"/>
-                    <DataGridTextColumn Header="Available" Binding="{Binding AvailableVersion}" Width="*" MinWidth="80" SortMemberPath="AvailableVersion"/>
-                    <DataGridTextColumn Header="Source" Binding="{Binding Source}" Width="80" MinWidth="60" SortMemberPath="Source"/>
-                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="*" MinWidth="80" SortMemberPath="Status"/>
+                    <DataGridTextColumn IsReadOnly="True" Header="Name" Binding="{Binding Name}" Width="2*" MinWidth="120" SortMemberPath="Name"/>
+                    <DataGridTextColumn IsReadOnly="True" Header="Id" Binding="{Binding Id}" Width="2*" MinWidth="120" SortMemberPath="Id"/>
+                    <DataGridTextColumn IsReadOnly="True" Header="Current" Binding="{Binding CurrentVersion}" Width="*" MinWidth="80" SortMemberPath="CurrentVersion"/>
+                    <DataGridTextColumn IsReadOnly="True" Header="Available" Binding="{Binding AvailableVersion}" Width="*" MinWidth="80" SortMemberPath="AvailableVersion"/>
+                    <DataGridTextColumn IsReadOnly="True" Header="Source" Binding="{Binding Source}" Width="80" MinWidth="60" SortMemberPath="Source"/>
+                    <DataGridTextColumn IsReadOnly="True" Header="Status" Binding="{Binding Status}" Width="*" MinWidth="80" SortMemberPath="Status"/>
                 </DataGrid.Columns>
             </DataGrid>
 

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -131,6 +131,11 @@
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Name" Binding="{Binding Name}" IsReadOnly="True" Width="180"/>
                         <DataGridTextColumn Header="Scope" Binding="{Binding ScopeLabel}" IsReadOnly="True" Width="70"/>
+                        <!-- The one editable report cell in the app, and deliberately so: this tab IS an
+                             editor, with Apply / Discard / Restore backup beside the grid, and
+                             UpdateSourceTrigger=PropertyChanged is what carries each keystroke to the
+                             view-model for Apply to write. A uniformity sweep must not make this read-only;
+                             EveryReportTextColumn_IsReadOnly names it as the exception. -->
                         <DataGridTextColumn Header="Value" Binding="{Binding Value, UpdateSourceTrigger=PropertyChanged}" Width="*">
                             <!-- Trim the *display* of a long value (e.g. a full PATH) against the
                                  Remove button and expose it on hover; the edit box still shows the

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -225,7 +225,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Binding="{Binding KB}" Width="100" MinWidth="70"
+                    <DataGridTextColumn IsReadOnly="True" Binding="{Binding KB}" Width="100" MinWidth="70"
                                         SortMemberPath="KB">
                         <DataGridTextColumn.Header>
                             <TextBlock Text="KB"
@@ -240,7 +240,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="Size" Binding="{Binding Size}" Width="80" MinWidth="60"
+                    <DataGridTextColumn IsReadOnly="True" Header="Size" Binding="{Binding Size}" Width="80" MinWidth="60"
                                         SortMemberPath="Size">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -251,7 +251,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="200" MinWidth="120"
+                    <DataGridTextColumn IsReadOnly="True" Header="Status" Binding="{Binding Status}" Width="200" MinWidth="120"
                                         SortMemberPath="Status">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -263,7 +263,7 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
-                    <DataGridTextColumn Header="Date" Binding="{Binding DateDisplay}" Width="100" MinWidth="80"
+                    <DataGridTextColumn IsReadOnly="True" Header="Date" Binding="{Binding DateDisplay}" Width="100" MinWidth="80"
                                         SortMemberPath="Date">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">


### PR DESCRIPTION
Closes #2105 — and corrects that issue's numbers, which I had inflated.

## What was wrong

Ten text cells across `AppUpdatesView` and `WindowsUpdateView` entered edit mode on a double-click. Typing there changed the in-memory row and nothing else, so the app appeared to accept an edit it silently discarded.

One of them carries a consequence: App Updates' **Id** is the value `WingetService.UpgradeAsync` builds `winget upgrade --id "…"` from, so retyping it turns a row that would have upgraded into a row that reports an error.

## Per-column, not grid-level — and the issue got this backwards

#2105 read the situation as "20 views set `IsReadOnly` on the DataGrid, these forgot". That was wrong, and setting it globally would have broken the feature:

**Every grid lacking `IsReadOnly` has a selection mechanism that needs the grid editable.** Six use `DataGridCheckBoxColumn` (App Updates, Windows Update, App Blocker, DNS & Hosts, Shortcut Cleaner, Uninstaller) and two use a `DataGridTemplateColumn` with a CheckBox. `DataGrid.IsReadOnly="True"` renders a `DataGridCheckBoxColumn` untickable — it would have disabled "Upgrade selected" outright. None of the 20 read-only grids has a checkbox column, which is why they can afford the grid-level form.

So the fix is `IsReadOnly="True"` on the ten text columns, leaving every checkbox, button and template column exactly as it was.

## The count in #2105 was inflated, and by what

The issue's table said App Updates 6, Windows Update **10 of 11**, plus five more views — 27 typeable cells in total. Re-measured: **10 cells across 2 views**.

The pattern I measured with, `<DataGridTextColumn[^>]*?/?>`, also matches `<DataGridTextColumn.CellStyle>` — a *property element*, not a column. There are **43** of those across the views, so the population read as 168 instead of 125, and every per-view number carried a share of them. Shortcut Cleaner, Uninstaller, Context Menu and Startup were listed as having typeable cells and have none; their text columns already carry the attribute per column.

Recording it here rather than quietly shipping the smaller fix, because the same pattern is now in the guard and its floor documents the trap.

## Environment Variables is the one deliberate exception

Its `Value` column stays editable, and the tab settles it: `Apply` / `Discard` / `Restore backup` sit beside the grid, and the binding is `UpdateSourceTrigger=PropertyChanged`, which exists to carry each keystroke to the view-model for `Apply` to write. Inline editing is the feature. Marked with a comment in the XAML and named in the guard's exception list with that reason, so a uniformity sweep cannot "fix" it.

## The guard

`EveryReportTextColumn_IsReadOnly` — a `DataGridTextColumn` must be read-only via its own attribute or via a grid whose every `<DataGrid>` tag sets it, with the exception list keyed to view + column header. Vacuity floor at 118 against 125 measured, and the remark records the property-element trap so the next person measuring does not repeat it.

## Verification

Mutation proof, three files restored byte-for-byte:

| Mutation | Result |
|---|---|
| App Updates' `Id` loses `IsReadOnly` | **RED**, naming `AppUpdatesView.xaml: Id` |
| Windows Update's `Status` loses it | **RED**, naming `WindowsUpdateView.xaml: Status` |
| the Environment Variables exception is removed | **RED**, naming `EnvironmentVariablesView.xaml: Value` |

The third confirms the allowlist is load-bearing rather than decoration. Baseline and post-restore green.

265 cases green across `ArchitectureTests`, `AppUpdatesViewModelTests`, `WindowsUpdate*` and `EnvironmentVariables*`. Builds 0 errors / 0 warnings, `dotnet format --verify-no-changes` clean on both, version consistency csproj 1.76.14 = CHANGELOG 1.76.14 = SECURITY 1.76.x.

**Not verified here:** that the cells are actually inert on screen, which needs the app running. What is verified is that the attribute is on all ten columns and that no checkbox column was touched — the XAML parses, and the grid-level form (which would have broken selection) is explicitly rejected by the guard's failure message.
