### PR TITLE
test: make elevation injectable so the admin-gate tests assert something

### DIFF
--- a/SysManager/SysManager.IntegrationTests/InfrastructureTests.cs
+++ b/SysManager/SysManager.IntegrationTests/InfrastructureTests.cs
@@ -140,20 +140,40 @@ public class WingetServiceTests
         Assert.Single(result);
     }
 
+    /// <summary>
+    /// A line the runner emits reaches whoever subscribed through <see cref="WingetService"/>, and stops
+    /// reaching them once they unsubscribe.
+    /// </summary>
+    /// <remarks>
+    /// <c>WingetService.LineReceived</c> is a pass-through: its <c>add</c>/<c>remove</c> accessors forward
+    /// straight to the runner's event, holding no list of their own. That is the whole behaviour worth
+    /// pinning, because getting it wrong is silent — a service that swallowed the subscription would leave
+    /// the App Updates console permanently blank while every other assertion stayed green.
+    /// <para>This test asserted nothing at all before. It built a real <c>PowerShellRunner</c>, called
+    /// <c>GetField</c> and discarded the result, then ended with <c>_ = gotLine;</c> under a comment saying
+    /// the path "requires a running session". So it passed on every machine no matter what the service did.
+    /// With the runner behind a seam there is no session to need: raise the far end and watch the near
+    /// end.</para>
+    /// </remarks>
     [Fact]
-    public void WingetService_EventForwardingWorks()
+    public void WingetService_ForwardsRunnerLines_ToItsOwnSubscribers()
     {
-        var runner = new PowerShellRunner();
+        var runner = new RecordingRunner();
         var winget = new WingetService(runner);
-        var gotLine = false;
-        winget.LineReceived += _ => gotLine = true;
 
-        // Manually trigger via runner
-        runner.GetType().GetField("LineReceived", BindingFlags.NonPublic | BindingFlags.Instance);
-        // Use reflection-safe call: just invoke whether subscribers are wired
-        // by raising on runner through its own event chain via PowerShellLine.
-        // Simplest: invoke via a fake append through the PowerShell runner.
-        // (We accept that this path requires a running session; skip if not possible.)
-        _ = gotLine;
+        var received = new List<string>();
+        void Sink(PowerShellLine line) => received.Add(line.Text);
+        winget.LineReceived += Sink;
+
+        runner.RaiseLine(PowerShellLine.Output("Git.Git  2.47.0  2.48.0  winget"));
+
+        Assert.Equal(["Git.Git  2.47.0  2.48.0  winget"], received);
+
+        // Removing must reach the runner too — a remove accessor that forgot to forward would leak every
+        // subscriber for the life of the process.
+        winget.LineReceived -= Sink;
+        runner.RaiseLine(PowerShellLine.Output("this line has no subscriber left"));
+
+        Assert.Single(received);
     }
 }

--- a/SysManager/SysManager.IntegrationTests/RecordingRunner.cs
+++ b/SysManager/SysManager.IntegrationTests/RecordingRunner.cs
@@ -1,0 +1,70 @@
+// SysManager · RecordingRunner
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using System.Text;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.IntegrationTests;
+
+/// <summary>
+/// An <see cref="IPowerShellRunner"/> that counts what it was asked to run, runs none of it, and can raise
+/// its own output events on demand.
+/// </summary>
+/// <remarks>
+/// Hand-rolled rather than substituted: this project does not reference NSubstitute, and pulling a second
+/// mocking dependency in — plus the row it would need in TESTING.md's framework table — is a larger change
+/// than the counter its callers actually need.
+/// <para>Every run member increments the SAME <see cref="Calls"/> counter, because the assertions it serves
+/// ask "did anything run at all", not which overload stayed untouched. <see cref="RaiseLine"/> and
+/// <see cref="RaiseProgress"/> exist because two of the seams under test are pure pass-throughs
+/// (<c>WingetService.LineReceived</c> forwards add/remove straight to the runner), and the only way to see a
+/// pass-through work is to raise the far end and watch the near end fire.</para>
+/// </remarks>
+internal sealed class RecordingRunner : IPowerShellRunner
+{
+    /// <summary>How many times the view-model or service asked for something to be executed.</summary>
+    public int Calls { get; private set; }
+
+    public event Action<PowerShellLine>? LineReceived;
+
+    public event Action<int>? ProgressChanged;
+
+    /// <summary>Push a line through as the real runner's reader threads would.</summary>
+    public void RaiseLine(PowerShellLine line) => LineReceived?.Invoke(line);
+
+    /// <summary>Push a 0-100 progress reading through.</summary>
+    public void RaiseProgress(int percent) => ProgressChanged?.Invoke(percent);
+
+    public Task<Collection<PSObject>> RunAsync(string script,
+                                               IDictionary<string, object?>? parameters = null,
+                                               CancellationToken cancellationToken = default)
+    {
+        Calls++;
+        return Task.FromResult(new Collection<PSObject>());
+    }
+
+    public Task<int> RunScriptViaPwshAsync(string script, CancellationToken cancellationToken = default)
+    {
+        Calls++;
+        return Task.FromResult(0);
+    }
+
+    public Task<int> RunProcessAsync(string fileName, string arguments,
+                                     CancellationToken cancellationToken = default,
+                                     Encoding? outputEncoding = null)
+    {
+        Calls++;
+        return Task.FromResult(0);
+    }
+
+    public Task<int> RunProcessWithShellAsync(string fileName, string arguments,
+                                              CancellationToken cancellationToken = default)
+    {
+        Calls++;
+        return Task.FromResult(0);
+    }
+}

--- a/SysManager/SysManager.IntegrationTests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/WindowsUpdateViewModelTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.Reflection;
+using SysManager.Helpers;
 using SysManager.Services;
 using SysManager.ViewModels;
 
@@ -10,6 +11,26 @@ namespace SysManager.IntegrationTests;
 
 public class WindowsUpdateViewModelTests
 {
+    /// <summary>A dialog that counts prompts instead of showing them, and always answers no.</summary>
+    private sealed class RecordingDialog : IDialogService
+    {
+        public int Prompts { get; private set; }
+
+        public bool Confirm(string message, string title)
+        {
+            Prompts++;
+            return false;
+        }
+
+        public CloseChoice AskCloseOrMinimize(string message, string title)
+        {
+            Prompts++;
+            return CloseChoice.Cancel;
+        }
+
+        public void Inform(string message, string title) => Prompts++;
+    }
+
     private static WindowsUpdateViewModel NewVm() => new(new PowerShellRunner(), new WindowsUpdateService(), new WindowsUpdatePolicyService());
 
     // ---------- construction ----------
@@ -89,26 +110,60 @@ public class WindowsUpdateViewModelTests
 
     // ---------- elevation gates ----------
 
+    /// <summary>
+    /// Elevated, installing the module is REFUSED and the reason is stated.
+    /// </summary>
+    /// <remarks>
+    /// The gate here runs the other way round from the rest of the tab: PSWindowsUpdate belongs in the
+    /// per-user module path, so an elevated session must not install it.
+    /// <para>This test was called <c>InstallModule_WhenNotElevated_SetsStatusMessage</c> and skipped itself
+    /// when elevated, which means it only ever ran the branch that PROCEEDS — calling a real
+    /// <c>PowerShellRunner</c> to install a PowerShell module on whoever ran it. It then asserted
+    /// <c>ex == null || ex is NullReferenceException</c>, which no behaviour can fail. The runner is a
+    /// substitute now, and the assertion is that nothing was run.</para>
+    /// </remarks>
     [Fact]
-    public async Task InstallModule_WhenNotElevated_SetsStatusMessage()
+    public async Task InstallModule_WhenElevated_RefusesAndSaysWhy()
     {
-        var vm = NewVm();
-        if (vm.IsElevated) return;
+        using var elevated = AdminHelper.ForceElevation(true);
+        var runner = new RecordingRunner();
+        var vm = new WindowsUpdateViewModel(runner, new WindowsUpdateService(), new WindowsUpdatePolicyService());
 
-        var ex = await Record.ExceptionAsync(() => vm.InstallModuleCommand.ExecuteAsync(null));
-        // May throw NRE if RelaunchAsAdmin succeeds but Application.Current is null in test.
-        // Either way, StatusMessage should have been set before the throw.
-        Assert.True(ex == null || ex is NullReferenceException);
+        await vm.InstallModuleCommand.ExecuteAsync(null);
+
+        Assert.Contains("non-administrator", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.False(vm.IsBusy);
+        Assert.Equal(0, runner.Calls);
     }
 
+    /// <summary>
+    /// With nothing selected, installing updates stops before it asks anything.
+    /// </summary>
+    /// <remarks>
+    /// The old version of this asserted the same "null or NRE" as the one above. The first thing
+    /// <c>InstallUpdatesAsync</c> does is count the selected rows, so with an empty list the honest assertion
+    /// is that it says so and never reaches the confirmation dialog — which also means the test cannot
+    /// accidentally start an install.
+    /// </remarks>
     [Fact]
-    public async Task InstallUpdates_WhenNotElevated_SetsStatusMessage()
+    public async Task InstallUpdates_WithNothingSelected_StopsBeforeConfirming()
     {
-        var vm = NewVm();
-        if (vm.IsElevated) return;
+        var runner = new RecordingRunner();
+        var vm = new WindowsUpdateViewModel(runner, new WindowsUpdateService(), new WindowsUpdatePolicyService());
+        Assert.Empty(vm.Updates);
 
-        var ex = await Record.ExceptionAsync(() => vm.InstallUpdatesCommand.ExecuteAsync(null));
-        Assert.True(ex == null || ex is NullReferenceException);
+        var previous = DialogService.Instance;
+        var dialog = new RecordingDialog();
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.InstallUpdatesCommand.ExecuteAsync(null);
+
+            Assert.Equal("No updates selected.", vm.StatusMessage);
+            Assert.Equal(0, dialog.Prompts);
+            Assert.Equal(0, runner.Calls);
+        }
+        finally { DialogService.Instance = previous; }
     }
 
     // ---------- runner plumbing ----------

--- a/SysManager/SysManager.Tests/AdminHelperTests.cs
+++ b/SysManager/SysManager.Tests/AdminHelperTests.cs
@@ -11,6 +11,8 @@ namespace SysManager.Tests;
 /// Tests for <see cref="AdminHelper"/>. These are safe to run on CI
 /// (non-admin) and on dev boxes (admin or not).
 /// </summary>
+// Serialized: the ForceElevation tests replace AdminHelper's elevation probe.
+[Collection("ProcessWideStatics")]
 public class AdminHelperTests
 {
     [Fact]
@@ -23,6 +25,66 @@ public class AdminHelperTests
         var a = AdminHelper.IsElevated();
         var b = AdminHelper.IsElevated();
         Assert.Equal(a, b);
+    }
+
+    /// <summary>
+    /// A forced scope decides what <see cref="AdminHelper.IsElevated"/> answers, and disposing it puts the
+    /// real probe back.
+    /// </summary>
+    /// <remarks>
+    /// This is the contract every other elevation test leans on, and nothing else can observe it. A leaked
+    /// override is invisible to the tests that use one, because each forces its own value first, and
+    /// invisible to the tests that compare a view-model against <c>IsElevated()</c>, because both sides read
+    /// the same leaked probe and therefore still agree. So the restore has to be asserted here or nowhere:
+    /// making <c>ElevationScope.Dispose</c> a no-op left the whole suite green until this test existed.
+    /// </remarks>
+    [Fact]
+    public void ForceElevation_DecidesTheAnswer_AndRestoresTheRealProbeOnDispose()
+    {
+        var real = AdminHelper.IsElevated();
+
+        using (AdminHelper.ForceElevation(true))
+            Assert.True(AdminHelper.IsElevated());
+
+        Assert.Equal(real, AdminHelper.IsElevated());
+
+        using (AdminHelper.ForceElevation(false))
+            Assert.False(AdminHelper.IsElevated());
+
+        Assert.Equal(real, AdminHelper.IsElevated());
+    }
+
+    /// <summary>
+    /// Nested scopes restore the ENCLOSING value, not the real probe.
+    /// </summary>
+    /// <remarks>
+    /// Restoring the default instead of the previous probe would look correct in every single-scope test and
+    /// break only where one forced test calls a helper that forces again — the case that is hardest to
+    /// debug, because the outer scope silently stops applying halfway through its own body.
+    /// <para>Both directions, and that is not symmetry for its own sake. With only the true-outside-false
+    /// nesting, a <c>Dispose</c> that restored the real probe would still satisfy the outer assertion on an
+    /// elevated host, so the test would pin the contract on a developer's box and pass vacuously on CI.
+    /// Running the mirror too means one of the two outer assertions contradicts the real probe whichever
+    /// way the host happens to be.</para>
+    /// </remarks>
+    [Fact]
+    public void ForceElevation_Nested_RestoresTheEnclosingScope_NotTheRealProbe()
+    {
+        using (AdminHelper.ForceElevation(true))
+        {
+            using (AdminHelper.ForceElevation(false))
+                Assert.False(AdminHelper.IsElevated());
+
+            Assert.True(AdminHelper.IsElevated());
+        }
+
+        using (AdminHelper.ForceElevation(false))
+        {
+            using (AdminHelper.ForceElevation(true))
+                Assert.True(AdminHelper.IsElevated());
+
+            Assert.False(AdminHelper.IsElevated());
+        }
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -183,6 +183,11 @@ public partial class ArchitectureTests
     /// reading the source also catches a class that touches the static inside a helper, and the same
     /// approach is already used for the destructive-op logging guard in ActivityLogServiceTests.
     /// </para>
+    /// <para>
+    /// <c>AdminHelper.ForceElevation</c> was added as a row the same day the seam itself was: it replaces
+    /// the elevation probe for the whole process, so a class that forgets the attribute would answer
+    /// "not elevated" to a test in the parallel group that is asserting the elevated branch.
+    /// </para>
     /// </remarks>
     [Fact]
     public void ProcessWideStaticUsers_AreInTheSerializedCollection()
@@ -194,6 +199,7 @@ public partial class ArchitectureTests
             ("DialogService.Instance =", "DialogService.Instance"),
             ("new DialogAnswer(", "DialogService.Instance (via the DialogAnswer helper)"),
             ("OperationLockService.Instance", "OperationLockService.Instance"),
+            ("AdminHelper.ForceElevation(", "AdminHelper.ElevationProbe"),
         ];
 
         var testDir = FindTestSourceDirectory();
@@ -520,6 +526,72 @@ public partial class ArchitectureTests
             + "A bounded Task.WhenAny(work, Task.Delay(...)) timeout is fine and is not matched here:\n  "
             + string.Join("\n  ", offenders));
     }
+
+    /// <summary>
+    /// No test may skip itself because the session happens to be elevated.
+    /// </summary>
+    /// <remarks>
+    /// Sixteen cases across all three test projects opened with a variant of
+    /// <c>if (AdminHelper.IsElevated()) return;</c>, added so an elevated host would not report a false
+    /// failure. The CI runner IS elevated and the main workstation cannot run the suite at all, so the
+    /// elevation gate on SFC, DISM, Windows Update, precise bandwidth mode and the nine privileged tabs
+    /// asserted nothing anywhere. <c>EtwBandwidthSourceTests</c> even said so in a comment: "elevated CI
+    /// runner: the negative path is moot".
+    /// <para>The replacement is <c>AdminHelper.ForceElevation(bool)</c>, which pins the answer for the
+    /// scope's lifetime and restores it on dispose, so the negative branch is reachable on any host. A test
+    /// that genuinely has both behaviours to describe asserts BOTH, the way
+    /// <c>UninstallerUiTests.CurrentSession_ShowsMatchingGuidanceWithoutAdminRelaunchButton</c> picks the
+    /// expected copy from the current integrity level instead of returning early.</para>
+    /// <para>Comment lines are stripped first, because two of the rewritten tests quote the forbidden line
+    /// in their own remarks to explain what they replaced — matching those would fail the guard on the files
+    /// that got it right. Whitespace is collapsed because the original offender spread the <c>if</c> and its
+    /// <c>return</c> across two lines, which a per-line scan cannot see. A positive control asserts the
+    /// pattern still matches a known-bad string, so a regex that silently stops matching cannot read as
+    /// health.</para>
+    /// </remarks>
+    [Fact]
+    public void NoTestSkipsItselfBecauseTheSessionIsElevated()
+    {
+        // The needle must not appear literally in this file, which is one of the files scanned.
+        var skip = ElevationSelfSkip();
+        Assert.Matches(skip, "if (Helpers.AdminHelper." + "IsElevated()) return;");
+        Assert.Matches(skip, "if (!vm." + "IsElevated) return;");
+        Assert.DoesNotMatch(skip, "var elevated = AdminHelper." + "IsElevated();");
+
+        var root = FindRepoRoot();
+        var offenders = new List<string>();
+        var scanned = 0;
+
+        foreach (var project in new[] { "SysManager.Tests", "SysManager.IntegrationTests", "SysManager.UITests" })
+        {
+            var dir = Path.Combine(root, "SysManager", project);
+            Assert.True(Directory.Exists(dir), $"{dir} not found — this guard would pass vacuously");
+
+            foreach (var file in Directory.GetFiles(dir, "*.cs"))
+            {
+                if (Path.GetFileName(file) == "ArchitectureTests.cs") continue;   // this file, prose and all
+
+                scanned++;
+                var code = string.Join(" ", File.ReadAllLines(file).Where(IsCode).Select(l => l.Trim()));
+                foreach (var hit in skip.Matches(Collapse(code)).Cast<Match>())
+                    offenders.Add($"{Path.GetFileName(file)}  {hit.Value}");
+            }
+        }
+
+        Assert.True(scanned >= 200,
+            $"only {scanned} test source files were scanned across the three projects — the lookup is wrong "
+            + "and this guard is reading almost nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "These tests return early when the session is elevated, so on an elevated host — which the CI "
+            + "runner is — they assert nothing. Pin the value instead: "
+            + "using var notElevated = AdminHelper.ForceElevation(false); and build the view-model INSIDE "
+            + "the scope, because view-models read elevation once in their constructor. If the test has two "
+            + "real behaviours, assert both rather than skipping one:\n  " + string.Join("\n  ", offenders));
+    }
+
+    [GeneratedRegex(@"if \(!?[A-Za-z0-9_.]*IsElevated(\(\))?\) ?return ?;", RegexOptions.Compiled)]
+    private static partial Regex ElevationSelfSkip();
 
     /// <summary>
     /// An audio route SysManager cannot read must be shown as unknown, not as the system default.

--- a/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BandwidthMonitorViewModelTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.IO;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
@@ -15,6 +16,8 @@ namespace SysManager.Tests;
 /// factories are injected so no live network stack or ETW session is touched; a fake source returns
 /// deterministic snapshots.
 /// </summary>
+// Serialized: the three PreciseRequested tests replace AdminHelper's elevation probe.
+[Collection("ProcessWideStatics")]
 public class BandwidthMonitorViewModelTests : IDisposable
 {
     private readonly string _dir;
@@ -145,32 +148,71 @@ public class BandwidthMonitorViewModelTests : IDisposable
         Assert.False(vm.HasAlert);
     }
 
+    /// <summary>
+    /// Not elevated, requesting precise mode is refused even though the ETW source reports available.
+    /// </summary>
+    /// <remarks>
+    /// The body used to sit inside <c>if (!vm.IsElevated)</c> with the comment "on the test agent
+    /// AdminHelper.IsElevated() is almost always false" — so on the elevated CI runner it asserted nothing.
+    /// The scope wraps <c>NewVm</c> because the view-model reads elevation once, in its constructor.
+    /// <para>Two guards stand between the request and an ETW session: the property-changed handler refuses
+    /// and returns, and <c>StartSource</c> checks again in case precise mode was already requested when the
+    /// source is rebuilt for another reason. The status message is what distinguishes them — reaching the
+    /// second guard would leave <c>PreciseMode</c> false but say nothing to the user, so asserting the
+    /// message pins the first one specifically.</para>
+    /// </remarks>
     [Fact]
     public void PreciseRequested_WhenNotElevated_DoesNotEnterPreciseMode()
     {
-        // The ETW factory would report available, but a non-elevated process must not use it.
-        // On the test agent AdminHelper.IsElevated() is almost always false; assert the guard holds
-        // by checking we stayed in connection mode after requesting precise.
+        using var notElevated = AdminHelper.ForceElevation(false);
         var vm = NewVm(etwFactory: () => new FakeSource(BandwidthMode.PreciseEtw, available: true));
-
-        if (!vm.IsElevated)
-        {
-            vm.PreciseRequested = true;
-            Assert.False(vm.PreciseMode); // guard kept us on the safe source
-        }
-    }
-
-    [Fact]
-    public void PreciseRequested_FallsBackToConnections_WhenEtwCannotStart()
-    {
-        // Model an elevated-but-ETW-unavailable host: the ETW source's Start() returns false, so the
-        // VM must fall back to the connection source rather than showing precise mode.
-        var vm = NewVm(etwFactory: () => new FakeSource(BandwidthMode.PreciseEtw, available: false));
+        Assert.False(vm.IsElevated, "the scope must reach the view-model's constructor");
 
         vm.PreciseRequested = true;
 
-        // Regardless of elevation, an unavailable ETW source can never flip PreciseMode on.
+        Assert.False(vm.PreciseMode);   // the guard kept us on the safe source
+        Assert.Contains("needs administrator", vm.ModeDescription, StringComparison.Ordinal);
+        Assert.Contains("Run as administrator", vm.StatusMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Elevated but with an ETW session that will not start, the view-model falls back to connections.
+    /// </summary>
+    /// <remarks>
+    /// Pinning elevation is what makes this test its own name. Without it, a developer box refuses at the
+    /// elevation gate and never reaches the availability check, so the assertion passes for the wrong
+    /// reason and the fallback path is covered nowhere.
+    /// </remarks>
+    [Fact]
+    public void PreciseRequested_FallsBackToConnections_WhenEtwCannotStart()
+    {
+        using var elevated = AdminHelper.ForceElevation(true);
+        var vm = NewVm(etwFactory: () => new FakeSource(BandwidthMode.PreciseEtw, available: false));
+        Assert.True(vm.IsElevated, "the scope must reach the view-model's constructor");
+
+        vm.PreciseRequested = true;
+
         Assert.False(vm.PreciseMode);
+        Assert.Contains("needs administrator", vm.ModeDescription, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Elevated with a working ETW session, precise mode is what the user gets.
+    /// </summary>
+    /// <remarks>
+    /// The positive case had no test: both of the two above assert <c>PreciseMode</c> is false, so a
+    /// view-model that never entered precise mode at all would have satisfied the pair.
+    /// </remarks>
+    [Fact]
+    public void PreciseRequested_WhenElevatedAndEtwStarts_EntersPreciseMode()
+    {
+        using var elevated = AdminHelper.ForceElevation(true);
+        var vm = NewVm(etwFactory: () => new FakeSource(BandwidthMode.PreciseEtw, available: true));
+
+        vm.PreciseRequested = true;
+
+        Assert.True(vm.PreciseMode);
+        Assert.Contains("live kernel trace", vm.ModeDescription, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/CleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CleanupViewModelTests.cs
@@ -195,14 +195,18 @@ public class CleanupViewModelTests
 
     // ---------- elevation gate on SFC / DISM ----------
 
+    // Both of these used to open with `if (vm.IsElevated) return;` — a skip so an elevated host would not
+    // report a false failure. The CI runner IS elevated, and this workstation cannot run the suite, so the
+    // skip meant the elevation gate on SFC and DISM was asserted nowhere at all. AdminHelper.ForceElevation
+    // states the condition instead, and the view-model is built INSIDE the scope because it caches
+    // IsElevated in its constructor.
+
     [Fact]
     public async Task RunSfc_WhenNotElevated_SetsRequiresAdminMessageAndClearsRunning()
     {
+        using var notElevated = AdminHelper.ForceElevation(false);
         var vm = NewVm();
-        // Only meaningful when the test host is non-admin, which is the
-        // normal developer / CI case. If someone runs the test elevated,
-        // we skip the branch we care about.
-        if (vm.IsElevated) return;
+        Assert.False(vm.IsElevated, "the scope must reach the view-model's constructor");
 
         await vm.RunSfcCommand.ExecuteAsync(null);
 
@@ -214,14 +218,38 @@ public class CleanupViewModelTests
     [Fact]
     public async Task RunDism_WhenNotElevated_SetsRequiresAdminMessageAndClearsRunning()
     {
+        using var notElevated = AdminHelper.ForceElevation(false);
         var vm = NewVm();
-        if (vm.IsElevated) return;
+        Assert.False(vm.IsElevated, "the scope must reach the view-model's constructor");
 
         await vm.RunDismCommand.ExecuteAsync(null);
 
         Assert.Contains("admin", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
         Assert.False(vm.IsDismRunning);
         Assert.False(vm.IsAnyRunning);
+    }
+
+    /// <summary>
+    /// And the mirror image: elevated, the guard must let the command through to the runner.
+    /// </summary>
+    /// <remarks>
+    /// The negative test alone cannot tell a working gate from a command that refuses unconditionally. With
+    /// elevation forced on, SFC must get past the gate and launch <c>sfc.exe /scannow</c> through the runner
+    /// — asserted on the substitute, so nothing actually runs.
+    /// </remarks>
+    [Fact]
+    public async Task RunSfc_WhenElevated_ReachesTheRunner()
+    {
+        using var elevated = AdminHelper.ForceElevation(true);
+        var runner = Substitute.For<IPowerShellRunner>();
+        var vm = new CleanupViewModel(runner, Substitute.For<ICleanupPreScanService>());
+        Assert.True(vm.IsElevated);
+
+        await vm.RunSfcCommand.ExecuteAsync(null);
+
+        Assert.DoesNotContain("admin", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        await runner.Received(1).RunProcessAsync(
+            "sfc.exe", "/scannow", Arg.Any<CancellationToken>(), Arg.Any<System.Text.Encoding?>());
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/EtwBandwidthSourceTests.cs
+++ b/SysManager/SysManager.Tests/EtwBandwidthSourceTests.cs
@@ -18,6 +18,8 @@ namespace SysManager.Tests;
 /// real elevated session, the latter lives in <c>BandwidthFormat</c> and is tested in
 /// <see cref="BandwidthFormatTests"/>.</para>
 /// </summary>
+// Serialized: Start_WithoutAdministrator_RefusesCleanly replaces AdminHelper's elevation probe.
+[Collection("ProcessWideStatics")]
 public class EtwBandwidthSourceTests
 {
     /// <summary>
@@ -202,15 +204,23 @@ public class EtwBandwidthSourceTests
         Assert.Equal(7_000, row.TotalDownBytes);
     }
 
+    /// <summary>
+    /// Not elevated, <c>Start</c> refuses cleanly instead of throwing.
+    /// </summary>
+    /// <remarks>
+    /// The whole fallback story depends on it: the view-model reads <c>IsAvailable</c> and silently uses the
+    /// no-admin source instead.
+    /// <para>Used to open with <c>if (AdminHelper.IsElevated()) return;</c> and the comment "elevated CI
+    /// runner: the negative path is moot" — which was the clearest statement anywhere that this assertion ran
+    /// on no machine at all. <c>Start</c> asks <c>AdminHelper.IsElevated()</c> before it touches TraceEvent,
+    /// so forcing the probe is enough to reach the branch on any host.</para>
+    /// </remarks>
     [Fact]
     public void Start_WithoutAdministrator_RefusesCleanly()
     {
-        // The whole fallback story depends on this returning false rather than throwing: the ViewModel
-        // reads IsAvailable and silently uses the no-admin source instead.
+        using var notElevated = Helpers.AdminHelper.ForceElevation(false);
         var clock = new TestClock();
         using var src = new EtwBandwidthSource(clock);
-
-        if (Helpers.AdminHelper.IsElevated()) return;   // elevated CI runner: the negative path is moot
 
         Assert.False(src.Start());
         Assert.False(src.IsAvailable);

--- a/SysManager/SysManager.UITests/AdminBannerUiTests.cs
+++ b/SysManager/SysManager.UITests/AdminBannerUiTests.cs
@@ -5,12 +5,13 @@
 namespace SysManager.UITests;
 
 /// <summary>
-/// Regression net for the elevation-banner uniformity work: every tab that
-/// performs admin-gated actions must surface the shared "requires administrator"
-/// banner when the app is NOT elevated. The UI test host runs the app
-/// non-elevated, so the not-elevated banner variant is the one in view. If a
-/// future refactor drops the banner from one of these tabs (as had happened to
-/// six of them), the corresponding case fails by name.
+/// Regression net for the elevation-banner uniformity work: every tab that performs admin-gated actions
+/// must surface an elevation banner, and the variant shown must match the session. If a future refactor
+/// drops the banner from one of these tabs (as had happened to six of them), the corresponding case fails
+/// by name.
+/// <para>Which variant is in view depends on the host: the CI runner is elevated, a developer's box
+/// usually is not, and the app inherits the test process's integrity level because <c>AppFixture</c>
+/// launches it with <c>UseShellExecute = false</c>.</para>
 /// </summary>
 [Collection("App")]
 public class AdminBannerUiTests
@@ -34,20 +35,30 @@ public class AdminBannerUiTests
         new object[] { "nav-gaming-profile" },
     };
 
+    /// <summary>
+    /// Each privileged tab shows the elevation banner that matches the session it is running in.
+    /// </summary>
+    /// <remarks>
+    /// This used to open with <c>if (Helpers.AdminHelper.IsElevated()) return;</c> — a silent skip so an
+    /// elevated session would not report a false failure. On the CI runner, which IS elevated, that meant
+    /// all nine cases returned before reaching the tab: nine green rows asserting nothing. Every tab has
+    /// both banner variants, so there is nothing to skip; asserting the one that belongs to the current
+    /// integrity level covers both hosts, and it is the shape
+    /// <c>UninstallerUiTests.CurrentSession_ShowsMatchingGuidanceWithoutAdminRelaunchButton</c> already uses.
+    /// <para>The elevated variant carries "Running as administrator" in all nine views; only the clause
+    /// after it differs per tab, so the shared prefix is what to wait for.</para>
+    /// </remarks>
     [Theory]
     [MemberData(nameof(PrivilegedTabs))]
-    public void PrivilegedTab_ShowsAdminBanner_WhenNotElevated(string navId)
+    public void PrivilegedTab_ShowsTheElevationBannerForTheCurrentSession(string navId)
     {
-        // Guard: this assertion is only meaningful when the test host is NOT
-        // elevated (the banner's not-elevated variant is what carries the
-        // "requires administrator" phrase). If the suite is ever run elevated,
-        // skip rather than report a false failure.
-        if (Helpers.AdminHelper.IsElevated())
-            return;
-
         _fx.GoToTab(navId);
+
+        var elevated = Helpers.AdminHelper.IsElevated();
+        var expected = elevated ? "Running as administrator" : "requires administrator";
         Assert.True(
-            _fx.HasAdminBanner(),
-            $"Privileged tab '{navId}' did not show the 'requires administrator' banner when not elevated.");
+            _fx.HasText(expected),
+            $"Privileged tab '{navId}' showed no elevation banner for the current integrity level "
+            + $"(elevated: {elevated}). Expected to find: \"{expected}\".");
     }
 }

--- a/SysManager/SysManager.UITests/AppFixture.cs
+++ b/SysManager/SysManager.UITests/AppFixture.cs
@@ -241,14 +241,6 @@ public sealed class AppFixture : IDisposable
         => WaitForTextInCurrentTab(text, timeoutSeconds) is not null;
 
     /// <summary>
-    /// True when the current tab shows the shared "requires administrator"
-    /// elevation banner (the not-elevated variant carries that phrase). Used to
-    /// assert that privileged tabs surface the banner when the app is not elevated.
-    /// </summary>
-    public bool HasAdminBanner(int timeoutSeconds = 5)
-        => WaitForText("requires administrator", timeoutSeconds) is not null;
-
-    /// <summary>
     /// Count Button controls currently realized anywhere in the window. A crude
     /// but useful smoke signal that a tab rendered its action surface rather than
     /// an empty/crashed view.

--- a/SysManager/SysManager/Helpers/AdminHelper.cs
+++ b/SysManager/SysManager/Helpers/AdminHelper.cs
@@ -13,7 +13,51 @@ namespace SysManager.Helpers;
 /// </summary>
 public static class AdminHelper
 {
-    public static bool IsElevated()
+    /// <summary>
+    /// How elevation is decided. Production never replaces it; a test does, so the not-elevated branch can
+    /// be asserted on any host.
+    /// </summary>
+    /// <remarks>
+    /// A seam here rather than 65 constructor parameters: <c>IsElevated()</c> has that many call sites, and
+    /// they are not all in view-models — <c>ServiceRegistration</c>, <c>EtwBandwidthSource</c> and
+    /// <c>TemperatureService</c> ask too. Threading a provider through all of them would be a large diff for
+    /// a value that is fixed for the life of the process.
+    /// <para>The reason it is needed: sixteen test cases opened with <c>if (IsElevated) return;</c> so they
+    /// would not report a false failure on an elevated host — and the CI runner IS elevated, which
+    /// <c>EtwBandwidthSourceTests</c> states in a comment. The result was that the elevation gate on SFC,
+    /// DISM, Windows Update and nine privileged tabs asserted nothing anywhere: not on CI, and not on a
+    /// workstation that cannot run the suite.</para>
+    /// <para>Process-wide mutable state, so a test that replaces it belongs in the
+    /// <c>ProcessWideStatics</c> collection and must restore it — <see cref="ForceElevation"/> does both.
+    /// Same shape as <c>DialogService.Instance</c>, which tests already swap this way.</para>
+    /// </remarks>
+    internal static Func<bool> ElevationProbe { get; set; } = QueryElevation;
+
+    public static bool IsElevated() => ElevationProbe();
+
+    /// <summary>
+    /// Pins <see cref="IsElevated"/> to <paramref name="elevated"/> until the returned scope is disposed.
+    /// </summary>
+    /// <remarks>
+    /// Restores the previous probe rather than the default one, so nesting cannot leave a stale override
+    /// behind — and restoring is what makes the override safe to use beside tests that read real elevation.
+    /// </remarks>
+    internal static IDisposable ForceElevation(bool elevated) => new ElevationScope(elevated);
+
+    private sealed class ElevationScope : IDisposable
+    {
+        private readonly Func<bool> _previous;
+
+        internal ElevationScope(bool elevated)
+        {
+            _previous = ElevationProbe;
+            ElevationProbe = () => elevated;
+        }
+
+        public void Dispose() => ElevationProbe = _previous;
+    }
+
+    private static bool QueryElevation()
     {
         using var identity = WindowsIdentity.GetCurrent();
         var principal = new WindowsPrincipal(identity);

--- a/TESTING.md
+++ b/TESTING.md
@@ -101,11 +101,11 @@ collection definitions (all defined in `TestCollections.cs`, each with
 `DisableParallelization = true`):
 
 - `[Collection("ProcessWideStatics")]` — tests that touch **any** process-wide static: swapping
-  `DialogService.Instance`, or acquiring `OperationLockService.Instance`. This was once two
-  collections, `"DialogService"` and `"OperationLock"`, and the split was itself the defect: two
-  *different* serialized collections still run in parallel **with each other**, so a test swapping
-  the dialog could race a test holding the lock. xUnit allows one collection per class, so the fix
-  was to merge them. This is the collection most of the suite uses.
+  `DialogService.Instance`, acquiring `OperationLockService.Instance`, or pinning elevation with
+  `AdminHelper.ForceElevation`. This was once two collections, `"DialogService"` and `"OperationLock"`,
+  and the split was itself the defect: two *different* serialized collections still run in parallel
+  **with each other**, so a test swapping the dialog could race a test holding the lock. xUnit allows
+  one collection per class, so the fix was to merge them. This is the collection most of the suite uses.
 - `[Collection("ProcessEnvironment")]` — tests that mutate the process's environment variables.
 - `[Collection("IconCache")]` — tests touching the shared icon cache.
 - `[Collection("Network")]` — tests using ICMP sockets. Defined here, but currently used only by
@@ -119,9 +119,31 @@ collection definitions (all defined in `TestCollections.cs`, each with
   *not* shown — asserting the side effect alone cannot distinguish "the user said yes" from
   "no gate ran at all". Requires `[Collection("ProcessWideStatics")]` on the test class — a fitness
   function in `ArchitectureTests` fails the build if a class swaps a process-wide static without it.
+- `AdminHelper.ForceElevation(bool)` — pins what `AdminHelper.IsElevated()` answers for the scope's
+  lifetime and restores the previous probe on dispose: `using var notElevated =
+  AdminHelper.ForceElevation(false);`. **Construct the view-model inside the scope** — view-models read
+  elevation once, in their constructor, so a scope opened afterwards changes nothing they will look at.
+  Requires `[Collection("ProcessWideStatics")]`.
 - `SyncProgress<T>` — a synchronous `IProgress<T>` that records reports on the calling thread, so
   progress assertions need no `Task.Delay`.
 - `StaHelper` — runs a delegate on an STA thread for WPF-dependent types.
+
+### Testing an admin-gated path
+
+Never skip the assertion on an elevated host. Sixteen cases used to open with a variant of
+`if (AdminHelper.IsElevated()) return;`, added so an elevated machine would not report a false failure —
+but the CI runner *is* elevated and the primary workstation cannot run the suite at all, so the elevation
+gate on SFC, DISM, Windows Update, precise bandwidth mode and the nine privileged tabs asserted nothing
+anywhere. Pin the value with `ForceElevation` instead, and assert both sides: the negative test alone
+cannot tell a working gate from a command that refuses unconditionally.
+
+Where a screen genuinely has two behaviours rather than one gate — a UI test, say, where the app inherits
+the test process's integrity level — pick the expected copy from the current level rather than returning
+early. `UninstallerUiTests.CurrentSession_ShowsMatchingGuidanceWithoutAdminRelaunchButton` and
+`AdminBannerUiTests.PrivilegedTab_ShowsTheElevationBannerForTheCurrentSession` both do this.
+
+`ArchitectureTests.NoTestSkipsItselfBecauseTheSessionIsElevated` fails the build if the skip comes back,
+across all three test projects.
 
 ### Dependency-graph validation
 


### PR DESCRIPTION
Closes #2102

## Problem

Fifteen test cases across all three test projects opened with a variant of `if (AdminHelper.IsElevated()) return;`, added so an elevated host would not report a false failure. The CI runner is elevated and the primary workstation cannot run the suite at all, so the elevation gate on SFC, DISM, Windows Update, precise bandwidth mode and the nine privileged tabs asserted nothing anywhere. `EtwBandwidthSourceTests` stated it in a comment: "elevated CI runner: the negative path is moot".

The issue's table said sixteen and listed four sites totalling fourteen. Re-derived from current source it is **fifteen** skip cases — the table omitted `BandwidthMonitorViewModelTests.PreciseRequested_WhenNotElevated_DoesNotEnterPreciseMode`, and the sixteenth item was the separately-described assertion-free `WingetService_EventForwardingWorks`.

## The seam

`AdminHelper.ElevationProbe` is now the single source the whole app reads, including the command guards, and `ForceElevation(bool)` pins it for a scope and restores the **previous** probe on dispose. A seam rather than 65 constructor parameters: `IsElevated()` has that many call sites and they are not all in view-models — `ServiceRegistration`, `EtwBandwidthSource` and `TemperatureService` ask too, for a value that is fixed for the life of the process. Same shape as `DialogService.Instance`, which tests already swap.

This also closes the "asks twice" complaint in the issue: `CleanupViewModel` seeds an `IsElevated` property in its constructor *and* the commands call the static again, and both now route through the one probe.

## What the tests assert now

| Area | Before | After |
|---|---|---|
| Cleanup | SFC + DISM skipped when elevated | both refuse without admin, **and** SFC reaches the runner with admin |
| Bandwidth Monitor | precise-mode negative case skipped | refused when not elevated, falls back when ETW will not start, **and** engages when both hold |
| ETW source | skipped when elevated | `Start` refuses cleanly without administrator |
| Windows Update (integration) | 2 cases skipped when elevated | the module install refuses **when elevated**, which is the direction that gate runs |
| Admin banner UI theory | 9 cases returned early | asserts the banner variant belonging to the current integrity level |

Two of these were worse than "asserts nothing":

- `InstallModule_WhenNotElevated_SetsStatusMessage` skipped on an elevated host, so it only ever ran the branch that **proceeds** — calling a real `PowerShellRunner` to install a PowerShell module on whoever ran it. It then asserted `ex == null || ex is NullReferenceException`, which no behaviour can fail.
- `PreciseRequested_FallsBackToConnections_WhenEtwCannotStart` was not skipped, but on any non-elevated box it never reached the availability check its name describes: the elevation gate refused first. Pinning elevation is what makes it its own test.

`WingetService_EventForwardingWorks` asserted nothing at all — it fetched a `FieldInfo`, discarded it, and ended with `_ = gotLine;` under a comment saying the path "requires a running session". It now raises a line on a recording runner and asserts it reaches the service's subscribers, and that unsubscribing stops it. Those pass-through `add`/`remove` accessors are the whole behaviour worth pinning: a service that swallowed the subscription would leave the App Updates console permanently blank with every other assertion green.

The recording runner is hand-rolled rather than substituted because `SysManager.IntegrationTests` does not reference NSubstitute, and pulling a second mocking dependency in — plus the row it would need in TESTING.md's framework table — is a larger change than a counter for three tests.

## Mechanical enforcement

- **`NoTestSkipsItselfBecauseTheSessionIsElevated`** fails the build on the skip, across all three test projects. Comments are stripped, because two rewritten tests quote the forbidden line while explaining what they replaced; whitespace is collapsed, because the original offender spread the `if` and its `return` over two lines, which a per-line scan cannot see; and a positive control asserts the pattern still matches known-bad text, so a regex that silently stops matching cannot read as health.
- **`ProcessWideStaticUsers_AreInTheSerializedCollection`** gained a row for `ForceElevation`, so a class that pins elevation without joining the serialized collection is named by the failure message.

## Red/green

Nine mutations, each behaving as claimed:

| Mutation | Expected | Result |
|---|---|---|
| Invert the real `QueryElevation` probe | every forced test unaffected (10/10), both ambient comparisons unaffected (2/2) | PASS |
| `ElevationScope.Dispose` → no-op | both new `AdminHelperTests` red | PASS |
| `Dispose` restores the **default** probe | the nesting test red | PASS |
| Invert the SFC gate | the elevated test red | PASS |
| Reword the SFC refusal | SFC red, DISM (untouched) green | PASS |
| Remove the precise-mode setter refusal | negative test red on its status message | PASS |
| Remove the `StartSource` backstop too | `PreciseMode` itself flips | PASS |
| `WingetService.LineReceived` swallows the subscription | red | PASS |
| Remove the new `[Collection]` attribute | the guard names the class | PASS |

Plus three on the new guard: reintroducing the skip in its two-line form (UI project) and its one-line form (integration project) each turns it red and names the file; the same text inside a comment leaves it green.

Two of these mutations were findings rather than confirmations, and both changed the code:

- The `Dispose` no-op left the **entire** suite green. Nothing could observe the restore: every test that uses a scope forces its own value first, and the tests that compare a view-model against `IsElevated()` read the leaked probe on both sides and therefore still agree. Hence the two new `AdminHelperTests`.
- The first nesting test only detected a wrong restore on a *non-elevated* host — pinning the contract on a developer's box and passing vacuously on CI, which is the disease this PR is curing. It now runs both directions, so one outer assertion contradicts the real probe whichever way the host is.

## Verification

- `dotnet build` on all four projects: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes` on the solution: clean.
- Full `ArchitectureTests` sweep: **104 green, 1 red** — the red is the throwaway local runner's own `Program.cs` missing an author header, which is not in the repository.
- Integration suite, the touched tests and their neighbours: 10 green, 0 red.
- Run twice, from a rebuilt tree.

## Not in this PR

`FileShredderServiceTests` has nine self-skips of the same shape for a different reason — the environment cannot create a junction or a hard link, so "nothing to assert". That is link-creation privilege rather than elevation, so `ForceElevation` does not reach it; filed separately.

Test-only: no version bump, no changelog entry, no release. TESTING.md documents the helper, the constructor-ordering trap, and the rule.
