### PR TITLE
fix: stop reporting healthy apps as "Not responding" in Processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.17] - 2026-09-07
+
+Some perfectly healthy apps were being listed as "Not responding" in Processes — Films & TV and Settings did
+it on this machine every single refresh. They are fine; the check SysManager used to ask them was the wrong
+one. The list also refreshes faster now, and no longer freezes for five seconds when an app really has
+frozen.
+
+### Fixed
+- **"Not responding" now means it.** SysManager asked each app whether it was alive by sending it a message
+  and waiting up to five seconds for a reply. Some apps from the Microsoft Store never reply to that message
+  even when they are perfectly responsive — measured over four passes, Films & TV and Settings answered
+  "no reply" instantly, every time — so they were labelled frozen on every refresh. The check is now the same
+  one Windows itself uses to decide whether to grey out a window and add "(Not responding)" to its title, so
+  the column agrees with Task Manager.
+- **The Processes list no longer stalls on a frozen app.** The old check waited up to five seconds *per*
+  frozen window before it could finish the refresh, so the one case the column exists for was also the one
+  that made the whole list hang. Confirmed against a deliberately frozen window: the old check blocked the
+  refresh for 5,013 ms; the new one answered in under a millisecond and still reported the freeze.
+- **Refreshing the list does about a third less work.** Finding each app's window was being done twice for
+  every process, once for the responsiveness check and once for the "has a window" flag, and neither reused
+  the other's answer. It is now done once per refresh for all of them. On a machine with 478 processes a
+  refresh went from 202 ms to 138 ms, and the part that is not the deliberate CPU-sampling pause dropped
+  from 102 ms to 38 ms.
+
 ## [1.76.16] - 2026-09-07
 
 Four screens showed an empty table with no explanation until you pressed the right button — and did not say

--- a/SysManager/SysManager.Tests/ProcessManagerServiceTests.cs
+++ b/SysManager/SysManager.Tests/ProcessManagerServiceTests.cs
@@ -75,6 +75,105 @@ public class ProcessManagerServiceTests
             () => _service.SnapshotAsync(ct: cts.Token));
     }
 
+    // ── window probes: one enumeration per refresh ──
+
+    /// <summary>
+    /// The session's windows are enumerated ONCE per refresh, however many processes there are.
+    /// </summary>
+    /// <remarks>
+    /// This replaced <c>p.Responding</c> and <c>p.MainWindowHandle</c>, which each resolve the main window
+    /// by walking every top-level window in the session and do not share the result. Measured on a machine
+    /// with 479 processes: reading <c>Responding</c> alone cost 41.6 ms, reading <c>MainWindowHandle</c>
+    /// alone 43.6 ms, and reading both 81.4 ms — additive, so the walk really did run twice per process,
+    /// and 205x the cost of one pass (0.4 ms). Only 15 of those 479 processes had a window at all.
+    /// <para>Counted rather than timed, because a stopwatch assertion measures how busy the machine is.
+    /// One call is the property that makes the cost independent of the process count, so one call is what
+    /// is asserted.</para>
+    /// </remarks>
+    [Fact]
+    public async Task Snapshot_EnumeratesWindowsOncePerRefresh_NotOncePerProcess()
+    {
+        var lookups = 0;
+        var service = new ProcessManagerService(
+            () => { lookups++; return new Dictionary<int, IntPtr>(); },
+            _ => false);
+
+        var result = await service.SnapshotAsync();
+
+        Assert.True(result.Count > 1, $"only {result.Count} processes were listed — this cannot distinguish "
+                                      + "one lookup per refresh from one per process");
+        Assert.Equal(1, lookups);
+    }
+
+    /// <summary>
+    /// A process whose main window has stopped pumping messages is reported as not responding.
+    /// </summary>
+    [Fact]
+    public async Task Snapshot_ReportsNotResponding_ForAProcessWhoseWindowIsHung()
+    {
+        var self = Environment.ProcessId;
+        var window = new IntPtr(0x1234);
+        var probed = new List<IntPtr>();
+
+        var service = new ProcessManagerService(
+            () => new Dictionary<int, IntPtr> { [self] = window },
+            handle => { probed.Add(handle); return true; });
+
+        var result = await service.SnapshotAsync();
+
+        var mine = Assert.Single(result, p => p.Pid == self);
+        Assert.Equal("Not responding", mine.Status);
+        Assert.True(mine.HasMainWindow);
+
+        // Only the one window that exists is probed — asking about a zero handle would be asking whether
+        // a window that is not there has stopped responding.
+        Assert.Equal([window], probed);
+    }
+
+    /// <summary>
+    /// With no window, a process is responding and has none — a service is not hung for lacking a message
+    /// loop, which is also what <c>Process.Responding</c> reported (it returns true on a zero handle).
+    /// </summary>
+    [Fact]
+    public async Task Snapshot_ReportsRunning_ForEveryProcessWithoutAWindow()
+    {
+        var probed = 0;
+        var service = new ProcessManagerService(
+            () => new Dictionary<int, IntPtr>(),
+            _ => { probed++; return true; });
+
+        var result = await service.SnapshotAsync();
+
+        Assert.All(result, p =>
+        {
+            Assert.Equal("Running", p.Status);
+            Assert.False(p.HasMainWindow);
+        });
+
+        // The hung probe was the expensive half — with no windows there is nothing to ask about, and the
+        // stubbed probe answering "hung" proves it was never consulted rather than merely agreeing.
+        Assert.Equal(0, probed);
+    }
+
+    /// <summary>
+    /// A window that answers is reported as running, so the hung probe's answer is what decides the column
+    /// rather than the mere presence of a window.
+    /// </summary>
+    [Fact]
+    public async Task Snapshot_ReportsRunning_ForAProcessWhoseWindowAnswers()
+    {
+        var self = Environment.ProcessId;
+        var service = new ProcessManagerService(
+            () => new Dictionary<int, IntPtr> { [self] = new(0x1234) },
+            _ => false);
+
+        var result = await service.SnapshotAsync();
+
+        var mine = Assert.Single(result, p => p.Pid == self);
+        Assert.Equal("Running", mine.Status);
+        Assert.True(mine.HasMainWindow);
+    }
+
     // ── KillProcess ──
 
     [Fact]

--- a/SysManager/SysManager/Services/ProcessManagerService.cs
+++ b/SysManager/SysManager/Services/ProcessManagerService.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using Serilog;
 using SysManager.Helpers;
 using SysManager.Models;
@@ -14,15 +15,31 @@ namespace SysManager.Services;
 /// Enumerates running processes with CPU/memory usage. Kill is opt-in
 /// and requires confirmation in the ViewModel layer.
 /// </summary>
-public sealed class ProcessManagerService
+public sealed partial class ProcessManagerService
 {
+    private readonly Func<IReadOnlyDictionary<int, IntPtr>> _mainWindowsByPid;
+    private readonly Func<IntPtr, bool> _isHungWindow;
+
+    public ProcessManagerService() : this(QueryMainWindowsByPid, IsHungAppWindow) { }
+
+    /// <summary>
+    /// Test seam for the two window probes, so "one enumeration per refresh" can be asserted by counting
+    /// rather than measured with a stopwatch.
+    /// </summary>
+    internal ProcessManagerService(Func<IReadOnlyDictionary<int, IntPtr>> mainWindowsByPid,
+                                   Func<IntPtr, bool> isHungWindow)
+    {
+        _mainWindowsByPid = mainWindowsByPid;
+        _isHungWindow = isHungWindow;
+    }
+
     // knownPids: PIDs the caller already shows. Their identity (description/path) is static and the
     // view model keeps it on the surviving entry (ReconcileInto), so for those PIDs we skip the
     // expensive MainModule/FileVersionInfo/File.Exists reads and refresh only the volatile metrics.
     public Task<IReadOnlyList<ProcessEntry>> SnapshotAsync(IReadOnlySet<int>? knownPids = null, CancellationToken ct = default)
         => Task.Run(() => Snapshot(knownPids, ct), ct);
 
-    private static IReadOnlyList<ProcessEntry> Snapshot(IReadOnlySet<int>? knownPids, CancellationToken ct)
+    private IReadOnlyList<ProcessEntry> Snapshot(IReadOnlySet<int>? knownPids, CancellationToken ct)
     {
         List<ProcessEntry> results = [];
         Process[] procs;
@@ -47,18 +64,34 @@ public sealed class ProcessManagerService
 
             int logicalCores = Environment.ProcessorCount;
 
+            // One window enumeration for the whole refresh. Both properties this replaces resolve the
+            // main window by walking every top-level window in the session, and they do NOT share the
+            // result: measured on 479 processes, reading Responding cost 41.6 ms, reading
+            // MainWindowHandle cost 43.6 ms, and reading both cost 81.4 ms — additive, so the walk ran
+            // twice per process. Responding then also sent WM_NULL through SendMessageTimeout with
+            // SMTO_ABORTIFHUNG and a 5000 ms timeout, which is most expensive in exactly the case the
+            // column exists for: an app that has genuinely stopped pumping messages. One pass plus
+            // IsHungAppWindow costs 0.4 ms for the same answers.
+            var mainWindows = _mainWindowsByPid();
+
             foreach (var p in procs)
             {
                 if (ct.IsCancellationRequested) break;
                 try
                 {
+                    // A process with no top-level window is not hung, it simply has no message loop to
+                    // stall — which is also what Responding reported for it (it returns true when the
+                    // main window handle is zero).
+                    var hasWindow = mainWindows.TryGetValue(p.Id, out var mainWindow);
+
                     var entry = new ProcessEntry
                     {
                         Pid = p.Id,
                         Name = p.ProcessName,
                         MemoryBytes = p.WorkingSet64,
                         ThreadCount = p.Threads.Count,
-                        Status = p.Responding ? "Running" : "Not responding"
+                        HasMainWindow = hasWindow,
+                        Status = hasWindow && _isHungWindow(mainWindow) ? "Not responding" : "Running"
                     };
 
                     // Calculate CPU %
@@ -94,9 +127,6 @@ public sealed class ProcessManagerService
                     try { entry.StartTime = p.StartTime; }
                     catch (InvalidOperationException) { /* access denied or process exited */ }
                     catch (System.ComponentModel.Win32Exception) { /* access denied or process exited */ }
-                    try { entry.HasMainWindow = p.MainWindowHandle != IntPtr.Zero; }
-                    catch (InvalidOperationException) { /* access denied or process exited */ }
-                    catch (System.ComponentModel.Win32Exception) { /* access denied or process exited */ }
 
                     results.Add(entry);
                 }
@@ -111,6 +141,74 @@ public sealed class ProcessManagerService
 
         return results;
     }
+
+    /// <summary>
+    /// Maps each process id to its main window, in one pass over the session's top-level windows.
+    /// </summary>
+    /// <remarks>
+    /// "Main window" is defined the same way <c>Process.MainWindowHandle</c> defines it — the first
+    /// visible, unowned top-level window belonging to the process — so the responsiveness column and the
+    /// "has a window" flag keep answering about the same window they did before. A dialog or tooltip is
+    /// owned by its parent and is skipped, which is what stops a modal prompt from being mistaken for an
+    /// app's main window.
+    /// <para>Processes with no window are simply absent from the result rather than present with a zero
+    /// handle: on this machine 15 of 479 processes had one, so a map of only the windows that exist is
+    /// both smaller and the honest shape.</para>
+    /// </remarks>
+    private static IReadOnlyDictionary<int, IntPtr> QueryMainWindowsByPid()
+    {
+        var byPid = new Dictionary<int, IntPtr>();
+
+        // EnumWindows walks in Z-order, so the first window accepted for a process is its topmost one —
+        // the same one Process.MainWindowHandle settles on.
+        var enumerated = EnumWindows((window, _) =>
+        {
+            if (!IsWindowVisible(window)) return true;
+            if (GetWindow(window, GwOwner) != IntPtr.Zero) return true;   // owned: a dialog, not the main window
+            if (GetWindowThreadProcessId(window, out var pid) != 0)
+                byPid.TryAdd((int)pid, window);
+            return true;
+        }, IntPtr.Zero);
+
+        // The callback never returns false, so false here is a real failure rather than an early stop. It
+        // leaves an empty map, which reads as "nothing has a window" and reports every process as
+        // responding — worth a line in the log rather than silence. Read immediately: the callback's own
+        // GetWindowThreadProcessId also sets the last error, and EnumWindows returns after every callback.
+        if (!enumerated)
+            Log.Debug("ProcessManager: EnumWindows failed with {Error}; window state unavailable this refresh",
+                Marshal.GetLastWin32Error());
+
+        return byPid;
+    }
+
+    /// <summary>Callback for <see cref="EnumWindows"/>; returning false stops the enumeration.</summary>
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private delegate bool EnumWindowsCallback(IntPtr window, IntPtr state);
+
+    /// <summary>GW_OWNER — the owner of a window, or zero for an unowned top-level window.</summary>
+    private const uint GwOwner = 4;
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool EnumWindows(EnumWindowsCallback callback, IntPtr state);
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    private static partial uint GetWindowThreadProcessId(IntPtr window, out uint processId);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool IsWindowVisible(IntPtr window);
+
+    [LibraryImport("user32.dll")]
+    private static partial IntPtr GetWindow(IntPtr window, uint command);
+
+    /// <summary>
+    /// True when a window has stopped pumping messages — the non-blocking answer to the question
+    /// <c>Process.Responding</c> answered by sending it one and waiting up to five seconds.
+    /// </summary>
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool IsHungAppWindow(IntPtr window);
 
     /// <summary>
     /// Kill a process by PID. Returns true if successful.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.16</Version>
-    <FileVersion>1.76.16.0</FileVersion>
-    <AssemblyVersion>1.76.16.0</AssemblyVersion>
+    <Version>1.76.17</Version>
+    <FileVersion>1.76.17.0</FileVersion>
+    <AssemblyVersion>1.76.17.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Third item of #2104. The other open item there (the 300 ms Dashboard WMI round-trips) is untouched.

## This turned out to be a correctness bug, not just a cost

`Process.Responding` asks whether an app is alive by sending its main window `WM_NULL` through `SendMessageTimeout` with `SMTO_ABORTIFHUNG` and a 5000 ms timeout, and treats **any** failure as "not responding". Some windows never accept that message however healthy they are.

Measured side by side on the same windows, four consecutive passes, every pass identical:

```
round N: 15 windowed processes
  !! Video.UI          IsHungAppWindow=False  Responding=false  probe took 0.0 ms  lastError=0
  !! SystemSettings    IsHungAppWindow=False  Responding=false  probe took 0.0 ms  lastError=0
```

Films & TV and Settings — two Store apps that were open and perfectly responsive — were labelled **"Not responding"** on every single refresh. Not a timeout: the probe returned failure in 0.0 ms with `lastError` 0. Nothing was wrong with the apps; the question was wrong.

The replacement is `IsHungAppWindow`, which is the state Windows itself consults to grey out a window and append "(Not responding)" to its title. The column now agrees with Task Manager.

## It also stops the refresh freezing on the one case the column is for

Proven against a message loop stalled on purpose (a hidden window in a throwaway process, so nothing appeared on screen), twice with identical results:

| state | `IsHungAppWindow` | the old probe | how long the old probe blocked |
|---|---|---|---|
| healthy | False | responding | 0.1 ms |
| stalled | False | **not responding** | **5,013.7 ms** |
| stalled longer | **True** | not responding | **5,001.0 ms** |
| stall ended | False | responding | 0.5 ms |

So the old code blocked the whole refresh for five seconds per frozen window before it could report the freeze. `IsHungAppWindow` answered in under a millisecond and did detect the stall.

**The honest trade-off:** `IsHungAppWindow` trails a fresh freeze by up to ~5 s, because that is Windows' own hang timeout, whereas the old probe flags it as soon as its 5 s wait expires. The tab refreshes on a timer, so the label arrives one tick later instead of after a five-second stall — and it is the same lag Task Manager has.

## The cost, measured rather than assumed

`p.Responding` and `p.MainWindowHandle` each resolve the main window by walking every top-level window in the session, and they do **not** share the result. I expected the BCL to cache it and checked before patching:

| what was read, per process | median over 5 rounds, 479 processes |
|---|---|
| `MainWindowHandle` only | 43.6 ms |
| `Responding` only | 41.6 ms |
| `Responding` then `MainWindowHandle` | **81.4 ms** |
| `MainWindowHandle` then `Responding` | **86.7 ms** |
| one `EnumWindows` pass + `IsHungAppWindow` | **0.4 ms** |

Additive in both orders — the ratio to reading one alone is 1.96x, so the walk really did run twice per process, as the issue claimed. Only **15 of 479** processes had a window at all.

End to end, before and after on the same machine, median of five, 478 processes:

| | before | after |
|---|---|---|
| steady-state refresh (what the timer runs) | 202.0 ms | **137.8 ms** |
| minus the deliberate 100 ms CPU-sampling pause | 102.0 ms | **37.8 ms** |
| first refresh (every pid unknown) | 2323.7 ms | 1982.5 ms |

Both versions gave a window to the same 15 processes, by name (chrome, explorer ×3, obs64, OUTLOOK, slack, WindowsTerminal, …), which is the evidence that the new enumeration matches `Process.MainWindowHandle`'s definition of "main window": first visible, unowned, top-level.

The first refresh is dominated by something else entirely — `MainModule` / `FileVersionInfo` / `File.Exists` for every unknown pid — so it is not what this change is about. Worth its own issue.

## Design

The window pass and the hung probe are constructor-injected, so "once per refresh" is asserted by **counting** rather than by timing. A stopwatch assertion measures how busy the machine is; one call is the property that makes the cost independent of the process count, so one call is what the test asserts.

## Red/green

Five mutations, all behaving as claimed:

| Mutation | Expected | Result |
|---|---|---|
| Lookup moved back inside the per-process loop | counting test red, with the real number | red: `Expected: 1, Actual: 468` |
| Probe ignored, everything reported running | hung test red, answering test green | PASS |
| Every window called hung without asking | answering test red, no-window test green | PASS |
| Zero handle probed as well | no-window test red | PASS |
| Visibility filter dropped | the REAL pass over-claims | 15 → 61 windowed processes |

Mutations 2 and 3 are deliberately mirror images: a test that passed on the mere presence of a window would survive one of them, and neither does. Mutation 5 is checked against the live machine rather than a test, because the filter's effect is only visible in the real enumeration.

Two of my own expectations were wrong and were corrected rather than worked around: the hung test also fires under mutations 3 and 4, because it asserts the probe was consulted with exactly the one handle that exists — the test is stronger than my prediction of it, not weaker.

## Verification

- `dotnet build` on all four projects: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes` on the solution: clean.
- Regression sweep, `ProcessManagerService` + `ProcessManagerViewModel` + every `ArchitectureTests` guard: **155 green, 1 red** — the red is the local throwaway runner's own `Program.cs` missing an author header, which is not in the repository.
- The shipped code path (not a copy of it) exercised against the real machine through a temporary console harness: 15 windows found, statuses populated, 137.8 ms median.
- Leak scan over the diff with all 43 current terms: one hit, a pre-existing CHANGELOG history line naming a Windows feature the Privacy tab toggles. `git diff` confirms it is not part of this change.

## Deferred to the secondary workstation

Launching the app and confirming the Processes tab visually, which is where the idle-CPU% half of #2104's measurement request belongs. Everything above was obtained without running SysManager.
