### PR TITLE
fix: say why three lists came back empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.19] - 2026-09-07
+
+Three lists used to go blank without saying why. Search winget for something that does not exist and the
+results area simply vanished; pick a category with nothing in it and the app list emptied; search the
+environment variables for a word that matches nothing and you were left with column headers over empty space.
+All three now tell you what happened and which control to reach for.
+
+### Fixed
+- **A winget search that finds nothing says so.** The results area hid itself when the list came back empty,
+  and nothing replaced it, so a misspelt name produced no results and no explanation — indistinguishable from
+  the search not having run. It now says "No packages found" with a hint that search matches package names
+  and IDs. Only after a search: an empty list before you have searched is just the starting state.
+- **An app filter that matches nothing says so.** Easiest to hit without typing anything at all — the
+  category dropdown offers "Custom", and none of the 46 built-in apps are in that category, so choosing it
+  emptied the list silently. It now points you at "All" in the category list or the filter box.
+- **An environment-variable search that matches nothing says so.** The grid kept its column headers over
+  empty space, which reads as "this machine has no environment variables" rather than "none of them match
+  what you typed". The message distinguishes the two: it only appears when variables were actually read, so a
+  scope with nothing in it is never blamed on the search box.
+
 ## [1.76.18] - 2026-09-07
 
 The drive list in System Health now tells you how much room is left on each drive. It already knew — it just

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1545,6 +1545,53 @@ public partial class ArchitectureTests
     private static partial Regex SearchableFieldSpan();
 
     /// <summary>
+    /// Each list that can filter itself down to nothing must have something to say when it does.
+    /// </summary>
+    /// <remarks>
+    /// Not the whole-repo sweep #2121 plans — that one needs all eight of its views resolved first, because
+    /// an exception list carrying reasons nobody has checked is a false claim sitting in the test suite.
+    /// This is the three that ARE resolved, pinned by the state they were given, so deleting one is a
+    /// failure rather than a silent regression to a blank panel.
+    /// <para>Each row names the flag or count the view binds. The flags exist because a bare
+    /// <c>Count == 0</c> cannot tell "the filter matched nothing" from "nothing was loaded yet" — Bulk
+    /// Installer's search would greet the user with "No packages found" before they typed, and Environment
+    /// Variables would blame a search box for a read that came back empty. Where the source collection is
+    /// static, the count IS unambiguous, and Bulk Installer's curated list says so.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryResolvedNoResultsState_IsStillWiredToItsView()
+    {
+        (string View, string Binding, string Copy)[] expected =
+        [
+            ("BulkInstallerView.xaml", "Binding SearchFoundNothing", "No packages found"),
+            ("BulkInstallerView.xaml", "Binding FilteredApps.Count", "No apps match this filter"),
+            ("EnvironmentVariablesView.xaml", "Binding HasNoMatches", "No variables match your search"),
+        ];
+
+        var viewsDir = Path.Combine(FindAppProjectDir(), "Views");
+        var offenders = new List<string>();
+
+        foreach (var (view, binding, copy) in expected)
+        {
+            var path = Path.Combine(viewsDir, view);
+            Assert.True(File.Exists(path), $"{path} not found — this guard would pass vacuously");
+
+            var xaml = File.ReadAllText(path);
+            if (!xaml.Contains("<v:EmptyState", StringComparison.Ordinal))
+                offenders.Add($"{view} — no EmptyState control at all");
+            if (!xaml.Contains(binding, StringComparison.Ordinal))
+                offenders.Add($"{view} — nothing binds {binding}");
+            if (!xaml.Contains(copy, StringComparison.Ordinal))
+                offenders.Add($"{view} — the copy \"{copy}\" is gone");
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These lists can filter themselves down to nothing and no longer explain it, so the user is "
+            + "left looking at an empty panel — column headers over empty space, or a search area that "
+            + "simply vanishes:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
     /// Every field the chkdsk picker fills in per drive must be shown by the row that lists that drive.
     /// </summary>
     /// <remarks>

--- a/SysManager/SysManager.Tests/BulkInstallerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BulkInstallerViewModelTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.IO;
+using NSubstitute;
 using SysManager.Helpers;
 using SysManager.Services;
 using SysManager.ViewModels;
@@ -102,6 +103,118 @@ public class BulkInstallerViewModelTests
         Assert.Contains("All", vm.Categories);
         Assert.Contains("Custom", vm.Categories);
         Assert.Equal(13, vm.Categories.Count);
+    }
+
+    // ── no-results state for the winget search ──
+
+    /// <summary>
+    /// A view-model whose winget search reaches a substituted runner, so no process is started.
+    /// </summary>
+    /// <remarks>
+    /// <c>NewVm</c> builds a real <c>PowerShellRunner</c>, which for the search path means launching an
+    /// actual <c>winget search</c> — a live process, a network round-trip, and an answer that depends on the
+    /// machine. The seam is one level down from the view-model: the service collects <c>LineReceived</c>
+    /// around <c>RunProcessAsync</c>, so a substituted runner that emits nothing is a search that matched
+    /// nothing.
+    /// </remarks>
+    private static BulkInstallerViewModel VmWithSubstitutedRunner(IPowerShellRunner runner) =>
+        new(new BulkInstallerService(runner),
+            new AppIconService(null, Path.Combine(Path.GetTempPath(), "SysManagerTests", Guid.NewGuid().ToString("N"))));
+
+    /// <summary>
+    /// A search that matches nothing says so — and only once the search has actually run.
+    /// </summary>
+    /// <remarks>
+    /// Before this, the results <c>ItemsControl</c> hid itself on an empty <c>Count</c> and nothing replaced
+    /// it, so a query with no matches produced no results and no explanation. The flag is what keeps the
+    /// message out of sight beforehand: an empty list before the first search is the starting state, not a
+    /// failed search.
+    /// </remarks>
+    [Fact]
+    public async Task SearchWinget_WhenNothingMatches_SaysSo_ButNotBeforeTheSearch()
+    {
+        var vm = VmWithSubstitutedRunner(Substitute.For<IPowerShellRunner>());
+        Assert.False(vm.SearchFoundNothing);   // nothing searched yet
+
+        vm.SearchQuery = "qwertyasdfzxcv";
+        await vm.SearchWingetCommand.ExecuteAsync(null);
+
+        Assert.Empty(vm.SearchResults);
+        Assert.True(vm.SearchFoundNothing);
+    }
+
+    /// <summary>
+    /// A query too short to search leaves the state alone rather than claiming nothing was found.
+    /// </summary>
+    /// <remarks>
+    /// <c>SearchWingetAsync</c> returns before doing anything under two characters. Setting the flag there
+    /// would tell the user their one-letter query matched nothing, when it was never sent.
+    /// </remarks>
+    [Fact]
+    public async Task SearchWinget_WithTooShortAQuery_DoesNotClaimNothingWasFound()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        var vm = VmWithSubstitutedRunner(runner);
+
+        vm.SearchQuery = "q";
+        await vm.SearchWingetCommand.ExecuteAsync(null);
+
+        Assert.False(vm.SearchFoundNothing);
+
+        // Not DidNotReceiveWithAnyArgs: the constructor legitimately runs `winget list` to learn which
+        // apps are already installed, so the assertion has to name the SEARCH rather than any winget call.
+        await runner.DidNotReceive().RunProcessAsync(
+            "winget",
+            Arg.Is<string>(args => args.StartsWith("search", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<System.Text.Encoding?>());
+    }
+
+    /// <summary>
+    /// When winget itself is missing, the tab says THAT — not "no packages found".
+    /// </summary>
+    /// <remarks>
+    /// The two answers point somewhere different: one is "try another word", the other is "winget is not on
+    /// this machine". Showing the no-results state on a failure would send the user to reword a query that
+    /// was never able to run.
+    /// </remarks>
+    [Fact]
+    public async Task SearchWinget_WhenWingetIsMissing_DoesNotClaimNoPackagesWereFound()
+    {
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunProcessAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>(),
+                               Arg.Any<System.Text.Encoding?>())
+              .Returns<Task<int>>(_ => throw new System.ComponentModel.Win32Exception(2));
+        var vm = VmWithSubstitutedRunner(runner);
+
+        vm.SearchQuery = "firefox";
+        await vm.SearchWingetCommand.ExecuteAsync(null);
+
+        Assert.False(vm.SearchFoundNothing);
+        Assert.Equal(WingetFailure.WingetUnavailable, vm.StatusMessage);
+    }
+
+    // ── no-results state for the curated list ──
+
+    /// <summary>
+    /// The category dropdown offers "Custom", and no curated app is in it — so the list empties with no
+    /// text typed at all. That is the state the view now explains.
+    /// </summary>
+    /// <remarks>
+    /// Asserted because the copy tells the user to pick "All" in the category list, and that instruction is
+    /// only right if a category really can empty the list. <c>Categories</c> is hardcoded while the app
+    /// catalogue is not, so the two can disagree — and they do.
+    /// </remarks>
+    [Fact]
+    public void SelectingACategoryWithNoCuratedApp_EmptiesTheList()
+    {
+        var vm = NewVm();
+        Assert.NotEmpty(vm.FilteredApps);
+
+        vm.SelectedCategory = "Custom";
+
+        Assert.Empty(vm.FilteredApps);
+        Assert.DoesNotContain(vm.Apps, a => a.Category == "Custom");
     }
 
     // ── re-entrancy guard (regression: shared CTS disposed mid-install) ──

--- a/SysManager/SysManager.Tests/EnvironmentVariablesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/EnvironmentVariablesViewModelTests.cs
@@ -1,0 +1,95 @@
+// SysManager · EnvironmentVariablesViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="EnvironmentVariablesViewModel"/>'s no-results state.
+/// </summary>
+/// <remarks>
+/// The view-model reads the real environment hives on construction, which is a read and needs no elevation.
+/// A throwaway backup directory is passed even though nothing here writes one, for the same reason
+/// <c>BulkInstallerViewModelTests</c> passes a temp icon cache: a test never builds a service against the
+/// developer's real profile, whether or not this particular test would touch it.
+/// </remarks>
+public class EnvironmentVariablesViewModelTests : IDisposable
+{
+    private readonly string _backupDir =
+        Path.Combine(Path.GetTempPath(), "SysManagerEnvVmTests", Guid.NewGuid().ToString("N"));
+
+    private EnvironmentVariablesViewModel NewVm()
+    {
+        var vm = new EnvironmentVariablesViewModel(new EnvironmentVariableService(_backupDir));
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_backupDir)) Directory.Delete(_backupDir, recursive: true); }
+        catch (IOException) { /* a leftover temp dir must never fail a test run */ }
+    }
+
+    /// <summary>
+    /// A search term that matches no name and no value is reported as a search with no matches.
+    /// </summary>
+    /// <remarks>
+    /// The grid kept its column headers over empty space, which reads as "this machine has no environment
+    /// variables" rather than "none of them match what you typed".
+    /// </remarks>
+    [Fact]
+    public void SearchMatchingNothing_ReportsNoMatches()
+    {
+        var vm = NewVm();
+        Assert.NotEmpty(vm.Variables);           // the machine always has some
+        Assert.False(vm.HasNoMatches);
+
+        vm.SearchText = "zzz_no_such_variable_" + Guid.NewGuid().ToString("N");
+
+        Assert.Empty(vm.FilteredVariables);
+        Assert.True(vm.HasNoMatches);
+    }
+
+    /// <summary>
+    /// Clearing the search puts the state back, so the message is not left behind over a full list.
+    /// </summary>
+    [Fact]
+    public void ClearingTheSearch_ClearsTheNoMatchesState()
+    {
+        var vm = NewVm();
+        vm.SearchText = "zzz_no_such_variable_" + Guid.NewGuid().ToString("N");
+        Assert.True(vm.HasNoMatches);
+
+        vm.SearchText = "";
+
+        Assert.NotEmpty(vm.FilteredVariables);
+        Assert.False(vm.HasNoMatches);
+    }
+
+    /// <summary>
+    /// With nothing read at all, the tab does NOT blame the search.
+    /// </summary>
+    /// <remarks>
+    /// This is the half a bare <c>FilteredVariables.Count == 0</c> would get wrong. An empty grid because
+    /// the hives could not be read is a different problem from a search that matched nothing, and telling
+    /// the user to clear a search box would send them to fix something that is not broken. Same distinction
+    /// <c>LogsViewModel.HasNoResults</c> draws between "the filters hid everything" and "the log could not
+    /// be read".
+    /// </remarks>
+    [Fact]
+    public void WithNoVariablesRead_DoesNotBlameTheSearch()
+    {
+        var vm = NewVm();
+        vm.Variables.Clear();
+
+        vm.SearchText = "anything";
+
+        Assert.Empty(vm.FilteredVariables);
+        Assert.False(vm.HasNoMatches);
+    }
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.18</Version>
-    <FileVersion>1.76.18.0</FileVersion>
-    <AssemblyVersion>1.76.18.0</AssemblyVersion>
+    <Version>1.76.19</Version>
+    <FileVersion>1.76.19.0</FileVersion>
+    <AssemblyVersion>1.76.19.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -69,6 +69,19 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
     public BulkObservableCollection<InstallableApp> SearchResults { get; } = new();
 
     /// <summary>
+    /// True when a search finished and matched nothing, so the view can say so.
+    /// </summary>
+    /// <remarks>
+    /// A flag rather than <c>SearchResults.Count == 0</c>, because that is also true before the first
+    /// search — the view would greet the user with "No packages found" for a query they had not typed. Same
+    /// shape as <c>LogsViewModel.HasNoResults</c>, which distinguishes "the filters hid everything" from
+    /// "nothing was loaded". Deliberately NOT set on the two failure paths: those already put their own
+    /// reason in <see cref="StatusMessage"/>, and "no packages found" would contradict "winget is
+    /// unavailable".
+    /// </remarks>
+    [ObservableProperty] private bool _searchFoundNothing;
+
+    /// <summary>
     /// True when "Select &lt;category&gt;" is worth offering: only once a real category is chosen.
     /// While the filter is "All" that button would tick exactly what Select All already does, and two
     /// controls doing the same thing under different names is its own small confusion.
@@ -327,6 +340,7 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
     {
         if (string.IsNullOrWhiteSpace(SearchQuery) || SearchQuery.Length < 2) return;
         IsSearching = true;
+        SearchFoundNothing = false;
         SearchResults.Clear();
         try
         {
@@ -335,6 +349,7 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
             // is sanitized against argument injection before it reaches the command line.
             var lines = await _service.SearchAsync(SearchQuery).ConfigureAwait(true);
             SearchResults.ReplaceWith(ParseSearchResults(string.Join("\n", lines)));
+            SearchFoundNothing = SearchResults.Count == 0;
         }
         // Missing winget is the one search failure with a specific, actionable answer, so it is named
         // rather than folded into "ensure winget is available" — which tells the user to check the very

--- a/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
@@ -38,6 +38,17 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
     public BulkObservableCollection<EnvVariable> Variables { get; } = new();
     public BulkObservableCollection<EnvVariable> FilteredVariables { get; } = new();
 
+    /// <summary>
+    /// True when variables were read but the search and scope filters hid every one of them.
+    /// </summary>
+    /// <remarks>
+    /// Both halves matter. Without "were read", a scope the machine has nothing in — or a read that came
+    /// back empty — would be described to the user as a search that matched nothing, sending them to edit a
+    /// search box that is not the problem. Same shape as <c>LogsViewModel.HasNoResults</c>, which keeps
+    /// "the filters hid everything" apart from "the log could not be read".
+    /// </remarks>
+    [ObservableProperty] private bool _hasNoMatches;
+
     /// <summary>Directories of the selected PATH-like variable, with missing/duplicate flags.</summary>
     public BulkObservableCollection<PathEntry> PathEntries { get; } = new();
 
@@ -136,6 +147,7 @@ public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
         }
 
         FilteredVariables.ReplaceWith(source);
+        HasNoMatches = Variables.Count > 0 && FilteredVariables.Count == 0;
     }
 
     private void OnVariablePropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:BulkInstallerViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -170,11 +171,21 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
+
+                <!-- No-results state: a search ran and matched nothing. Gated on the view-model flag, not
+                     on SearchResults.Count, so it stays out of sight until the user has actually searched. -->
+                <v:EmptyState Glyph="&#xE721;"
+                              Title="No packages found"
+                              Message="Try a shorter word, or check the spelling. Search matches package names and IDs."
+                              Visibility="{Binding SearchFoundNothing, Converter={StaticResource FlexVis}}"/>
             </StackPanel>
         </Border>
 
         <!-- App list (grouped by category) -->
         <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
+            <!-- Grid, not the ScrollViewer alone: a Border takes one child, and the no-results state has to
+                 be able to sit over the list rather than scroll with it. -->
+            <Grid>
             <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="0">
                 <ItemsControl ItemsSource="{Binding GroupedView}"
                               VirtualizingPanel.IsVirtualizing="True"
@@ -275,6 +286,17 @@
 
                 </ItemsControl>
             </ScrollViewer>
+
+            <!-- No-results state: the filter excluded every curated app. Bound to the count rather than to
+                 a flag, and that is safe here for a reason the other two lists cannot claim — the curated
+                 list is static, so an empty FilteredApps can only mean the filter matched nothing. The
+                 category dropdown is the likelier culprit than the text box: it is hardcoded and offers
+                 "Custom", which no curated app is in. -->
+            <v:EmptyState Glyph="&#xE71C;"
+                          Title="No apps match this filter"
+                          Message="Pick All in the category list, or clear the filter box above."
+                          Visibility="{Binding FilteredApps.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            </Grid>
         </Border>
 
         <!-- Status bar -->

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:EnvironmentVariablesViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -119,6 +120,10 @@
 
             <!-- Variables grid -->
             <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+                <!-- Grid, not the DataGrid alone: a Border takes one child, and the no-results state
+                     overlays the grid so the column headers stay put instead of the whole table swapping
+                     out and back as matches come and go. -->
+                <Grid>
                 <DataGrid ItemsSource="{Binding FilteredVariables}"
                           SelectedItem="{Binding SelectedVariable}"
                           AutomationProperties.Name="Environment variables"
@@ -159,6 +164,15 @@
                         </DataGridTemplateColumn>
                     </DataGrid.Columns>
                 </DataGrid>
+
+                <!-- No-results state: variables were read, and the search plus scope filters hid all of
+                     them. Gated on the flag rather than the count so a scope the machine has nothing in is
+                     never described as a search that matched nothing. -->
+                <v:EmptyState Glyph="&#xE721;"
+                              Title="No variables match your search"
+                              Message="Clear the search box, or switch the scope filter back to All."
+                              Visibility="{Binding HasNoMatches, Converter={StaticResource FlexVis}}"/>
+                </Grid>
             </Border>
 
             <!-- PATH editor -->


### PR DESCRIPTION
Three of the eight views in #2121, resolved. The remaining five (About, Dashboard, Ping, Profile, Tweaks Hub) and the repo-wide guard stay open there.

## What went wrong

| List | How you reach the empty state | What the user saw |
|---|---|---|
| `BulkInstallerView.SearchResults` | search winget for a name that does not exist | the whole results area vanished — its visibility is bound to its own `Count` and nothing replaced it |
| `BulkInstallerView.GroupedView` / `FilteredApps` | choose the **Custom** category | the app list emptied, silently |
| `EnvironmentVariablesView.FilteredVariables` | search for a word matching no name or value | column headers over empty space |

The middle one is reachable **without typing anything**, and that is worth naming: the category dropdown is hardcoded while the catalogue that fills it is not. 46 curated apps across 11 categories, 12 offered — `Custom` has none, so selecting it empties the list on a fresh session.

## Count or flag: the actual design question

Two of the three need a flag, and one does not.

- **`SearchFoundNothing`** — false until a search has completed and matched nothing. A bare `SearchResults.Count == 0` is also true before the first search, so the tab would greet the user with "No packages found" for a query they never typed. Deliberately **not** set on the two failure paths: those already put their own reason in `StatusMessage`, and "no packages found" would contradict "winget is unavailable" — one says try another word, the other says winget is not on this machine.
- **`HasNoMatches`** — requires that variables were **read** *and* the filters hid all of them. Without the first half, a scope the machine has nothing in would be described as a search that matched nothing, sending the user to edit a search box that is not the problem. Same distinction `LogsViewModel.HasNoResults` draws between "the filters hid everything" and "the log could not be read".
- **The curated app list needs neither.** It is 46 static entries, so an empty `FilteredApps` can only mean the filter excluded everything, and a `Count` + `Inverse` binding says exactly that.

## A correction to #2121's own table

**`PrivacyView.FilteredToggles` is not a gap.** It is filtered only by category, and the category list is built from the toggles themselves:

```csharp
List<string> cats = ["All"];
cats.AddRange(Toggles.Select(t => t.Category).Distinct().OrderBy(c => c));
```

Every selectable category therefore has at least one row, and `Toggles` comes from static definitions. There is no reachable empty state to write copy for — a verified exemption rather than an assumed one, which is what the issue asks for.

It is also the exact mirror of Bulk Installer, and the pair is the useful lesson: a category list **derived** from its data cannot disagree with it; a **hardcoded** one can, and does.

## The guard

`EveryResolvedNoResultsState_IsStillWiredToItsView` pins the three by binding **and** by sentence, so rewording the copy away is a failure rather than a silent drift.

It is deliberately not the repo-wide sweep #2121 plans. That one needs all eight views resolved first: an exception list carrying reasons nobody has checked is a false claim sitting in the test suite, which is worse than no guard.

## Red/green

Eight mutations, all behaving as claimed:

| Mutation | Expected | Result |
|---|---|---|
| Bulk Installer search state deleted | guard names `SearchFoundNothing` | PASS |
| curated-list state unbound | guard names `FilteredApps.Count` | PASS |
| Environment Variables state unbound | guard names `HasNoMatches` | PASS |
| one `Title` reworded | guard names the sentence, not only the binding | PASS |
| flag true from construction | "not before the search" goes red | PASS |
| flag set on the too-short early return | that test red, the normal one green | PASS |
| flag set when winget is missing | that test red, the normal one green | PASS |
| `Variables.Count > 0` half dropped | the unread test red, the match test green | PASS |

Two of my own mutations were wrong first and were corrected rather than worked around: setting `SearchFoundNothing` at the *top* of the search cannot be seen by either timing test (one asserts before any search runs, the other returns before that line is reached — so the mutation was inert, not the tests weak), and the `WingetUnavailable` assignment appears twice in the file, so the anchor had to include the log line above it.

One test assertion was also too broad and was tightened: `DidNotReceiveWithAnyArgs()` caught the constructor's legitimate `winget list --disable-interactivity`, so the too-short-query test now names the *search* command specifically.

## A test that would have started a process

`NewVm()` in `BulkInstallerViewModelTests` builds a real `PowerShellRunner`, which on the search path means launching an actual `winget search` — a live process, a network round-trip, and an answer that depends on the machine. The new tests go through a substituted runner instead; the service collects `LineReceived` around `RunProcessAsync`, so a runner that emits nothing *is* a search that matched nothing.

## Verification

- `dotnet build` on all four projects: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: clean.
- Regression sweep — every `ArchitectureTests` guard plus the Bulk Installer and Environment Variables suites: **210 green, 1 red**, the red being the local throwaway runner's own `Program.cs` missing an author header, which is not in the repository.
- Version consistency (csproj ×3, newest CHANGELOG entry, SECURITY table): consistent at 1.76.19.
- Leak scan over the diff with all 43 current terms: one hit, a pre-existing CHANGELOG history line naming a Windows feature the Privacy tab toggles; `git diff` confirms it is not part of this change.

## Deferred to the secondary workstation

Seeing the three states on screen. `ui-mockups/no-results-states.html` has before/after for each, plus the Privacy exemption written out; the main workstation does not run the app.
