### PR TITLE
test: point the integration suite's colour expectations at StatusColors

### DIFF
--- a/SysManager/SysManager.IntegrationTests/DeepCleanupViewUiTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DeepCleanupViewUiTests.cs
@@ -58,11 +58,25 @@ public class DeepCleanupViewUiTests
         Assert.Contains(vm.NavItems, n => n.Id == "nav-about");
     }
 
+    /// <summary>
+    /// About closes out the Info group — the last thing in the sidebar before Advanced.
+    /// </summary>
+    /// <remarks>
+    /// Was <c>NavItems_CorrectOrder_AboutLast</c>, asserting <c>NavItems.Last().Id == "nav-about"</c>. That
+    /// stopped being true when the Advanced group was appended after Info, so the real last entry is
+    /// <c>nav-env-variables</c> — and nothing said so, because CI only compile-checks this project.
+    /// <para>Rewritten to the invariant that survived the change rather than deleted: About belongs at the end
+    /// of Info, which is where the shell's own comment puts it ("About is eager … the sidebar version label
+    /// and the tab show one shared VM"). Asserting it as the last of its group cannot rot when a group is
+    /// appended, only when About itself moves — which is the thing worth catching.</para>
+    /// </remarks>
     [Fact]
-    public void NavItems_CorrectOrder_AboutLast()
+    public void NavItems_AboutIsLastInTheInfoGroup()
     {
         var vm = new MainWindowViewModel();
-        Assert.Equal("nav-about", vm.NavItems.Last().Id);
+        var info = vm.NavGroups.Single(g => g.Id == "grp-info");
+
+        Assert.Equal("nav-about", info.Children[^1].Id);
     }
 
     [Fact]

--- a/SysManager/SysManager.IntegrationTests/DiskHealthServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DiskHealthServiceTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
 using SysManager.Services;
 
 namespace SysManager.IntegrationTests;
@@ -37,7 +38,7 @@ public class DiskHealthServiceTests
             Assert.False(string.IsNullOrWhiteSpace(r.FriendlyName));
             Assert.False(string.IsNullOrWhiteSpace(r.MediaType));
             Assert.False(string.IsNullOrWhiteSpace(r.Verdict));
-            Assert.Matches("^#[0-9A-Fa-f]{6}$", r.VerdictColorHex);
+            Assert.Contains(r.VerdictColorHex, StatusColors.AllBrushKeys);
         }
     }
 

--- a/SysManager/SysManager.IntegrationTests/HealthAnalyzerExtendedTests.cs
+++ b/SysManager/SysManager.IntegrationTests/HealthAnalyzerExtendedTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 
@@ -72,7 +73,7 @@ public class HealthAnalyzerExtendedTests
             M("dns", TargetRole.PublicDns, avg: 15, jitter: 2),
         });
         Assert.Contains("healthy", diag.Headline, StringComparison.OrdinalIgnoreCase);
-        Assert.Equal("#06D6A0", diag.ColorHex);
+        Assert.Equal(StatusColors.Good, diag.ColorHex);
     }
 
     // ---------- Local network ----------
@@ -234,13 +235,13 @@ public class HealthAnalyzerExtendedTests
     // ---------- Verdict colors ----------
 
     [Theory]
-    [InlineData(HealthVerdict.Good, "#06D6A0")]
-    [InlineData(HealthVerdict.LocalNetwork, "#FF6B6B")]
-    [InlineData(HealthVerdict.IspOrUpstream, "#FFD166")]
-    [InlineData(HealthVerdict.GameServer, "#F72585")]
-    [InlineData(HealthVerdict.StreamingService, "#B388FF")]
-    [InlineData(HealthVerdict.Mixed, "#FF6B6B")]
-    [InlineData(HealthVerdict.Unknown, "#9AA0A6")]
+    [InlineData(HealthVerdict.Good, StatusColors.Good)]
+    [InlineData(HealthVerdict.LocalNetwork, StatusColors.Bad)]
+    [InlineData(HealthVerdict.IspOrUpstream, StatusColors.Warning)]
+    [InlineData(HealthVerdict.GameServer, StatusColors.Info)]
+    [InlineData(HealthVerdict.StreamingService, StatusColors.Info)]
+    [InlineData(HealthVerdict.Mixed, StatusColors.Bad)]
+    [InlineData(HealthVerdict.Unknown, StatusColors.Neutral)]
     public void AllVerdicts_ProduceValidColor(HealthVerdict expectedVerdict, string expectedColor)
     {
         // Build the conditions to trigger each verdict

--- a/SysManager/SysManager.IntegrationTests/HealthDiagnosticTests.cs
+++ b/SysManager/SysManager.IntegrationTests/HealthDiagnosticTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.ComponentModel;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.IntegrationTests;
@@ -16,7 +17,7 @@ public class HealthDiagnosticTests
         Assert.Equal(HealthVerdict.Unknown, d.Verdict);
         Assert.Equal("Waiting for data…", d.Headline);
         Assert.Equal("", d.Detail);
-        Assert.Equal("#9AA0A6", d.ColorHex);
+        Assert.Equal(StatusColors.Neutral, d.ColorHex);
         Assert.Equal(0, d.WorstLossPercent);
         Assert.Equal(0, d.WorstJitterMs);
         Assert.Equal(0, d.AveragePingMs);

--- a/SysManager/SysManager.IntegrationTests/SystemHealthViewModelExtendedTests.cs
+++ b/SysManager/SysManager.IntegrationTests/SystemHealthViewModelExtendedTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
 using SysManager.Services;
 using SysManager.ViewModels;
 
@@ -31,7 +32,7 @@ public class SystemHealthViewModelExtendedTests
         Assert.Equal(0, vm.WheaMemoryErrors);
         Assert.Equal(0, vm.MemoryDiagnosticResults);
         Assert.False(string.IsNullOrWhiteSpace(vm.MemoryHealthVerdict));
-        Assert.Matches("^#[0-9A-Fa-f]{6}$", vm.MemoryHealthColorHex);
+        Assert.Contains(vm.MemoryHealthColorHex, StatusColors.AllBrushKeys);
     }
 
     [Fact]

--- a/SysManager/SysManager/Helpers/StatusColors.cs
+++ b/SysManager/SysManager/Helpers/StatusColors.cs
@@ -47,4 +47,16 @@ internal static class StatusColors
     /// report".
     /// </summary>
     public const string Neutral = "TextMuted";
+
+    /// <summary>
+    /// Every distinct brush key above (<see cref="Elevated"/> shares <see cref="Warning"/>'s), so a caller can
+    /// assert that a <c>*ColorHex</c> value names one of them without restating the list.
+    /// </summary>
+    /// <remarks>
+    /// Exists because two tests asserted the shape instead — <c>Assert.Matches("^#[0-9A-Fa-f]{6}$", …)</c> —
+    /// and went permanently red when these became brush keys. A test that names the set cannot rot that way,
+    /// and a copy of the set in the test would be a second source of truth in the one class whose whole point
+    /// is being the first.
+    /// </remarks>
+    public static readonly string[] AllBrushKeys = [Good, Warning, Info, Bad, Neutral];
 }


### PR DESCRIPTION
Closes the first half of #2101 — and corrects its count.

## Eleven assertions, not nine, across four files

`StatusColors` members are theme brush KEYS now (`Good = "Success"`, `Neutral = "TextMuted"`), and every producer of a `*ColorHex` property assigns one. Eleven assertions in `SysManager.IntegrationTests` still compared against the pre-migration hex literals, so all eleven were permanently failing — and CI only `dotnet build`s that project, so nothing said so.

#2101 found nine in two files. Two more turned up while fixing them, in files the issue never named:

| File | Assertions | Shape |
|---|---|---|
| `HealthAnalyzerExtendedTests.cs` | 8 | one `Assert.Equal` plus 7 `[InlineData]` rows |
| `HealthDiagnosticTests.cs` | 1 | `Assert.Equal("#9AA0A6", d.ColorHex)` |
| `SystemHealthViewModelExtendedTests.cs` | 1 | `Assert.Matches("^#[0-9A-Fa-f]{6}$", …)` |
| `DiskHealthServiceTests.cs` | 1 | same regex, on `VerdictColorHex` |

The two `Assert.Matches` are why the issue missed them: it searched for hex *literals*, and a regex asserting hex *shape* contains no colour to grep for. The runner found them, not me.

## Repointed at the member, not its value

Each expectation now names the `StatusColors` member the producer actually assigns — read off `HealthAnalyzer` rather than inferred:

| Verdict | Member |
|---|---|
| Good | `Good` |
| LocalNetwork, Mixed | `Bad` |
| IspOrUpstream | `Warning` |
| GameServer, StreamingService | `Info` |
| Unknown | `Neutral` |

Worth noting what the old rows recorded: GameServer was `#F72585` and StreamingService `#B388FF`, two distinct colours that now both resolve to `Info`. The migration collapsed them, and these tests would have said so had they been able to run.

The two shape assertions get `Assert.Contains(value, StatusColors.AllBrushKeys)` — a stronger claim than the old regex, since it names the permitted set rather than a character class.

## One production line

`StatusColors.AllBrushKeys` — the five distinct keys (`Elevated` shares `Warning`'s). A copy of that list in the test would put a second source of truth inside the one class whose stated purpose is being the first. It adds no behaviour.

## Also: the nav-order test asserted the wrong tab

`NavItems_CorrectOrder_AboutLast` asserted `NavItems.Last().Id == "nav-about"`. Appending the Advanced group after Info made the real last entry `nav-env-variables`, and the test had been red ever since.

Rewritten rather than deleted, to the invariant that survived the change: `NavItems_AboutIsLastInTheInfoGroup`. Asserting About's position *within its group* cannot rot when a group is appended — only when About itself moves, which is the thing worth catching.

## Verification

Ten of the eleven are pure computation and were run through a throwaway runner pointed at the integration assembly (kept outside the repo, so there is nothing to exclude from git). Reverting every expectation to its pre-migration literal — the state that shipped — gives:

```
3 green, 10 red
RED  AllVerdicts_ProduceValidColor[0..6]: Expected "#06D6A0" … Actual "Success" (and the other six)
RED  Good_HeadlineMentionsHealthy:        Expected "#06D6A0" … Actual "Success"
RED  Defaults_AreSafe:                    Expected "#9AA0A6" … Actual "TextMuted"
RED  Defaults_AreSafe:                    Regex "^#[0-9A-Fa-f]{6}$" … Value "TextMuted"
```

13 green, 0 red after restore, with all three files hashed identical.

**The eleventh is not run here:** `DiskHealthServiceTests.EachReport_HasFriendlyNameAndMedia` calls `CollectAsync()` and needs live WMI. Its assertion is the same shape as the `Defaults_AreSafe` one above, which *is* run and shows the exact failure.

**Not addressed here:** #2101's second point, that a project whose assertions cannot run anywhere in the pipeline will rot again. That is a CI question — a scheduled non-blocking job, or moving the pure assertions into the blocking suite — and it stays open on the issue.

Builds 0 errors / 0 warnings on all four projects, `dotnet format --verify-no-changes` clean on all four, 190 cases green in `ArchitectureTests` and the theme-contrast suites. `test:` — no version bump, no CHANGELOG, no release.
