### PR TITLE
fix: mark the two destructive buttons that did not look destructive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.20] - 2026-09-07
+
+Deleting a saved volume preset in Audio Mixer wipes it off the disk straight away, and the Delete button was
+the quietest control in its row — quieter than Apply next to it. It is now red, like every other button in
+SysManager that destroys something. The kill button in Processes is marked more clearly too.
+
+### Fixed
+- **Deleting a volume preset now looks like deleting.** The button rewrote the presets file immediately with
+  no way back, while wearing the same understated style as Cancel or Refresh. The confirmation prompt was
+  already there; what was missing was the warning *before* the click. It now uses the same red as Shortcut
+  Cleaner, Debloater, Uninstaller, File Shredder and the rest.
+- **The kill button in Processes is marked the way the rest of the app marks danger.** It was red text on a
+  transparent button — the only place in SysManager that signalled danger that way, so it was easy to read as
+  ordinary. It now has a red outline that fills solid red the moment you point at it, matching every other
+  destructive button while it is pointed at, and staying calm in a list that can run to several hundred rows.
+
 ## [1.76.19] - 2026-09-07
 
 Three lists used to go blank without saying why. Search winget for something that does not exist and the

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1545,6 +1545,100 @@ public partial class ArchitectureTests
     private static partial Regex SearchableFieldSpan();
 
     /// <summary>
+    /// A button whose command destroys something at click time must look like it.
+    /// </summary>
+    /// <remarks>
+    /// #2008 recorded two attempts at making this mechanical and both fail against the real code, so this
+    /// is neither of them. Matching LABELS catches "Deselect All", "Remove duplicates" and "Save current as
+    /// preset" — precision far too low to gate a build. Matching CONFIRMATION DIALOGS looks better, since a
+    /// command calling <c>DialogService.Instance.Confirm</c> reads like the app marking its own irreversible
+    /// actions, but of 25 buttons bound to a confirming command only 3 wear a destructive style and the
+    /// other 22 are right as they are: <c>SelectAll</c> confirms because selecting everything is a big
+    /// action, <c>ApplyChanges</c> because it writes staged edits. Confirmation means "this is significant",
+    /// not "this destroys something".
+    /// <para>What IS mechanical is a list. Each row names a command that performs an immediate,
+    /// unrecoverable change and the style its button must carry — data, not a heuristic, so it has no
+    /// false positives to argue with, and adding the next one is one row. It catches the regression
+    /// #1615 actually was: Shortcut Cleaner's "Delete Selected" quietly wearing <c>SecondaryButton</c>.</para>
+    /// <para>The staged-edit commands are deliberately absent, and that is the judgement the list encodes.
+    /// <c>DeleteVariableCommand</c> looks like the strongest candidate in the app and is not one: it removes
+    /// a row from an in-memory collection and says "deleted for real when you press Apply", with Discard
+    /// able to undo it. #2008's own table lists it as an immediate deletion, which is wrong by the exemption
+    /// the same issue defines for <c>RemoveDirectory</c>, <c>RemoveEntry</c>, <c>RemoveItem</c> and
+    /// <c>RemoveTarget</c>.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryImmediatelyDestructiveButton_WearsADestructiveStyle()
+    {
+        // command → (view, acceptable styles). Two styles are acceptable because one destructive control per
+        // screen and one per DataGrid row are different problems: ~470 filled red buttons in a process list
+        // read as "this screen is dangerous" rather than "this button is".
+        (string Command, string View, string[] Styles)[] destructive =
+        [
+            ("DeletePresetCommand", "AudioMixerView.xaml", ["DangerButton"]),
+            ("KillProcessCommand", "ProcessManagerView.xaml", ["DangerButton", "DangerGhostButton"]),
+            ("DeleteSelectedCommand", "ShortcutCleanerView.xaml", ["DangerButton"]),
+            ("ShredAllCommand", "FileShredderView.xaml", ["DangerButton"]),
+            ("UninstallSelectedCommand", "UninstallerView.xaml", ["DangerButton"]),
+        ];
+
+        var appDir = FindAppProjectDir();
+        var viewsDir = Path.Combine(appDir, "Views");
+        var offenders = new List<string>();
+        var checkedButtons = 0;
+
+        // Every style named above must exist. Found by mutating this guard: deleting DangerGhostButton
+        // outright leaves the app BUILDING and this test GREEN, because a StaticResource inside a
+        // DataTemplate is resolved when the template is realised, not at compile time — so the reference
+        // survives compilation and throws only when the user opens that tab. The compiler is no protection
+        // here, which makes checking the definition part of the job rather than belt-and-braces.
+        var appXaml = File.ReadAllText(Path.Combine(appDir, "App.xaml"));
+        foreach (var style in destructive.SelectMany(d => d.Styles).Distinct(StringComparer.Ordinal))
+            if (!appXaml.Contains($"x:Key=\"{style}\"", StringComparison.Ordinal))
+                offenders.Add($"App.xaml — the style {style} is referenced but no longer defined; "
+                              + "the tab using it will throw when it opens");
+
+        foreach (var (command, view, styles) in destructive)
+        {
+            var path = Path.Combine(viewsDir, view);
+            Assert.True(File.Exists(path), $"{path} not found — this guard would pass vacuously");
+
+            var xaml = Collapse(File.ReadAllText(path));
+            var at = xaml.IndexOf(command, StringComparison.Ordinal);
+            if (at < 0)
+            {
+                offenders.Add($"{view} — nothing binds {command} any more; update this guard or the view");
+                continue;
+            }
+
+            checkedButtons++;
+
+            // The button's own element: back to the nearest "<Button" and forward to its close. A window
+            // around the command reference would reach into the neighbouring control's style.
+            var open = xaml.LastIndexOf("<Button", at, StringComparison.Ordinal);
+            var close = xaml.IndexOf('>', at);
+            if (open < 0 || close < 0)
+            {
+                offenders.Add($"{view} — could not read the element around {command}");
+                continue;
+            }
+
+            var element = xaml[open..close];
+            if (!styles.Any(style => element.Contains($"StaticResource {style}", StringComparison.Ordinal)))
+                offenders.Add($"{view} — {command} is on a button styled as neither "
+                              + string.Join(" nor ", styles));
+        }
+
+        Assert.True(checkedButtons == destructive.Length,
+            $"only {checkedButtons} of {destructive.Length} listed commands were found in their views");
+
+        Assert.True(offenders.Count == 0,
+            "These buttons perform an immediate, unrecoverable change while looking like an ordinary "
+            + "action, so the only warning the user gets arrives after the click:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
     /// Each list that can filter itself down to nothing must have something to say when it does.
     /// </summary>
     /// <remarks>

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -480,6 +480,68 @@
                 </Setter>
             </Style>
 
+            <!--
+                DangerGhostButton — a destructive action that repeats once per row.
+
+                DangerButton is the app's mark for "this destroys something", and every use of it is a
+                single deliberate control in a toolbar or a footer. Process Manager's kill button is the
+                first destructive control that appears once per DataGrid row, and this machine lists ~470
+                processes: filling all of them red reads as "this whole screen is dangerous" rather than
+                "this button is", which spends the loudest signal in the app on nothing.
+
+                So: red outline and red glyph at rest, and a solid red fill on hover or keyboard focus, at
+                which point it looks exactly like every other destructive action. Restraint in the grid,
+                the full signal the moment the pointer is on it.
+
+                It exists as a NAMED style because the treatment was previously a GhostButton carrying
+                Foreground="{DynamicResource Danger}" inline — the only place in the app marking danger
+                that way, so one meaning had two mechanisms and the next row-level destructive button had
+                to guess. A style can be reused and can be found; a pair of attributes in a DataTemplate
+                cannot.
+            -->
+            <Style x:Key="DangerGhostButton" TargetType="Button" BasedOn="{StaticResource ButtonBase}">
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="BorderThickness" Value="1"/>
+                <Setter Property="Foreground" Value="{DynamicResource Danger}"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="Bd" Background="Transparent" CornerRadius="{StaticResource RadiusMd}"
+                                    Padding="{TemplateBinding Padding}"
+                                    BorderThickness="1" BorderBrush="{DynamicResource Danger}">
+                                <ContentPresenter x:Name="Cp" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                  TextBlock.Foreground="{TemplateBinding Foreground}"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Danger}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextOnDanger}"/>
+                                </Trigger>
+                                <Trigger Property="IsPressed" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Danger}"/>
+                                    <Setter TargetName="Bd" Property="Opacity" Value="0.75"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextOnDanger}"/>
+                                </Trigger>
+                                <!-- Keyboard focus gets the same fill as hover: a red outline alone is not a
+                                     visible focus indicator against a red border. -->
+                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Danger}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextOnDanger}"/>
+                                </Trigger>
+                                <!-- Disabled greys out to a neutral border rather than fading red, for the
+                                     same reason DangerButton owns its own template: a faded red on a light
+                                     preset is both illegible and still alarming. -->
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Border1}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
+                                    <Setter Property="Opacity" Value="0.6"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
             <!-- ============================================================ -->
             <!-- ToggleSwitch — purple pill toggle (on/off/locked)             -->
             <!-- ============================================================ -->

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.19</Version>
-    <FileVersion>1.76.19.0</FileVersion>
-    <AssemblyVersion>1.76.19.0</AssemblyVersion>
+    <Version>1.76.20</Version>
+    <FileVersion>1.76.20.0</FileVersion>
+    <AssemblyVersion>1.76.20.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AudioMixerView.xaml
+++ b/SysManager/SysManager/Views/AudioMixerView.xaml
@@ -35,8 +35,11 @@
                 <Button Content="Apply" Command="{Binding ApplyPresetCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
                         AutomationProperties.Name="Apply selected preset"/>
+                <!-- DangerButton: DeletePreset rewrites the presets file on disk immediately, so there is
+                     no undo, and it was the quietest control in its own row. The confirmation dialog was
+                     already there; what was missing is the signal BEFORE the click. -->
                 <Button Content="Delete" Command="{Binding DeletePresetCommand}"
-                        Style="{StaticResource GhostButton}" Margin="0,0,16,0"
+                        Style="{StaticResource DangerButton}" Margin="0,0,16,0"
                         AutomationProperties.Name="Delete selected preset"/>
 
                 <TextBox Text="{Binding NewPresetName, UpdateSourceTrigger=PropertyChanged}"

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -155,6 +155,13 @@
                         <DataGridTemplateColumn Header="" Width="Auto">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
+                                    <!-- GhostButton is correct here and a sweep must not "fix" it to
+                                         DangerButton. DeleteVariable deletes nothing at click time: it
+                                         removes the row from the in-memory list and says so — "removed
+                                         locally now, deleted for real when you press Apply" — with Discard
+                                         still able to undo it. Painting a staged edit red spends the app's
+                                         strongest signal on something reversible, which is what makes it
+                                         stop meaning anything where it counts. -->
                                     <Button Content="Delete" Command="{Binding DataContext.DeleteVariableCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
                                             CommandParameter="{Binding}"
                                             AutomationProperties.Name="{Binding Name, StringFormat='Delete variable {0}'}"

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -271,12 +271,18 @@
                                             IsEnabled="{Binding CanOpenFileLocation}"
                                             Style="{StaticResource GhostButton}" Padding="4,2" FontSize="12"
                                             Margin="0,0,4,0"/>
+                                    <!-- DangerGhostButton, not GhostButton + an inline Danger foreground:
+                                         the old form was the only place in the app marking danger that way,
+                                         so one meaning had two mechanisms. Not DangerButton either — this
+                                         repeats once per row, and ~470 filled red buttons in one grid read
+                                         as "this screen is dangerous" instead of "this button is". The
+                                         style fills solid red on hover, so it matches every other
+                                         destructive action the moment the pointer is on it. -->
                                     <Button Content="X" ToolTip="Kill process"
                                             AutomationProperties.Name="{Binding Name, StringFormat='Kill {0}'}"
                                             Command="{Binding DataContext.KillProcessCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                             CommandParameter="{Binding}"
-                                            Style="{StaticResource GhostButton}" Padding="6,2" FontSize="12"
-                                            Foreground="{DynamicResource Danger}"/>
+                                            Style="{StaticResource DangerGhostButton}" Padding="6,2" FontSize="12"/>
                                 </StackPanel>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
Closes #2008

## Audio Mixer · Delete preset

`DeletePresetCommand` calls `_presets.Delete(name)`, which rewrites the presets file on disk immediately. The code says so itself: *"there is no undo."* It was wearing `GhostButton`, making it the quietest control in a row that also holds Apply.

Now `DangerButton`, the same style Shortcut Cleaner, Debloater, Uninstaller, File Shredder, Scheduled Maintenance, Edge/OneDrive and File Lock already use. The confirmation dialog was already there; what was missing was the signal *before* the click.

## Process Manager · the per-row kill button

It was a `GhostButton` carrying `Foreground="{DynamicResource Danger}"` inline — red text on a transparent button, and the only place in the app marking danger that way. It was never *unmarked*; the problem is that one meaning had two mechanisms, so the next person writing a row-level destructive button had to guess.

**It is deliberately not simply moved to `DangerButton`.** Every existing `DangerButton` is one considered control in a toolbar or a footer. This one repeats once per `DataGrid` row, and this machine lists ~470 processes — filling all of them reads as "this whole screen is dangerous" rather than "this button is", which spends the loudest signal in the app on nothing.

So the ad-hoc treatment becomes a named style, **`DangerGhostButton`**: red outline and red glyph at rest, solid red fill on hover *and* on keyboard focus, at which point it looks exactly like every other destructive action. Restraint in the grid, the full signal the moment the pointer is on it. It also gives the button a real border, which the project's interaction contract asks for and which red-text-on-ghost only had by inheriting `GhostButton`'s neutral one.

Keyboard focus gets the same fill as hover on purpose: a red outline alone is not a visible focus indicator against a red border.

All three options are in `ui-mockups/destructive-button-styles.html`, including the rejected wall-of-red.

## A correction to #2008's own table

**Environment Variables' Delete is not an immediate deletion, and stays on `GhostButton`.** Its own dialog says so:

> It is removed locally now and deleted for real when you press Apply.

The command removes the row from the in-memory collection, recomputes pending changes, and sets the status to *"press Apply to delete it"* — with Discard able to undo it. That is exactly the case #2008 itself lists as **not** wrong, under the same rule it applies to `RemoveDirectory`, `RemoveEntry`, `RemoveItem` and `RemoveTarget`: a staged edit is not destructive until Apply.

A comment now says this in the view, so a future uniformity sweep does not "fix" it. Painting a staged edit red spends the strongest signal in the app on something reversible, which is how that signal stops meaning anything where it counts.

## There is a mechanical guard after all

#2008 concluded there could not be one, and documented two rules that failed. Both were **heuristics**:

- **by label** — the regex also catches "Deselect All", "Remove duplicates", "Save current as preset"
- **by confirmation dialog** — of 25 buttons bound to a confirming command, only 3 wear a destructive style and the other 22 are right as they are; `SelectAll` confirms because selecting everything is a big action, `ApplyChanges` because it writes staged edits. Confirmation means "significant", not "destructive".

A curated **list** is neither. `EveryImmediatelyDestructiveButton_WearsADestructiveStyle` names five commands and the styles their buttons may carry — data, so it has no false positives to argue with, and adding the next one is one row. It covers the regression #1615 actually was (Shortcut Cleaner's "Delete Selected" quietly on `SecondaryButton`), not just the two buttons this PR touches.

The staged-edit commands are absent from the list, and that absence is the judgement it encodes.

## Red/green

| Mutation | Expected | Result |
|---|---|---|
| Audio Mixer Delete back on `GhostButton` | guard names `AudioMixerView` + `DeletePresetCommand` | PASS |
| kill button back on `GhostButton` | guard names `ProcessManagerView` | PASS |
| kill button on `DangerButton` instead | guard **stays green** — both are accepted for a per-row control | PASS |
| Shortcut Cleaner downgraded to `SecondaryButton` | guard covers buttons that were already correct | PASS |
| a listed command renamed in its view | guard fails on "not found", not silently on fewer buttons | PASS |
| `DangerGhostButton` deleted from App.xaml | guard names the missing style | PASS |

**The last one found a gap in the guard rather than confirming it.** Deleting the style outright left the app **building** and the guard **green**: a `StaticResource` inside a `DataTemplate` is resolved when the template is realised, not at compile time, so the reference survives compilation and would throw only when the user opens that tab. The compiler is no protection here — so the guard now also checks that every style it names is still defined in `App.xaml`.

## Verification

- `dotnet build` on all four projects: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: clean.
- Every `ArchitectureTests` guard: **96 green, 1 red** — the red is the local throwaway runner's own `Program.cs` missing an author header, which is not in the repository. The style-adjacent guards (`EveryPairedForegroundToken_IsBoundBySomeStyle`, `NoStyle_SuppressesTheKeyboardFocusIndicator`, `EveryTemplatedKeyboardControl_ProvidesAFocusVisual`) pass with the new style in place.
- Version consistency (csproj ×3, newest CHANGELOG entry, SECURITY table): consistent at 1.76.20.
- Leak scan over the diff with all 43 current terms: one hit, a pre-existing CHANGELOG history line naming a Windows feature the Privacy tab toggles; `git diff` confirms it is not part of this change.

## Deferred to the secondary workstation

Seeing the hover fill on a real screen, and checking the red outline against the six light presets. `Danger` and `TextOnDanger` are both theme tokens updated per preset by `ThemeService`, and the disabled state greys to a neutral border rather than fading red for exactly that reason — but the mockup is a dark-theme approximation, not a substitute for looking.
