### PR TITLE
fix: tell the user what the four blank screens are waiting for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.16] - 2026-09-07
+
+Four screens showed an empty table with no explanation until you pressed the right button — and did not say
+which button. Traceroute, Windows Update, Deep Cleanup's large-file list and the drive-health panel in System
+Health now tell you what they are waiting for.
+
+### Fixed
+- **The four screens that opened blank now say what they need.** Each of them starts with nothing to show,
+  which is normal — but a column header over empty space looks like something went wrong rather than like
+  something has not been asked for yet. Each now shows a short line naming the button that fills it: Trace now,
+  List updates, Scan drive, Run SMART check. Same look as the thirty-odd screens that already did this.
+
 ## [1.76.15] - 2026-09-04
 
 On any of the six light colour themes, the green tick on the little "finished" pop-up was almost invisible

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.15</Version>
-    <FileVersion>1.76.15.0</FileVersion>
-    <AssemblyVersion>1.76.15.0</AssemblyVersion>
+    <Version>1.76.16</Version>
+    <FileVersion>1.76.16.0</FileVersion>
+    <AssemblyVersion>1.76.16.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -1,7 +1,8 @@
 <!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.DeepCleanupView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views">
 
     <Grid Background="{DynamicResource Surface0}">
         <ScrollViewer VerticalScrollBarVisibility="Auto">
@@ -196,6 +197,10 @@
                             <TextBlock Text="{Binding LargeCurrentFolder}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,4,0,0" TextTrimming="CharacterEllipsis"/>
                         </StackPanel>
 
+                        <!-- Grid wrapper so the empty state overlays the table rather than stacking under it:
+                             the parent is a StackPanel, where a sibling would appear BELOW the header row
+                             instead of in place of the missing rows. -->
+                        <Grid>
                         <DataGrid AutomationProperties.Name="Large files" ItemsSource="{Binding LargeFiles}"
                                   AutoGenerateColumns="False" HeadersVisibility="Column"
                                   GridLinesVisibility="None" IsReadOnly="True"
@@ -229,6 +234,11 @@
                                 </DataGridTemplateColumn>
                             </DataGrid.Columns>
                         </DataGrid>
+                        <v:EmptyState Glyph="&#xE838;"
+                                      Title="No large files listed yet"
+                                      Message="Pick a location above and press Scan drive to list the biggest files it holds."
+                                      Visibility="{Binding LargeFiles.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                        </Grid>
                     </StackPanel>
                 </Border>
             </StackPanel>

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -282,6 +282,13 @@
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
+                        <!-- Stacked rather than overlaid: the parent is a StackPanel and an ItemsControl with
+                             no items takes no space, so there is no header row to sit on top of — the card
+                             was simply its own title and explanation above blank space. -->
+                        <v:EmptyState Glyph="&#xEDA2;"
+                                      Title="No drive health read yet"
+                                      Message="Press Run SMART check to ask your drives how they are doing."
+                                      Visibility="{Binding DiskHealth.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                     </StackPanel>
                 </Border>
 

--- a/SysManager/SysManager/Views/TracerouteView.xaml
+++ b/SysManager/SysManager/Views/TracerouteView.xaml
@@ -101,6 +101,12 @@
                             <DataGridTextColumn Header="ms" Binding="{Binding LatencyMs, StringFormat={}{0:F0}}" Width="60" MinWidth="40"/>
                         </DataGrid.Columns>
                     </DataGrid>
+                    <!-- Before the first trace the grid is a header row over nothing, with no hint of what to
+                         press. Same slot as the grid so it sits where the rows will appear. -->
+                    <v:EmptyState Grid.Row="2" Glyph="&#xE774;"
+                                  Title="No route traced yet"
+                                  Message="Type an address above and press Trace now to see every step between your PC and it."
+                                  Visibility="{Binding Shared.TracerouteHops.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                 </Grid>
             </Border>
         </Grid>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -182,6 +182,9 @@
 
         <!-- Update table (DataGrid) -->
         <Border Grid.Row="5" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="0">
+          <!-- Grid wrapper so the empty state can sit in the same cell as the table. A Border takes one
+               child, and the table is a header row over nothing until the user asks Windows what is due. -->
+          <Grid>
             <DataGrid AutomationProperties.Name="Windows updates" ItemsSource="{Binding Updates}"
                       AutoGenerateColumns="False" HeadersVisibility="Column"
                       Background="Transparent" BorderThickness="0"
@@ -364,6 +367,11 @@
                     </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
+            <v:EmptyState Glyph="&#xE895;"
+                          Title="No updates listed yet"
+                          Message="Press List updates to ask Windows what is waiting for this PC."
+                          Visibility="{Binding Updates.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+          </Grid>
         </Border>
 
         <!-- Console output (shown during install/reboot check) -->


### PR DESCRIPTION
Part of #2111 — the four grids that open blank. `fix:`, not `feat:`, for the same reason #2114 was: the shared control and the convention already exist and roughly thirty views follow them, so these four were incomplete rather than unbuilt. The issue's list was wrong in both directions and the corrected measurement is below.

## The four

Each starts with nothing to show, which is correct, and said nothing about it:

| View | Collection | Filled by | Was |
|---|---|---|---|
| `TracerouteView` | `Shared.TracerouteHops` | `Trace now` | a `#`/Address/ms header row over blank space |
| `WindowsUpdateView` | `Updates` | `List updates` | same |
| `DeepCleanupView` | `LargeFiles` | `Scan drive` | same |
| `SystemHealthView` | `DiskHealth` | `Run SMART check` | an `ItemsControl` with no items takes no space, so the card was its own title and explanation above nothing |

Each message names the button that fills it, taken from the view's own `Content` rather than paraphrased.

## Two placements, for two different parents

- Traceroute's grid is already in a `Grid` — the state goes in the same `Grid.Row`, so it sits where the rows will appear.
- Windows Update's and Deep Cleanup's grids needed a `Grid` wrapper: the first is a `Border`'s only child (a Border takes one child) and the second is in a `StackPanel`, where a sibling would stack *below* the header row instead of standing in for the missing rows.
- System Health's is stacked deliberately: an `ItemsControl` with no items occupies no space, so there is nothing to overlay.

`DeepCleanupView` also gained the `xmlns:v` declaration it lacked.

## #2111's list was wrong both ways

The issue named six views by looking for instances of the shared `EmptyState` control. That misses the app's **second** established form — a `Subtle` TextBlock bound to the collection's `Count` with `ConverterParameter=Inverse`. Twenty-three views use that one, and several of the six already had it:

- **Speed Test needed nothing.** Both history tables already say *"No history yet — run a test to start tracking."* Listed in the issue as missing.
- **CLI Interface needed nothing.** `Commands` is filled in the constructor from `CliRunner`'s static list, so it is never empty.

## And it undercounted: eight more views have no empty state at all

While building a guard for this I measured it properly — a view listing a bound collection must have an `EmptyState` control **or** a `.Count`-bound `Inverse` binding. Of 44 views that list a collection, **eight** have neither:

`AboutView`, `BulkInstallerView`, `DashboardView`, `EnvironmentVariablesView`, `PingView`, `PrivacyView`, `ProfileView`, `TweaksHubView`

Some of those collections may be constructor-populated and legitimately exempt (`PrivacyView`'s toggles, for instance); others look like real gaps — `BulkInstallerView`'s only `Inverse` bindings are `IsElevated`, `FilterText`, `SearchQuery` and `Icon`, none of them an empty state.

**The guard is not in this PR.** Landing it would have meant eight exception entries I have not verified one by one, which puts unverified claims into the codebase. The eight need the same treatment the four got — read the view-model, decide whether the collection can be empty, write copy naming the real control — and that is its own batch. Filing it as a follow-up.

## The guard is worth recording anyway, because its first version was wrong

My first attempt asked whether the file contained `:EmptyState` **or** any `ConverterParameter=Inverse`. The mutation proof killed it: deleting Traceroute's and System Health's empty states both left it **green**, satisfied by a `Shared.IsAutoTraceRunning` button binding and an `IsElevated` admin banner respectively. Tying the lighter form to `.Count` fixes it.

Its second version was wrong too, in a way the proof's own baseline check caught: the pattern `Binding [\w.]+\.Count\s*,[^}]*ConverterParameter=Inverse` cannot reach past `Converter={StaticResource FlexVis}`, because that contains a `}`. It matched nothing and flagged fourteen views including ones I had just verified by hand. `[^"]*` is the right bound — the attribute's own quote.

Both are in the follow-up branch, not here.

## Verification

Builds 0 errors / 0 warnings, `dotnet format --verify-no-changes` clean, 92 cases green in `ArchitectureTests` (plus the harness-only author-header case for the throwaway runner), version consistency csproj 1.76.16 = CHANGELOG 1.76.16 = SECURITY 1.76.x, CHANGELOG dated today in UTC.

**Not verified here:** how the four states look on screen, which needs the app running. What is verified is that all four bind to the right collection's `Count`, that the XAML parses, and that each message names a button string that exists in its own view.
