### PR TITLE
fix: give the Windows Update category badges a per-theme fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.21] - 2026-09-07
+
+On any of the six light themes, the coloured category tags in Windows Update lost their colour. The text was
+right — red for Security, green for Defender, indigo for Driver — but the tinted pill behind it kept a shade
+mixed for the dark themes, which is invisible against a near-white card. The Category column is meant to be
+scannable at a glance, and on light themes it was not.
+
+### Fixed
+- **Windows Update category tags now get their colour on light themes too.** Ten tag colours were written
+  directly into the screen instead of coming from the theme, so they were correct on dark themes and washed
+  out on every light one. They now come from the same place as the text on them, and are mixed per theme —
+  the same treatment the text itself already had. Dark themes look the same as before.
+
 ## [1.76.20] - 2026-09-07
 
 Deleting a saved volume preset in Audio Mixer wipes it off the disk straight away, and the Delete button was

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -5870,8 +5870,20 @@ public partial class ArchitectureTests
             + string.Join("\n  ", offenders));
     }
 
-    /// <summary>A colour-bearing attribute given a literal hex value.</summary>
-    [GeneratedRegex(@"(?:Foreground|Background|Fill|Stroke|BorderBrush)=""#[0-9A-Fa-f]{6,8}""")]
+    /// <summary>
+    /// A colour-bearing attribute given a literal hex value, set directly OR through a
+    /// <c>&lt;Setter&gt;</c>.
+    /// </summary>
+    /// <remarks>
+    /// The <c>Setter</c> alternative is not defensive completeness — it is where the largest instance of
+    /// this defect actually lived. Windows Update's category badge set its fill in a Style, so the colour
+    /// arrived as <c>&lt;Setter Property="Background" Value="#14EF4444"/&gt;</c>: the attribute carrying the
+    /// literal is <c>Value</c>, which the direct-attribute pattern cannot match. Twenty literals sat in
+    /// that one file while this guard reported the whole view layer clean, and the badge kept a
+    /// dark-calibrated tint on all six light presets — the one part of the theme system that never
+    /// recomputed per preset.
+    /// </remarks>
+    [GeneratedRegex(@"(?:(?:Foreground|Background|Fill|Stroke|BorderBrush)=""#[0-9A-Fa-f]{6,8}""|<Setter\s+Property=""(?:Foreground|Background|Fill|Stroke|BorderBrush)""\s+Value=""#[0-9A-Fa-f]{6,8}"")")]
     private static partial Regex LiteralColourAttribute();
 
     /// <summary>

--- a/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
+++ b/SysManager/SysManager.Tests/ThemeStatusBrushTests.cs
@@ -81,6 +81,73 @@ public class ThemeStatusBrushTests
         }
     }
 
+    /// <summary>
+    /// The dark and light arrays define exactly the same keys.
+    /// </summary>
+    /// <remarks>
+    /// The failure mode is silent, which is why it needs a test rather than care. A key added to one array
+    /// only is not an error anywhere: <c>ApplyStatusBrushes</c> iterates whichever array the current mode
+    /// selects, so the brush simply never gets created in the other mode and every
+    /// <c>{DynamicResource}</c> naming it resolves to nothing — the element keeps whatever it inherited and
+    /// looks *plausible*. The whole point of this palette is that light presets get their own value, so a
+    /// key present in dark and missing in light produces exactly the bug the palette exists to prevent, on
+    /// the themes least likely to be the one a developer had open.
+    /// <para>Whole key set rather than a list of names, so it covers the next family added without being
+    /// edited — this is the same reasoning as the four-key test above, which it now supersedes for
+    /// completeness while that one keeps naming the load-bearing four explicitly.</para>
+    /// </remarks>
+    [Fact]
+    public void Palette_DefinesTheSameKeys_InBothModes()
+    {
+        var dark = ThemeService.StatusPalette(isDark: true).Select(p => p.Key).ToHashSet(StringComparer.Ordinal);
+        var light = ThemeService.StatusPalette(isDark: false).Select(p => p.Key).ToHashSet(StringComparer.Ordinal);
+
+        // Vacuity floor: an empty set on both sides would satisfy set equality while pinning nothing.
+        Assert.True(dark.Count >= 30, $"only {dark.Count} dark keys — the palette lookup is wrong");
+
+        var darkOnly = dark.Except(light, StringComparer.Ordinal).Order().ToList();
+        var lightOnly = light.Except(dark, StringComparer.Ordinal).Order().ToList();
+
+        Assert.True(darkOnly.Count == 0,
+            "these keys exist in the DARK palette only, so on every light preset they resolve to nothing "
+            + "and the elements naming them silently keep an inherited colour:\n  "
+            + string.Join("\n  ", darkOnly));
+
+        Assert.True(lightOnly.Count == 0,
+            "these keys exist in the LIGHT palette only, so on dark themes they resolve to nothing:\n  "
+            + string.Join("\n  ", lightOnly));
+    }
+
+    /// <summary>
+    /// Every subtle badge fill is more opaque on light than on dark.
+    /// </summary>
+    /// <remarks>
+    /// The convention the existing entries already follow, and the reason these could not simply be one
+    /// shared value: an 8%-alpha tint that reads clearly over a dark surface is essentially invisible over a
+    /// near-white one. Light <c>SuccessBgSubtle</c> is <c>#2622C55E</c> against dark's <c>#1A22C55E</c> —
+    /// same green, more of it. Asserted on alpha rather than on contrast because these are decorative fills
+    /// behind text that is already AA by its own <c>…Text</c> brush; the failure being pinned is a fill
+    /// nobody can see, not unreadable text.
+    /// </remarks>
+    [Theory]
+    [InlineData("BadgeIndigoBgSubtle")]
+    [InlineData("BadgePurpleBgSubtle")]
+    [InlineData("BadgePinkBgSubtle")]
+    [InlineData("BadgeNeutralBgSubtle")]
+    [InlineData("SuccessBgSubtle")]
+    [InlineData("DangerBgSubtle")]
+    [InlineData("InfoBgSubtle")]
+    [InlineData("WarningBgSubtle")]
+    public void SubtleFill_IsMoreOpaqueOnLightThanOnDark(string key)
+    {
+        var dark = Lookup(ThemeService.StatusPalette(true), key);
+        var light = Lookup(ThemeService.StatusPalette(false), key);
+
+        Assert.True(light.A > dark.A,
+            $"{key} is alpha {light.A} on light and {dark.A} on dark — a tint calibrated for a dark surface "
+            + "disappears over a near-white one, which is the whole reason this palette is per-mode");
+    }
+
     // Base semantic brushes (Info/Success/Warning/Danger) are used directly as small-text Foreground
     // across the app (e.g. Cleanup's TEMP-folders stat). They were static App.xaml resources that never
     // recomputed per mode, so their light-cyan/green/amber/red washed out on near-white light surfaces.

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -427,6 +427,10 @@ public sealed class ThemeService
         [
             ("WarningText", C("#FCD34D")), ("WarningBgSubtle", C("#1AFBBF24")),
             ("WarningBg", C("#40FBBF24")), ("WarningStripe", C("#FBBF24")),
+            // WarningBorder completes the family: Success, Info and Danger each had a Border and Warning
+            // did not, so the one badge tinted amber had to keep a literal where its three neighbours
+            // could use a brush.
+            ("WarningBorder", C("#33FBBF24")),
             ("SuccessText", C("#4ADE80")), ("SuccessBgSubtle", C("#1A22C55E")), ("SuccessBorder", C("#3322C55E")),
             ("InfoText", C("#7DD3FC")), ("InfoBgSubtle", C("#1A38BDF8")), ("InfoBorder", C("#3338BDF8")),
             ("DangerText", C("#F87171")), ("DangerBgSubtle", C("#1AEF4444")), ("DangerBorder", C("#33EF4444")),
@@ -439,6 +443,17 @@ public sealed class ThemeService
             // so they get their own per-preset brushes (Security/Defender/Servicing reuse Danger/Success/
             // Info text). Dark = the previous hardcoded Tailwind-300 tints; light darkened for AA.
             ("BadgeIndigoText", C("#A5B4FC")), ("BadgePurpleText", C("#D8B4FE")), ("BadgePinkText", C("#F9A8D4")),
+            // …and the fills behind that text, which stayed hardcoded when the text was migrated. The
+            // badge kept an 8%-alpha dark-calibrated tint on every light preset, so on light themes the
+            // text correctly darkened to indigo-700/purple-700/pink-800 while its background did not
+            // follow — the Category column lost the colour-coding that makes it scannable.
+            // One NEUTRAL family covers three rows that used two different slates (#475569 for "no
+            // category matched", #94A3B8 for Hidden and History). At 8% alpha over the same surface the
+            // two are indistinguishable, so keeping them apart bought a distinction nobody can see.
+            ("BadgeIndigoBgSubtle", C("#1A6366F1")), ("BadgeIndigoBorder", C("#336366F1")),
+            ("BadgePurpleBgSubtle", C("#1AA855F7")), ("BadgePurpleBorder", C("#33A855F7")),
+            ("BadgePinkBgSubtle", C("#1AEC4899")), ("BadgePinkBorder", C("#33EC4899")),
+            ("BadgeNeutralBgSubtle", C("#1A94A3B8")), ("BadgeNeutralBorder", C("#3394A3B8")),
 
             // Base semantic brushes (used directly as small-text Foreground / dot Fill across the app,
             // e.g. Cleanup's TEMP-folders stat). These were static App.xaml resources that never
@@ -463,6 +478,7 @@ public sealed class ThemeService
         [
             ("WarningText", C("#92400E")), ("WarningBgSubtle", C("#26FBBF24")),   // amber-800 text — AA on white
             ("WarningBg", C("#40FBBF24")), ("WarningStripe", C("#D97706")),
+            ("WarningBorder", C("#55FBBF24")),
             ("SuccessText", C("#15803D")), ("SuccessBgSubtle", C("#2622C55E")), ("SuccessBorder", C("#5522C55E")),
             ("InfoText", C("#0369A1")), ("InfoBgSubtle", C("#2638BDF8")), ("InfoBorder", C("#5538BDF8")),
             ("DangerText", C("#B91C1C")), ("DangerBgSubtle", C("#26EF4444")), ("DangerBorder", C("#55EF4444")),
@@ -473,6 +489,14 @@ public sealed class ThemeService
             // Category badges darkened for AA on light presets (indigo-700 / purple-700 / pink-800).
             // pink-800 #9D174D (not pink-700) clears 4.5:1 on the most-tinted light surface #FBCFE8.
             ("BadgeIndigoText", C("#4338CA")), ("BadgePurpleText", C("#7E22CE")), ("BadgePinkText", C("#9D174D")),
+            // Badge fills on light: the same hue at higher alpha, which is the convention the existing
+            // light entries already follow (light SuccessBgSubtle is #2622C55E against dark's #1A22C55E —
+            // same green, more of it). An 8%-alpha tint over a near-white surface is essentially
+            // invisible, which is exactly why these could not simply be shared with the dark array.
+            ("BadgeIndigoBgSubtle", C("#266366F1")), ("BadgeIndigoBorder", C("#556366F1")),
+            ("BadgePurpleBgSubtle", C("#26A855F7")), ("BadgePurpleBorder", C("#55A855F7")),
+            ("BadgePinkBgSubtle", C("#26EC4899")), ("BadgePinkBorder", C("#55EC4899")),
+            ("BadgeNeutralBgSubtle", C("#2694A3B8")), ("BadgeNeutralBorder", C("#5594A3B8")),
 
             // Light: darker, saturated tones that meet WCAG AA as SMALL text — not just on pure white,
             // but on the most-tinted light preset card surface (soft-blossom Surface2 #FBCFE8 is the

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.20</Version>
-    <FileVersion>1.76.20.0</FileVersion>
-    <AssemblyVersion>1.76.20.0</AssemblyVersion>
+    <Version>1.76.21</Version>
+    <FileVersion>1.76.21.0</FileVersion>
+    <AssemblyVersion>1.76.21.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -284,44 +284,44 @@
                                         BorderThickness="1">
                                     <Border.Style>
                                         <Style TargetType="Border">
-                                            <Setter Property="Background" Value="#14475569"/>
-                                            <Setter Property="BorderBrush" Value="#28475569"/>
+                                            <Setter Property="Background" Value="{DynamicResource BadgeNeutralBgSubtle}"/>
+                                            <Setter Property="BorderBrush" Value="{DynamicResource BadgeNeutralBorder}"/>
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding Category}" Value="Security">
-                                                    <Setter Property="Background" Value="#14EF4444"/>
-                                                    <Setter Property="BorderBrush" Value="#28EF4444"/>
+                                                    <Setter Property="Background" Value="{DynamicResource DangerBgSubtle}"/>
+                                                    <Setter Property="BorderBrush" Value="{DynamicResource DangerBorder}"/>
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding Category}" Value="Cumulative">
-                                                    <Setter Property="Background" Value="#14F59E0B"/>
-                                                    <Setter Property="BorderBrush" Value="#28F59E0B"/>
+                                                    <Setter Property="Background" Value="{DynamicResource WarningBgSubtle}"/>
+                                                    <Setter Property="BorderBrush" Value="{DynamicResource WarningBorder}"/>
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding Category}" Value="Defender">
-                                                    <Setter Property="Background" Value="#1422C55E"/>
-                                                    <Setter Property="BorderBrush" Value="#2822C55E"/>
+                                                    <Setter Property="Background" Value="{DynamicResource SuccessBgSubtle}"/>
+                                                    <Setter Property="BorderBrush" Value="{DynamicResource SuccessBorder}"/>
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding Category}" Value="Driver">
-                                                    <Setter Property="Background" Value="#146366F1"/>
-                                                    <Setter Property="BorderBrush" Value="#286366F1"/>
+                                                    <Setter Property="Background" Value="{DynamicResource BadgeIndigoBgSubtle}"/>
+                                                    <Setter Property="BorderBrush" Value="{DynamicResource BadgeIndigoBorder}"/>
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding Category}" Value="Servicing">
-                                                    <Setter Property="Background" Value="#1438BDF8"/>
-                                                    <Setter Property="BorderBrush" Value="#2838BDF8"/>
+                                                    <Setter Property="Background" Value="{DynamicResource InfoBgSubtle}"/>
+                                                    <Setter Property="BorderBrush" Value="{DynamicResource InfoBorder}"/>
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding Category}" Value=".NET">
-                                                    <Setter Property="Background" Value="#14A855F7"/>
-                                                    <Setter Property="BorderBrush" Value="#28A855F7"/>
+                                                    <Setter Property="Background" Value="{DynamicResource BadgePurpleBgSubtle}"/>
+                                                    <Setter Property="BorderBrush" Value="{DynamicResource BadgePurpleBorder}"/>
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding Category}" Value="Feature upgrade">
-                                                    <Setter Property="Background" Value="#14EC4899"/>
-                                                    <Setter Property="BorderBrush" Value="#28EC4899"/>
+                                                    <Setter Property="Background" Value="{DynamicResource BadgePinkBgSubtle}"/>
+                                                    <Setter Property="BorderBrush" Value="{DynamicResource BadgePinkBorder}"/>
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding Category}" Value="Hidden">
-                                                    <Setter Property="Background" Value="#1494A3B8"/>
-                                                    <Setter Property="BorderBrush" Value="#2894A3B8"/>
+                                                    <Setter Property="Background" Value="{DynamicResource BadgeNeutralBgSubtle}"/>
+                                                    <Setter Property="BorderBrush" Value="{DynamicResource BadgeNeutralBorder}"/>
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding Category}" Value="History">
-                                                    <Setter Property="Background" Value="#1494A3B8"/>
-                                                    <Setter Property="BorderBrush" Value="#2894A3B8"/>
+                                                    <Setter Property="Background" Value="{DynamicResource BadgeNeutralBgSubtle}"/>
+                                                    <Setter Property="BorderBrush" Value="{DynamicResource BadgeNeutralBorder}"/>
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>


### PR DESCRIPTION
Closes #1617

## The half-migration

The badge text was moved to per-preset brushes and the migration stopped at the background. The same `DataTemplate` reads `DangerText` / `WarningText` / `SuccessText` / `BadgeIndigoText` for its label and kept **twenty hardcoded ARGB tints** for its fill and border — with an in-file comment explaining why the *text* had to move ("fell to ~1.8:1 on the light presets").

So on every light preset the text correctly darkened to indigo-700 / purple-700 / pink-800 while the pill behind it stayed an 8%-alpha dark-theme tint. The Category column is meant to be scannable at a glance, and on six of twelve presets it was not. It was the last hole in a theme system that deliberately recomputes every status brush per preset.

## Reuse before invention

| Category | was | now |
|---|---|---|
| Security | `#14EF4444` / `#28EF4444` | `DangerBgSubtle` / `DangerBorder` |
| Cumulative | `#14F59E0B` / `#28F59E0B` | `WarningBgSubtle` / **`WarningBorder`** (new) |
| Defender | `#1422C55E` / `#2822C55E` | `SuccessBgSubtle` / `SuccessBorder` |
| Servicing | `#1438BDF8` / `#2838BDF8` | `InfoBgSubtle` / `InfoBorder` |
| Driver | `#146366F1` / `#286366F1` | **`BadgeIndigoBgSubtle` / `BadgeIndigoBorder`** (new) |
| .NET | `#14A855F7` / `#28A855F7` | **`BadgePurpleBgSubtle` / `BadgePurpleBorder`** (new) |
| Feature upgrade | `#14EC4899` / `#28EC4899` | **`BadgePinkBgSubtle` / `BadgePinkBorder`** (new) |
| default, Hidden, History | `#14475569`/`#28475569` and `#1494A3B8`/`#2894A3B8` | **`BadgeNeutralBgSubtle` / `BadgeNeutralBorder`** (new, one family for all three) |

Four categories reuse the semantic families their **text** already reuses — the consistent completion rather than a parallel set of values. `WarningBorder` is added because Success, Info and Danger each had a Border and Warning did not, so the one amber badge had to keep a literal where its three neighbours could use a brush.

**Three neutral rows collapse onto one family.** They used two different slates — `#475569` for "no category matched", `#94A3B8` for Hidden and History — and at 8% alpha over the same surface those are indistinguishable. Keeping them apart bought a distinction nobody can see.

**Light values follow the convention the existing entries already set: same hue, higher alpha.** Light `SuccessBgSubtle` is `#2622C55E` against dark's `#1A22C55E` — same green, more of it. Dark adopts the family alphas (`#1A`/`#33`) rather than the badge's old `#14`/`#28`: a 20→26 alpha step on a decorative tint that no longer needs its own scale.

## The guard existed, with a hole exactly where the defect lived

`NoViewPaintsItselfWithALiteralColour` matches `Background="#..."` as a **direct attribute**. The badge set its fill in a `Style`, so the literal arrived as:

```xml
<Setter Property="Background" Value="#14EF4444"/>
```

The attribute carrying the colour is `Value`. Twenty literals sat in one file while the guard reported the whole view layer clean — and the guard's own failure message promises "these views set a colour the theme cannot change".

Tightened **in place** to match both shapes, never a parallel guard. Measured before changing it: the tightened pattern finds **zero** other `Setter`-shaped colour literals across the view layer, so nothing else moves.

## Two tests for the failure modes that are silent

- **`Palette_DefinesTheSameKeys_InBothModes`** closes the risk #1617 names. A key added to one array only is not an error anywhere: `ApplyStatusBrushes` iterates whichever array the current mode selects, so the brush is never created in the other mode and every `{DynamicResource}` naming it resolves to nothing — the element keeps what it inherited and looks *plausible*. Asserted on the whole key set, so it covers the next family added without being edited.
- **`SubtleFill_IsMoreOpaqueOnLightThanOnDark`** pins the convention across all eight subtle fills, on **alpha** rather than contrast: these sit behind text that is already AA by its own `…Text` brush, so the failure being caught is a fill nobody can see, not unreadable text.

## Red/green

| Mutation | Expected | Result |
|---|---|---|
| one literal restored as a `Setter` value | tightened guard names the view | PASS |
| one literal as a direct attribute | still caught — tightening lost nothing | PASS |
| **old regex** + a `Setter` literal | **GREEN** | PASS |
| a new key dropped from the light array | parity test names it as dark-only | PASS |
| a new key dropped from the dark array | parity test names it as light-only | PASS |
| a light fill given the dark alpha | the invisible-tint test names it | PASS |

The third row is the point of the exercise: it is not a hypothesis about why the literals survived, it is the old pattern demonstrated blind to the exact shape they were written in.

## A correction to #1617

The issue asks for `MainWindow.xaml`'s success-toast literals (`#4022C55E`, `#2022C55E`, `#22C55E`) to be swept in the same PR "to avoid a half-migration". **They are already gone** — `MainWindow.xaml` now measures 0 raw hex, so that half needs nothing. Re-derived, the view layer's remaining literals are LogsView's 4 `DropShadowEffect` glow colours and ThemePopup's 8 swatch placeholders, both refuted in the issue and both outside this guard's attribute set.

The comment on #1617 also asked to sequence this after the accent-foreground decision in #1621. #1621 closed on 2026-09-02, so that dependency is resolved.

## Verification

- `dotnet build` on all four projects: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: clean.
- Every `ArchitectureTests` guard plus the full theme-contrast suites: **269 green, 1 red** — the red is the local throwaway runner's own `Program.cs` missing an author header, which is not in the repository. `NoThemedFill_CarriesAHardcodedWhiteForeground` and `EveryThemeEntryPoint_GoesThroughTheLegibilityCorrection` pass with the new families in place.
- `WindowsUpdateView.xaml` now measures 0 raw hex, down from 20.
- Version consistency (csproj ×3, newest CHANGELOG entry, SECURITY table): consistent at 1.76.21.
- Leak scan over the diff with all 43 current terms: one hit, a pre-existing CHANGELOG history line naming a Windows feature the Privacy tab toggles; `git diff` confirms it is not part of this change.

## Deferred to the secondary workstation

Looking at the badges on the six light presets, which is the whole point of the change. The dark values are chosen to keep dark themes visually unchanged, and the tests pin alpha and key parity — but neither substitutes for seeing an indigo pill on a near-white card.
