### PR TITLE
fix: show free space in the disk-check drive picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.18] - 2026-09-07
+
+The drive list in System Health now tells you how much room is left on each drive. It already knew — it just
+never said, and free space is the thing that decides whether a disk check can run at all.
+
+### Fixed
+- **The disk-check picker shows free space.** Each drive row listed its total size, file system and drive
+  type, but not how much of it was still free, so choosing a drive to check meant guessing or going to look
+  it up elsewhere. The number was already being read from the drive and carried all the way to the row;
+  nothing displayed it. It now sits between the size and the file system, in the same muted style as the rest
+  of the line: `476 GB · 163 GB free · NTFS · SSD NVMe`.
+
 ## [1.76.17] - 2026-09-07
 
 Some perfectly healthy apps were being listed as "Not responding" in Processes — Films & TV and Settings did

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1545,6 +1545,97 @@ public partial class ArchitectureTests
     private static partial Regex SearchableFieldSpan();
 
     /// <summary>
+    /// Every field the chkdsk picker fills in per drive must be shown by the row that lists that drive.
+    /// </summary>
+    /// <remarks>
+    /// <c>FreeGB</c> was queried from the drive, rounded, carried through <c>FixedDriveService</c> and
+    /// assigned onto every <c>DriveTarget</c> — and read by nothing. It is the number that decides whether a
+    /// disk check can run at all, so its absence was a missing capability rather than dead weight, and
+    /// neither the compiler nor the view-model tests could see it: a test reads the property exactly the way
+    /// the missing binding would have.
+    /// <para>Read from the initialiser rather than restated here, so a tenth field added to the row is
+    /// covered without touching this guard. Scope is deliberately what the code POPULATES per drive: a
+    /// computed convenience with no consumer is the same defect family but a different judgement call —
+    /// delete or bind — and does not belong to an automatic rule.</para>
+    /// <para>What it checks is that the view BINDS the field, not that the field is rendered as text. A
+    /// field bound only to a <c>Visibility</c> still passes, and deliberately: driving whether something
+    /// appears is a real use of the value, and demanding a text binding would fail a field whose whole job
+    /// is to gate a section. The defect this pins is the field nothing reads at all.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryFieldTheChkdskPickerFillsIn_IsShownInItsRow()
+    {
+        var appDir = FindAppProjectDir();
+        var source = File.ReadAllText(Path.Combine(appDir, "ViewModels", "SystemHealthViewModel.cs"));
+        var xaml = ChkdskRowTemplate(File.ReadAllText(Path.Combine(appDir, "Views", "SystemHealthView.xaml")));
+
+        var initialiser = DriveTargetInitialiser().Match(source);
+        Assert.True(initialiser.Success,
+            "could not find the DriveTarget initialiser in SystemHealthViewModel — if the picker was "
+            + "rewritten, update this guard rather than deleting it");
+
+        // Matched per assignment rather than split on commas: one initialiser value is
+        // string.Equals(d.Letter, "C:", StringComparison.OrdinalIgnoreCase), whose own argument commas
+        // split into fragments, and "StringComparison.OrdinalIgnoreCase)" starts with a capital, so a
+        // name-shaped filter accepts it as a field and the guard reports a property that does not exist.
+        var assigned = InitialiserAssignment().Matches(initialiser.Groups[1].Value)
+            .Select(m => m.Groups[1].Value)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(assigned.Count >= 7,
+            $"parsed only {assigned.Count} assigned fields from the DriveTarget initialiser — the regex is "
+            + "matching something narrower than the whole block");
+
+        var unshown = assigned
+            .Where(name => !xaml.Contains($"Binding {name}", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(unshown.Count == 0,
+            "the chkdsk picker fills these in for every drive and its row shows none of them, so the work "
+            + "is done and thrown away:\n  " + string.Join("\n  ", unshown));
+    }
+
+    /// <summary>The <c>new DriveTarget { … }</c> initialiser, capturing its assignments.</summary>
+    [GeneratedRegex(@"new DriveTarget\s*\{([^}]+)\}", RegexOptions.Compiled)]
+    private static partial Regex DriveTargetInitialiser();
+
+    /// <summary>One <c>Property =</c> assignment at the start of a line inside an object initialiser.</summary>
+    [GeneratedRegex(@"^\s*(\w+)\s*=", RegexOptions.Compiled | RegexOptions.Multiline)]
+    private static partial Regex InitialiserAssignment();
+
+    /// <summary>
+    /// Just the chkdsk picker's row template, from its <c>ItemsSource</c> to its closing tag.
+    /// </summary>
+    /// <remarks>
+    /// Searching the whole view is what a file-wide <c>Contains</c> does, and it is not the same question.
+    /// <c>MediaType</c> is bound three times in this view: once in the picker row, and twice in the
+    /// unrelated SMART sections above it — so removing the picker's binding left the guard green, satisfied
+    /// by a part of the screen the drive rows have nothing to do with. Scoping to the template is what makes
+    /// the answer be about the row.
+    /// </remarks>
+    private static string ChkdskRowTemplate(string xaml)
+    {
+        const string opens = "ItemsSource=\"{Binding ChkdskDrives}\"";
+        const string closes = "</ItemsControl>";
+
+        var start = xaml.IndexOf(opens, StringComparison.Ordinal);
+        Assert.True(start >= 0,
+            "could not find the chkdsk picker's ItemsControl in SystemHealthView — if the picker was "
+            + "rewritten, update this guard rather than deleting it");
+
+        var end = xaml.IndexOf(closes, start, StringComparison.Ordinal);
+        Assert.True(end > start, "the chkdsk ItemsControl is never closed — the view does not parse");
+
+        var slice = xaml[start..end];
+        // A slice that shrank to almost nothing would make every field look unbound, which reads as a real
+        // finding rather than as a broken marker.
+        Assert.True(slice.Length > 400,
+            $"the chkdsk row template sliced to {slice.Length} characters — too short to be the row");
+        return slice;
+    }
+
+    /// <summary>
     /// Every commit prefix the release workflow treats as releasing must be offered by the PR template,
     /// and every prefix the template offers must be one the project actually recognises.
     /// <para>The template's "Type of change" list omitted <c>test:</c> and <c>refactor:</c> — 41 and 15

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.17</Version>
-    <FileVersion>1.76.17.0</FileVersion>
-    <AssemblyVersion>1.76.17.0</AssemblyVersion>
+    <Version>1.76.18</Version>
+    <FileVersion>1.76.18.0</FileVersion>
+    <AssemblyVersion>1.76.18.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -366,6 +366,10 @@
                                                 <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
                                                     <TextBlock Text="{Binding SizeGB, StringFormat={}{0:F0} GB}" Foreground="{DynamicResource TextMuted}" FontSize="12"/>
                                                     <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" FontSize="12"/>
+                                                    <!-- Free space decides whether a check can run at all, and it was the one
+                                                         thing the picker computed and never showed. -->
+                                                    <TextBlock Text="{Binding FreeGB, StringFormat={}{0:F0} GB free}" Foreground="{DynamicResource TextMuted}" FontSize="12"/>
+                                                    <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" FontSize="12"/>
                                                     <TextBlock Text="{Binding FileSystem}" Foreground="{DynamicResource TextMuted}" FontSize="12"/>
                                                     <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" FontSize="12"
                                                                Visibility="{Binding MediaType, Converter={StaticResource FlexVis}}"/>


### PR DESCRIPTION
One row of #2100 — the `DriveTarget.FreeGB` instance. The other six, and widening the `Models/`-scoped guard to `ViewModels/`, stay open there.

## Problem

`FreeGB` is read from the drive, rounded, carried through `FixedDriveService`, and assigned onto every `DriveTarget` the chkdsk picker builds. Nothing reads it. The row shows total size, file system, media and bus — but not how much room is left, which is the number that decides whether a disk check can run at all, so choosing a drive meant guessing or going to look it up elsewhere.

Five tests already covered `DriveTarget` and none of them could notice, which is the signature of this defect class: a view-model property that is implemented, assigned and unit-tested but bound by nothing. The compiler cannot see it, and a view-model test cannot either, because the test reads the property exactly the way the missing binding would have.

## The change

```
before   476 GB  ·  NTFS  ·  SSD NVMe
after    476 GB  ·  163 GB free  ·  NTFS  ·  SSD NVMe
```

Additive: one segment between size and file system, in the same `TextMuted` 12 px style and the same `·` separator the line already used. No new style, no layout change, nothing moves.

Mockup: `ui-mockups/chkdsk-free-space.html`, which also shows the rejected alternative (`163 GB free of 476 GB` — reads well on its own but replaces the size segment rather than adding to it, so every row changes shape for a number that was only missing).

Wording follows the Landing tab, which already writes drive space as `163 / 476 GB (34%)`. Here the free half is what matters.

## A guard for the shape, not the instance

`EveryFieldTheChkdskPickerFillsIn_IsShownInItsRow` reads the field list out of the `new DriveTarget { … }` initialiser and requires each one to be bound inside the picker's own row template. A tenth field added later is covered without touching the guard.

It is scoped to what the code **populates** per drive. A computed convenience with no consumer is the same family but a different judgement call — delete or bind — and does not belong in an automatic rule. It also checks that the view *binds* the field, not that it renders it as text: a field bound only to a `Visibility` passes, deliberately, because gating whether something appears is a real use of the value.

**Two things the guard got wrong first, both found by mutating it rather than by reading it:**

1. Splitting the initialiser on commas also split the argument list of `string.Equals(d.Letter, "C:", StringComparison.OrdinalIgnoreCase)`. `StringComparison.OrdinalIgnoreCase)` starts with a capital, so a name-shaped filter accepted it as a field and the guard reported a property that does not exist. It now matches assignments, not commas.
2. Searching the whole view rather than the row template left it **green** when the picker's `MediaType` binding was deleted — `MediaType` is bound twice more in the unrelated SMART sections above it, so a file-wide `Contains` was answering a different question. It now slices the `ItemsControl` and asserts the slice is long enough to actually be the row.

## Red/green

| Mutation | Expected | Result |
|---|---|---|
| `FreeGB` binding removed | guard names `FreeGB` | PASS |
| both `MediaType` bindings removed | guard names `MediaType`, not `FreeGB` | PASS |
| a tenth field added and left unbound | guard names it, guard itself untouched | PASS |
| construction site renamed (anchor broken) | guard fails loudly on not finding the block | PASS |

The last one matters as much as the first: a guard that cannot find its anchor must say so, not parse zero fields and report health.

## Also found, filed rather than folded in

`DriveTarget.Display` is an eighth instance of the same defect class, not in #2100's table. It composes letter, label, size and file system into a string, five tests assert it, and the view binds it nowhere — the row builds that text from the individual properties instead. #2100's premise for this row ("absent from the type's own `Display` string, which is the only thing the view shows") is therefore wrong twice over: the view does not use `Display` at all.

Deleting it and its five tests is a `refactor:` and belongs to the delete pass #2100 already plans, not to a `fix:`. Commented on the issue.

## Verification

- `dotnet build` on all four projects: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: clean.
- Regression sweep — every `ArchitectureTests` guard plus the `SystemHealthViewModel` and `FixedDriveService` tests: **218 green, 1 red**, the red being the local throwaway runner's own `Program.cs` missing an author header, which is not in the repository.
- Version consistency (csproj ×3, newest CHANGELOG entry, SECURITY table): consistent at 1.76.18.
- Leak scan over the diff with all 43 current terms: one hit, a pre-existing CHANGELOG history line naming a Windows feature the Privacy tab toggles; `git diff` confirms it is not part of this change.

## Deferred to the secondary workstation

Seeing the row on screen. The mockup stands in for it here; the main workstation does not run the app.
