### PR TITLE
fix: say why four more panels came back empty, and land the sweep for the class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.22] - 2026-09-07
+
+Four more places that went blank without saying why. The temperature card on the Landing tab looked broken on
+any PC whose sensors are not readable — which is most of them without administrator. "What's new" promised
+release notes pulled live from GitHub and then showed nothing when offline. The health score showed a number
+with an empty space under it. And removing every target in Ping left an empty panel.
+
+### Fixed
+- **The temperature card says when there is nothing to read.** Most machines expose no readable sensors
+  without administrator, and some expose none either way, so the card rendered as an empty box — which reads
+  as a broken feature rather than an unavailable one. It now says so, and mentions that running as
+  administrator reaches more.
+- **"What's new" says when it cannot reach GitHub.** The release-notes fetch failed silently when offline,
+  leaving a section that had just promised notes "pulled live from GitHub" completely empty. It now names the
+  reason and points at Refresh.
+- **The health score says when there is nothing to improve.** An empty recommendation list left the heading
+  over blank space. Since empty here is good news, it now says so plainly — the same way the Tune-up card
+  beside it already did.
+- **Ping says when you have removed every target.** The list starts from the shipped presets, so an empty one
+  means you emptied it; the message points at both ways back.
+
 ## [1.76.21] - 2026-09-07
 
 On any of the six light themes, the coloured category tags in Windows Update lost their colour. The text was

--- a/SysManager/SysManager.IntegrationTests/DashboardHealthFlagTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DashboardHealthFlagTests.cs
@@ -1,0 +1,57 @@
+// SysManager · DashboardHealthFlagTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.IntegrationTests;
+
+/// <summary>
+/// The Landing tab's "nothing needs attention" flag, against a real health scan.
+/// </summary>
+/// <remarks>
+/// Here rather than in <c>SysManager.Tests</c> because reaching the flag means running the scan:
+/// <c>LoadHealthScoreAsync</c> is not a command, only the init path calls it, and that path also starts the
+/// polling loops and queries WMI. <c>DashboardViewModelTests</c>' own summary says WMI-touching dashboard
+/// work lives in this project; the unit suite keeps the "starts false" half, which needs no scan.
+/// </remarks>
+public class DashboardHealthFlagTests
+{
+    private static DashboardViewModel NewVm()
+    {
+        var sys = new SystemInfoService();
+        var diskHealth = new DiskHealthService();
+        return new DashboardViewModel(sys,
+            new TuneUpService(new ShortcutCleanerService(), diskHealth, sys),
+            new HealthScoreService(sys, diskHealth, new BatteryService()),
+            new TemperatureService(diskHealth, skipHardwareInit: true),
+            new WingetService(new PowerShellRunner()),
+            // Redirected for the same reason DashboardViewModelTests does it: reading the crash marker
+            // CONSUMES it, and pointed at the real profile a test would delete a genuine crash report
+            // before the user was ever told about it (#1772).
+            new CrashMarkerService(Path.Combine(Path.GetTempPath(), "SysManagerTests", "dash-health-crash")),
+            new MemoryTestService());
+    }
+
+    /// <summary>
+    /// The flag agrees with the scan's own result on whatever machine this runs on.
+    /// </summary>
+    /// <remarks>
+    /// An implication rather than a fixed expectation: whether this PC has recommendations is a property of
+    /// the PC, and a test that demanded one answer would pass or fail on the host rather than on the code.
+    /// What must hold everywhere is that the line the card shows matches what the scan found — no
+    /// recommendations means it shows, any recommendation means it does not.
+    /// </remarks>
+    [Fact]
+    public async Task NothingToImproveFlag_AgreesWithTheScanResult()
+    {
+        var vm = NewVm();
+        await vm.InitializationComplete;
+
+        if (!vm.HasHealthScore) return;   // the scan itself failed on this host; nothing to imply
+        Assert.NotNull(vm.HealthResult);
+        Assert.Equal(vm.HealthResult!.Recommendations.Count == 0, vm.HealthHasNothingToImprove);
+    }
+}

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1639,6 +1639,210 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Every view that lists a collection must have something to say when that collection is empty.
+    /// </summary>
+    /// <remarks>
+    /// The repo-wide sweep #2121 asks for, landed only after all its views were resolved — an exception list
+    /// carrying reasons nobody has checked is a false claim sitting in the test suite, which is worse than
+    /// no guard.
+    /// <para><b>Four accepted forms, and the count is the point.</b> An earlier draft looked for two — the
+    /// shared <c>EmptyState</c> control, or a <c>.Count</c>-bound <c>Inverse</c> visibility — and on that
+    /// criterion eight views "had neither affordance". Three of the eight already said something, in forms
+    /// the criterion could not see: Profile Export/Import and the Tune-up card gate a message on a DOMAIN
+    /// FLAG (<c>HasSections</c>, <c>TuneUpResult.WarningCount</c>), and Recent Activity uses a
+    /// <c>DataTrigger</c> on <c>.Count</c> with <c>Value="0"</c> instead of a converter. A guard that
+    /// rejected those would have failed on the views that got it right.</para>
+    /// <para><b>But not any <c>Inverse</c>.</b> That was the opposite mistake, and it made an earlier version
+    /// blind to exactly the defect it was written for: deleting Traceroute's and System Health's new empty
+    /// states both left it green, satisfied by a <c>Shared.IsAutoTraceRunning</c> button binding and an
+    /// <c>IsElevated</c> admin banner. The bar is an <c>Inverse</c> on a path that READS as emptiness —
+    /// <c>Has…</c>, <c>No…</c>, <c>…Count</c>, <c>…Unavailable</c>, <c>…FoundNothing</c>, <c>…IsEmpty</c> —
+    /// so an elevation flag still does not qualify.</para>
+    /// <para>Exceptions carry a reason and every one was verified against how the collection is filled, not
+    /// assumed from its name.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryViewThatListsACollection_HasSomethingToSayWhenItIsEmpty()
+    {
+        // view -> why its collections cannot reach an empty state a user would see.
+        var cannotBeEmpty = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["TweaksHubView.xaml"] =
+                "Essential and Advanced are LoadTweaks() — the static privacy toggles — partitioned by "
+                + "TweakItem.ClassifyTier, so both sides are non-empty by construction. Pinned by "
+                + "TweaksHubViewModelTests.BothTiers_AreNonEmpty rather than left as an assertion here",
+            ["PrivacyView.xaml"] =
+                "FilteredToggles is filtered only by category, and Categories is built FROM the toggles "
+                + "(['All'] + Toggles.Select(t => t.Category).Distinct()), so every selectable category has "
+                + "at least one row and Toggles itself is static",
+            ["CliInterfaceView.xaml"] =
+                "Commands is CliRunner.Commands, a static collection-expression list of flag/description "
+                + "tuples compiled into the binary — it is the CLI's own help text, not data read at runtime",
+            ["LegacyPanelsView.xaml"] =
+                "Panels is LegacyPanelService.Panels, the fixed catalog of classic Windows applets, also a "
+                + "static list",
+            ["CpuAffinityView.xaml"] =
+                "Cores comes from GetCores(), which falls back to a flat list of LogicalProcessorCount "
+                + "entries when the topology API fails or returns nothing — so it yields at least one core "
+                + "on any machine that can run the app. (Its Processes ComboBox is a different question and "
+                + "outside this guard, which asks about DataGrid and ItemsControl.)",
+        };
+
+        var viewsDir = Path.Combine(FindAppProjectDir(), "Views");
+        var files = Directory.GetFiles(viewsDir, "*.xaml");
+        Assert.True(files.Length >= 25,
+            $"only {files.Length} views enumerated — this guard is reading the wrong folder");
+
+        var offenders = new List<string>();
+        var listing = 0;
+
+        foreach (var file in files)
+        {
+            var name = Path.GetFileName(file);
+            var xaml = File.ReadAllText(file);
+
+            if (!CollectionItemsSource().IsMatch(xaml)) continue;
+            listing++;
+
+            if (cannotBeEmpty.ContainsKey(name)) continue;
+
+            var hasControl = xaml.Contains("<v:EmptyState", StringComparison.Ordinal);
+            var hasEmptinessInverse = EmptinessInverseBinding().IsMatch(xaml);
+            var hasZeroCountTrigger = ZeroCountDataTrigger().IsMatch(xaml);
+
+            if (!hasControl && !hasEmptinessInverse && !hasZeroCountTrigger)
+                offenders.Add(name);
+        }
+
+        // Vacuity floor: 44 views matched when this was measured. A collapse to a handful means the
+        // ItemsSource pattern stopped matching and the guard is inspecting almost nothing.
+        Assert.True(listing >= 40,
+            $"only {listing} views were found listing a collection — the ItemsSource pattern is out of date");
+
+        Assert.True(offenders.Count == 0,
+            "These views list a collection and say nothing when it is empty, so the user gets a column "
+            + "header over blank space or a panel that simply vanishes — indistinguishable from a broken "
+            + "feature. Add the shared <v:EmptyState/>, or a message gated on an emptiness flag or a "
+            + "zero-count trigger. If the collection genuinely cannot be empty, name the view in the "
+            + "exception list in this test WITH the reason, verified against how it is filled:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// Every empty-state flag is set where the data it describes arrives, on all of that method's paths.
+    /// </summary>
+    /// <remarks>
+    /// A flag exists precisely because a count cannot tell "empty" from "not loaded yet", so it is only
+    /// worth anything if it is assigned at the moment the load resolves — including the failure paths, which
+    /// are exactly the ones a later edit forgets. <c>AboutViewModel.LoadHistoryAsync</c> has two catch
+    /// blocks and both must set it; either one missed leaves the section promising notes "pulled live from
+    /// GitHub" and rendering nothing.
+    /// <para>Source-shape rather than behavioural, deliberately, for the two that cannot be reached from a
+    /// unit test: <c>AboutViewModel</c> takes the concrete <c>UpdateService</c> so the catch blocks need a
+    /// network failure, and <c>LoadHealthScoreAsync</c> is private with only the init path calling it. Their
+    /// behaviour is covered where it can be — <c>DashboardHealthFlagTests</c> in the integration project —
+    /// but that project is compile-only in CI (#2101), so the wiring itself is pinned here, in the blocking
+    /// suite, where deleting it fails a merge.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryEmptyStateFlag_IsSetWhereItsDataArrives()
+    {
+        // (file, method, flag, how many assignments the method must contain, why that number)
+        (string File, string Method, string Flag, int Assignments, string Why)[] wiring =
+        [
+            ("ViewModels/AboutViewModel.cs", "LoadHistoryAsync", "HistoryUnavailable", 3,
+             "the success path plus BOTH catch blocks — a missed catch leaves the section silent on the "
+             + "failure it exists to explain"),
+            ("ViewModels/DashboardViewModel.cs", "LoadHealthScoreAsync", "HealthHasNothingToImprove", 1,
+             "set beside HasHealthScore, so the good-news line and the score appear together"),
+            ("ViewModels/DashboardViewModel.cs", "RefreshTemperaturesAsync", "TemperaturesUnavailable", 1,
+             "set once per read, and OUTSIDE the dispatcher hop — inside it the assignment is skipped "
+             + "whenever Application.Current is null, which is every unit test"),
+        ];
+
+        var appDir = FindAppProjectDir();
+        var offenders = new List<string>();
+
+        foreach (var (file, method, flag, expected, why) in wiring)
+        {
+            var path = Path.Combine(appDir, file.Replace('/', Path.DirectorySeparatorChar));
+            Assert.True(File.Exists(path), $"{path} not found — this guard would pass vacuously");
+
+            var body = MethodBody(File.ReadAllText(path), method);
+            if (body.Length == 0)
+            {
+                offenders.Add($"{file} — {method} not found; update this guard or the view-model");
+                continue;
+            }
+
+            var found = body.Split($"{flag} =").Length - 1;
+            if (found != expected)
+                offenders.Add($"{file}:{method} assigns {flag} {found} time(s), expected {expected} — {why}");
+        }
+
+        Assert.True(offenders.Count == 0,
+            "An empty-state flag that is not set where its load resolves is worse than no flag: the view "
+            + "shows nothing AND says nothing, and the count binding it replaced would at least have said "
+            + "something.\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The text of a method from its signature to its closing brace, by brace matching.
+    /// </summary>
+    /// <remarks>
+    /// Brace-matched rather than sliced to the next member declaration: an <c>if</c>/<c>try</c> body indents
+    /// its own statements, and a "next member at four spaces" heuristic stops early on a method whose braces
+    /// nest — which is every method with a try/catch, i.e. exactly the ones this guard is counting inside.
+    /// <para>Anchored on the DECLARATION, not on the name. Matching <c>" Name("</c> found
+    /// <c>await LoadHistoryAsync();</c> instead — both flags this guard watches are called from an init path
+    /// that appears hundreds of lines ABOVE their own declaration, so the brace match started from a call
+    /// site and counted zero assignments in a block that was not the method. It reported the wiring missing
+    /// while the wiring was there.</para>
+    /// </remarks>
+    private static string MethodBody(string source, string method)
+    {
+        var declaration = new Regex(
+            @"^\s*(?:\[[^\]]*\]\s*)*(?:private|internal|public|protected)[^\n(]*\b"
+            + Regex.Escape(method) + @"\s*\(",
+            RegexOptions.Multiline);
+
+        var match = declaration.Match(source);
+        if (!match.Success) return "";
+
+        var open = source.IndexOf('{', match.Index + match.Length);
+        if (open < 0) return "";
+
+        var depth = 0;
+        for (var i = open; i < source.Length; i++)
+        {
+            if (source[i] == '{') depth++;
+            else if (source[i] == '}' && --depth == 0) return source[open..(i + 1)];
+        }
+        return "";
+    }
+
+    /// <summary>A <c>DataGrid</c> or <c>ItemsControl</c> bound to a collection.</summary>
+    [GeneratedRegex(@"<(?:DataGrid|ItemsControl)\b[^>]*ItemsSource=""\{Binding", RegexOptions.Compiled)]
+    private static partial Regex CollectionItemsSource();
+
+    /// <summary>
+    /// An inverted visibility binding on a path that reads as emptiness rather than as any old flag.
+    /// </summary>
+    /// <remarks>
+    /// <c>[^"]*</c> for the span between path and parameter, not <c>[^}]*</c>: the converter sits between
+    /// them as <c>Converter={StaticResource FlexVis}</c>, and a class excluding <c>}</c> cannot reach across
+    /// it — that version matched nothing and flagged fourteen views, several verified by hand minutes
+    /// earlier. The attribute's own closing quote is the correct bound.
+    /// </remarks>
+    [GeneratedRegex(@"Binding\s+[\w.]*(?:Count|Has\w+|No\w+|\w*Unavailable|\w*FoundNothing|\w*IsEmpty|\w*NoResults|\w*NoMatches)[^""]*ConverterParameter=Inverse",
+                    RegexOptions.Compiled)]
+    private static partial Regex EmptinessInverseBinding();
+
+    /// <summary>A <c>DataTrigger</c> firing on a collection count of zero.</summary>
+    [GeneratedRegex(@"DataTrigger\s+Binding=""\{Binding\s+[\w.]*Count\}""\s+Value=""0""", RegexOptions.Compiled)]
+    private static partial Regex ZeroCountDataTrigger();
+
+    /// <summary>
     /// Each list that can filter itself down to nothing must have something to say when it does.
     /// </summary>
     /// <remarks>

--- a/SysManager/SysManager.Tests/DashboardViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DashboardViewModelTests.cs
@@ -36,6 +36,53 @@ public class DashboardViewModelTests
             new MemoryTestService());
     }
 
+    // ---------- empty states on the cards ----------
+
+    /// <summary>
+    /// A temperature read that comes back with nothing sets the flag the card explains itself with.
+    /// </summary>
+    /// <remarks>
+    /// The harness already models the machine this is for: <c>TemperatureService(skipHardwareInit: true)</c>
+    /// returns an empty list, which is exactly what a PC with no readable sensors produces — common, not
+    /// exotic, since most machines expose nothing without administrator. Before the flag the card rendered
+    /// as an empty box, which reads as a broken feature rather than an unavailable one.
+    /// <para>This is also why the assignment sits OUTSIDE the dispatcher hop in
+    /// <c>RefreshTemperaturesAsync</c>: inside it, the whole update is skipped when
+    /// <c>Application.Current</c> is null — every unit test — and the state would be assertable nowhere.</para>
+    /// </remarks>
+    [Fact]
+    public async Task RefreshTemperatures_WithNoReadableSensors_SaysSo()
+    {
+        var vm = NewVm();
+        Assert.False(vm.TemperaturesUnavailable);   // nothing read yet
+
+        await vm.RefreshTemperaturesCommand.ExecuteAsync(null);
+
+        Assert.Empty(vm.Temperatures);
+        Assert.True(vm.TemperaturesUnavailable);
+    }
+
+    /// <summary>
+    /// Neither empty-state flag is set before anything has been read.
+    /// </summary>
+    /// <remarks>
+    /// The half a count binding gets wrong. Both cards would otherwise announce their empty state during
+    /// the first load — "no sensors could be read" while the read is in flight, "nothing needs attention"
+    /// before the scan has looked at anything.
+    /// <para>The health flag's behaviour is asserted in
+    /// <c>SysManager.IntegrationTests.DashboardHealthFlagTests</c> rather than here, because reaching it
+    /// means running the real health scan: <c>LoadHealthScoreAsync</c> is not a command, only the init path
+    /// calls it, and that path also starts the polling loops and hits WMI. This class's own summary says
+    /// where that belongs.</para>
+    /// </remarks>
+    [Fact]
+    public void Constructor_EmptyStateFlags_StartFalse()
+    {
+        var vm = NewVm();
+        Assert.False(vm.TemperaturesUnavailable);
+        Assert.False(vm.HealthHasNothingToImprove);
+    }
+
     // ---------- construction & defaults ----------
 
     [Fact]

--- a/SysManager/SysManager.Tests/TweaksHubViewModelTests.cs
+++ b/SysManager/SysManager.Tests/TweaksHubViewModelTests.cs
@@ -151,4 +151,33 @@ public class TweaksHubViewModelTests
         Assert.Single(vm.Essential);
         Assert.Single(vm.Advanced);
     }
+
+    /// <summary>
+    /// The REAL tweak catalogue fills both tiers, which is what makes this tab's empty state unreachable.
+    /// </summary>
+    /// <remarks>
+    /// This is the verification behind an exemption rather than a behaviour test.
+    /// <c>ArchitectureTests.EveryViewThatListsACollection_HasSomethingToSayWhenItIsEmpty</c> excuses
+    /// <c>TweaksHubView</c> from needing empty-state copy, on the grounds that
+    /// <c>LoadTweaks()</c> is the static privacy toggles partitioned by <c>ClassifyTier</c> and both sides
+    /// are non-empty by construction. An exemption nobody checked is a false claim sitting in the test
+    /// suite, so it is checked here — against the real definitions, not a substitute, because a substitute
+    /// would be asserting the fixture.
+    /// <para>Straight through <c>PrivacyService</c> and <c>TweakItem.ClassifyTier</c> rather than through the
+    /// view-model: the claim is about the DATA, and building the view-model would drag in a registry read
+    /// per toggle for no extra coverage.</para>
+    /// </remarks>
+    [Fact]
+    public void TheRealTweakCatalogue_FillsBothTiers()
+    {
+        var toggles = new PrivacyService().LoadToggles();
+        Assert.True(toggles.Count >= 10,
+            $"only {toggles.Count} toggle definitions — the catalogue lookup is wrong and this would pass "
+            + "vacuously");
+
+        var tiers = toggles.Select(t => TweakItem.ClassifyTier(t.RegistryPath)).ToList();
+
+        Assert.Contains(TweakTier.Essential, tiers);
+        Assert.Contains(TweakTier.Advanced, tiers);
+    }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.21</Version>
-    <FileVersion>1.76.21.0</FileVersion>
-    <AssemblyVersion>1.76.21.0</AssemblyVersion>
+    <Version>1.76.22</Version>
+    <FileVersion>1.76.22.0</FileVersion>
+    <AssemblyVersion>1.76.22.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -36,6 +36,17 @@ public sealed partial class AboutViewModel : ViewModelBase
 
     [ObservableProperty] private IReadOnlyList<ReleaseNote> _releaseHistory = [];
 
+    /// <summary>
+    /// True when the release-notes fetch finished without producing anything, so the section can say why
+    /// instead of promising live notes and rendering nothing.
+    /// </summary>
+    /// <remarks>
+    /// Not <c>ReleaseHistory.Count == 0</c>: that is also true before the first load, and the fetch is the
+    /// slowest thing on the tab. A count binding would greet the user with "could not reach GitHub" while
+    /// the request was still in flight.
+    /// </remarks>
+    [ObservableProperty] private bool _historyUnavailable;
+
     [ObservableProperty] private string _currentVersion = UpdateService.CurrentVersion.ToString(3);
     [ObservableProperty] private string _buildDate = BuildStamp();
 
@@ -306,9 +317,22 @@ public sealed partial class AboutViewModel : ViewModelBase
             }).ToList();
 
             ReleaseHistory = notes;
+            HistoryUnavailable = notes.Count == 0;
         }
-        catch (HttpRequestException ex) { Log.Debug("Release history load skipped (network): {Error}", ex.Message); }
-        catch (TaskCanceledException ex) { Log.Debug("Release history load timed out: {Error}", ex.Message); }
+        // Both failures leave ReleaseHistory as it was — empty, on a first load — so the flag is what
+        // separates "GitHub could not be reached" from "there is nothing to show". Without it the section
+        // promised release notes "pulled live from GitHub" and then rendered nothing at all, which reads as
+        // the feature being broken rather than the connection being down.
+        catch (HttpRequestException ex)
+        {
+            Log.Debug("Release history load skipped (network): {Error}", ex.Message);
+            HistoryUnavailable = true;
+        }
+        catch (TaskCanceledException ex)
+        {
+            Log.Debug("Release history load timed out: {Error}", ex.Message);
+            HistoryUnavailable = true;
+        }
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -63,6 +63,27 @@ public sealed partial class DashboardViewModel : ViewModelBase
     [ObservableProperty] private bool _hasHealthScore;
     [ObservableProperty] private bool _isHealthScoreLoading;
 
+    /// <summary>
+    /// True once the health scan has run and found nothing worth recommending — good news, and something
+    /// the card should say rather than leaving its heading over empty space.
+    /// </summary>
+    /// <remarks>
+    /// A flag rather than <c>HealthResult.Recommendations.Count</c>, because before the scan finishes
+    /// <c>HealthResult</c> is null: the count binding fails, and a failed binding leaves Visibility at its
+    /// default, so the card would announce "nothing needs attention" before anything had been checked.
+    /// </remarks>
+    [ObservableProperty] private bool _healthHasNothingToImprove;
+
+    /// <summary>
+    /// True once a temperature read has completed and returned no sensors at all.
+    /// </summary>
+    /// <remarks>
+    /// Common rather than exotic: most machines expose nothing readable without administrator, and some
+    /// expose nothing either way. The card previously rendered as an empty box, which reads as a broken
+    /// feature. Set after the read so it cannot flash while the first one is still in flight.
+    /// </remarks>
+    [ObservableProperty] private bool _temperaturesUnavailable;
+
     // ── Temperatures ─────────────────────────────────────────────────────
     public BulkObservableCollection<TemperatureReading> Temperatures { get; } = new();
 
@@ -368,6 +389,13 @@ public sealed partial class DashboardViewModel : ViewModelBase
     private async Task RefreshTemperaturesAsync()
     {
         var readings = await _temps.ReadAllAsync();
+        // Set OUTSIDE the dispatcher hop, deliberately. A plain bool needs no UI thread — WPF marshals
+        // property-change notifications itself, and it is collection mutations that must be on it — while
+        // inside the hop it would be skipped entirely whenever Application.Current is null, which is every
+        // unit test. The state would then be assertable nowhere, which is how the elevation branches in
+        // #2102 ended up unpinned.
+        TemperaturesUnavailable = readings.Count == 0;
+
         System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
             Temperatures.ReplaceWith(readings));
     }
@@ -704,6 +732,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
         {
             HealthResult = await _healthScore.ComputeAsync();
             HasHealthScore = true;
+            HealthHasNothingToImprove = HealthResult.Recommendations.Count == 0;
         }
         catch (Exception ex) when (ex is System.Management.ManagementException or InvalidOperationException)
         {

--- a/SysManager/SysManager/Views/AboutView.xaml
+++ b/SysManager/SysManager/Views/AboutView.xaml
@@ -2,7 +2,8 @@
 <UserControl x:Class="SysManager.Views.AboutView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:helpers="clr-namespace:SysManager.Helpers">
+             xmlns:helpers="clr-namespace:SysManager.Helpers"
+             xmlns:v="clr-namespace:SysManager.Views">
 
     <Grid Background="{DynamicResource Surface0}">
         <ScrollViewer VerticalScrollBarVisibility="Auto">
@@ -252,6 +253,16 @@
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
+
+                        <!-- The fetch finished with nothing. Worse here than elsewhere because the line
+                             directly above promises notes "pulled live from GitHub" and then renders
+                             nothing at all, which reads as the feature being broken rather than the
+                             connection being down. Gated on the flag so it cannot appear while the request
+                             — the slowest thing on this tab — is still in flight. -->
+                        <v:EmptyState Glyph="&#xE704;"
+                                      Title="Could not reach GitHub"
+                                      Message="Release notes need a connection. Check yours and press Refresh."
+                                      Visibility="{Binding HistoryUnavailable, Converter={StaticResource FlexVis}}"/>
                     </StackPanel>
                 </Border>
 

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -251,6 +251,15 @@
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
+
+                        <!-- Nothing to recommend, which is GOOD NEWS — so a statement, not an instruction,
+                             the same shape the Tune-up card above already uses. Gated on the flag because
+                             HealthResult is null until the scan finishes: a count binding would fail, and a
+                             failed binding leaves Visibility at its default, announcing "nothing needs
+                             attention" before anything had been checked. -->
+                        <TextBlock Style="{StaticResource Subtle}" TextWrapping="Wrap" Margin="0,6,0,0"
+                                   Text="Nothing needs attention right now."
+                                   Visibility="{Binding HealthHasNothingToImprove, Converter={StaticResource FlexVis}}"/>
                     </StackPanel>
                 </Grid>
             </Border>
@@ -403,6 +412,14 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
+
+                    <!-- Nothing readable. The lighter Subtle line rather than the EmptyState control: these
+                         cards sit in a tight grid and a centred glyph block would push the row. Gated on the
+                         view-model flag, not on Temperatures.Count, so it cannot flash while the first read
+                         is still in flight. -->
+                    <TextBlock Style="{StaticResource Subtle}" TextWrapping="Wrap" Margin="0,14,0,0"
+                               Text="No sensors could be read on this PC. Not every machine exposes them — running as administrator reaches more."
+                               Visibility="{Binding TemperaturesUnavailable, Converter={StaticResource FlexVis}}"/>
                 </StackPanel>
             </Border>
 

--- a/SysManager/SysManager/Views/PingView.xaml
+++ b/SysManager/SysManager/Views/PingView.xaml
@@ -169,6 +169,17 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
+
+                <!-- Every target removed. Reachable through the per-row remove button: the list starts from
+                     the shipped presets, so an empty one means the user emptied it, and the copy names both
+                     ways back — the Add target box below and the preset picker above. Bound to the count
+                     because presets load before the view is ever shown, so there is no loading window in
+                     which this could be wrong. -->
+                <v:EmptyState Glyph="&#xE968;"
+                              Title="No targets to watch"
+                              Message="Add a host below, or choose a preset above to load a set of them."
+                              Visibility="{Binding Shared.Targets.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+
                 <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                     <TextBox Text="{Binding Shared.NewTargetHost, UpdateSourceTrigger=PropertyChanged}" Width="240"
                              AutomationProperties.Name="New target host"/>


### PR DESCRIPTION
Closes #2121. The remaining five views, plus the repo-wide sweep the issue could only land once they were resolved.

## The verdict per collection, re-derived from how each is filled

| Collection | Verdict | Why |
|---|---|---|
| `Dashboard.Temperatures` | **gap** | `ReadAllAsync` returns nothing on a PC whose sensors are not readable — most machines, without administrator |
| `Dashboard.HealthResult.Recommendations` | **gap** | an empty list left "System Health Score" as a heading over nothing |
| `About.ReleaseHistory` | **gap** | `LoadHistoryAsync` swallows `HttpRequestException` into a Debug log, so offline shows a promise of live notes and then nothing |
| `Ping.Shared.Targets` | **gap** | `RemoveTarget` lets the user remove every one |
| `TweaksHub.Essential` / `.Advanced` | exempt | `LoadTweaks()` is the static privacy toggles partitioned by `ClassifyTier`; both sides non-empty by construction |
| `Dashboard.Alerts` | exempt | `StartAlertScans` adds five unconditionally and removes none |
| `Dashboard.Drives` | exempt | ready fixed drives — a Windows PC always has the system drive, and the `catch (IOException)` path sets a status |
| `Profile.Sections` | **already done** | "No exportable settings found yet. Change something you would want on another PC…" |
| `Dashboard.TuneUpResult.DiskResults` | **already done** | "Nothing else needs attention — no broken shortcuts, memory and disks look fine…" |
| `Dashboard.RecentActivity` | **already done** | "No activity recorded yet", via a `DataTrigger` |

## Count or flag

Three of the four gaps need a flag, and that is the whole design question: a count cannot tell *empty* from *not loaded yet*.

- `TemperaturesUnavailable`, `HealthHasNothingToImprove`, `HistoryUnavailable` — each set where its load resolves.
- Ping binds the **count**, and only Ping, because presets load before the view is ever shown, so there is no window in which it could be wrong.

`TemperaturesUnavailable` is assigned **outside** the dispatcher hop deliberately. A plain bool needs no UI thread — WPF marshals property-change notifications itself; it is collection mutations that must be on it — while inside the hop the assignment is skipped whenever `Application.Current` is null, which is every unit test. The state would then be assertable nowhere, which is how the elevation branches in #2102 ended up unpinned. Mutation 9 below is that reasoning made a failing test.

## Three corrections to #2121's own table

**1. Three of its eight views already said something**, in forms the issue's detection could not see. Profile Export/Import and the Tune-up card gate a message on a **domain flag** (`HasSections`, `TuneUpResult.WarningCount`); Recent Activity uses a **`DataTrigger`** on `.Count` with `Value="0"` instead of a converter. So the guard accepts four forms, not two — one that rejected those would have failed on the views that got it right. Recent Activity came off my own worklist because of this: I was one step from adding a second message beside an existing one.

**2. But not *any* `Inverse`.** That was the opposite mistake, and it made an earlier version of this guard blind to exactly the defect it was written for. The bar is an `Inverse` on a path that reads as emptiness — `Has…`, `No…`, `…Count`, `…Unavailable`, `…FoundNothing`, `…IsEmpty` — so an `IsElevated` banner still does not qualify. Mutation 7 proves the loosened version goes green.

**3. `Dashboard.Alerts` cannot be empty at all.** `StartAlertScans` adds five unconditionally and never removes them. The issue guessed "empty is good news"; the state is not reachable, so there is no copy to write.

## The sweep found three views the issue never listed

`CliInterfaceView`, `CpuAffinityView`, `LegacyPanelsView` — which is the value of a real pass over a hand-curated list of eight. All three are exemptions, verified against their sources: two static lists (`CliRunner.Commands`, `LegacyPanelService.Panels`), and `GetCores()` falling back to `LogicalProcessorCount` entries so it yields at least one core on any machine that can run the app.

Every exemption carries a reason, and TweaksHub's is **verified rather than asserted**: `TheRealTweakCatalogue_FillsBothTiers` runs the real `PrivacyService` definitions through `ClassifyTier` and requires both tiers. An exemption nobody checked is a false claim sitting in the test suite.

## Two guards

- **`EveryViewThatListsACollection_HasSomethingToSayWhenItIsEmpty`** — the repo-wide sweep, 44 views matched, vacuity floor at 40.
- **`EveryEmptyStateFlag_IsSetWhereItsDataArrives`** — the wiring, in the **blocking** suite, for the two flags a unit test cannot reach: `AboutViewModel` takes the concrete `UpdateService` so its catch blocks need a network failure, and `LoadHealthScoreAsync` is private with only the init path calling it. The health flag's behaviour lives in `DashboardHealthFlagTests` in the integration project, which CI only compiles (#2101) — so the wiring is pinned where deleting it fails a merge.

## Red/green

| Mutation | Expected | Result |
|---|---|---|
| Temperatures unbound alone | sweep **green** — it is per view, and Dashboard has three others | PASS |
| all four Dashboard states removed | sweep names `DashboardView`, and no other view | PASS |
| About state removed | names `AboutView` only | PASS |
| Ping state removed | names `PingView` only | PASS |
| TweaksHub exemption withdrawn | names it — the list is what excuses it, not a detection hole | PASS |
| `ClassifyTier` never returns `Advanced` | the catalogue test names it | PASS |
| pattern loosened to any `Inverse` | sweep goes **GREEN** — the blindness being avoided | PASS |
| About's timeout catch forgets the flag | wiring guard counts 2 and says so | PASS |
| temperature flag moved back inside the dispatcher hop | its test goes red | PASS |

Two of my own mutations were wrong first and were corrected rather than worked around: collapsing a state's `Visibility` while leaving the `<v:EmptyState/>` element in place does **not** make the sweep red, because the control counting on its own is the documented trade-off — 16 of its 27 usages hang off a domain flag rather than a count, and enumerating every flag name would be a worse rule. `EveryResolvedNoResultsState_IsStillWiredToItsView` is what pins specific bindings.

Also fixed while writing the wiring guard: `MethodBody` matched `" Name("` and found `await LoadHistoryAsync();` instead of the declaration — both flags it watches are called from an init path hundreds of lines *above* their own declaration, so it brace-matched from a call site and reported the wiring missing while the wiring was there. Anchored on the declaration now, with the reason in its remarks.

## Verification

- `dotnet build` on all four projects: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: clean.
- Regression sweep — every `ArchitectureTests` guard plus the Dashboard, TweaksHub and About suites: **232 green, 1 red**, the red being the local throwaway runner's own `Program.cs` missing an author header, which is not in the repository.
- Version consistency (csproj ×3, newest CHANGELOG entry, SECURITY table): consistent at 1.76.22.
- Leak scan over the diff with all 43 current terms: one hit, a pre-existing CHANGELOG history line naming a Windows feature the Privacy tab toggles; `git diff` confirms it is not part of this change.

## Deferred to the secondary workstation

Seeing the four states on a real screen. `ui-mockups/no-results-states-round2.html` has before/after for each plus the verdict table; the main workstation does not run the app.
