### PR TITLE
fix: show which menu style is applied, the notes it fetched, and where each release lives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,42 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.23] - 2026-09-07
+
+Three things the app already knew and never told you. The Context menu tab worked out which menu style was
+applied and then drew all three buttons identically, so there was no way to see which one you were on. "What's
+new" downloaded the release notes for the newest version and displayed none of them. And the ten release cards
+under it each held a link to their release on GitHub that nothing let you click.
+
+### Fixed
+- **The Context menu tab shows which menu style is applied.** It reads the current style on every scan and
+  compares it against the three presets, but the buttons were all drawn the same, so the answer was invisible
+  and the only way to be sure was to apply a preset and watch the entries change. The matching button now
+  carries a tick, the accent colour and its own accessible name.
+- **"What's new" shows the release notes it fetched.** The update check downloads the full notes for the
+  newest version, and the section presented only the version number and date — the notes themselves were
+  fetched on every check and thrown away. They now appear under the version, scrollable when long.
+- **Each release card links to its release.** Every entry in the release history carried the GitHub URL it
+  came from and offered no way to open it, so reading a note was a dead end. Each card now has a "View on
+  GitHub" link, greyed out for the rare entry whose URL came back empty.
+
+### Changed
+- **An unused second way to describe a drive was removed.** The chkdsk drive picker built a one-line summary
+  of each drive that no part of the interface asked for; the row composes what it shows from the individual
+  fields. Five tests kept it alive by reading it exactly the way the missing binding would have.
+
+### Added
+- **A check that a view-model property nothing displays cannot ship.** The three fixes above are one defect
+  repeated: a property maintained by the code, verified by tests, and bound by no view. The existing sweep
+  for this asked whether a property was *written or* shown, which every instance of the defect satisfies. The
+  new one asks whether it is shown in XAML or read somewhere other than its own assignment, and it names the
+  offenders rather than reporting a count.
+- **A check that a style trigger cannot be silently outranked.** The first cut of the Context menu fix put the
+  tick and the accessible name in a trigger while the buttons still set both as plain attributes — and WPF
+  ranks an attribute above a style trigger, so the colours changed and the tick never appeared. Nothing else
+  could see it: the property was bound, the trigger was there, the build was clean. Caught while reviewing the
+  change and now pinned.
+
 ## [1.76.22] - 2026-09-07
 
 Four more places that went blank without saying why. The temperature card on the Landing tab looked broken on

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ it is drawn on — above the 3:1 WCAG asks of a non-text indicator.
 Manage Windows Explorer right-click entries — toggle them on or off without
 deleting anything (uses the standard `LegacyDisable` registry mechanism):
 - **Presets:** Win10 Default (classic full menu), Win11 Default (modern compact), Custom
+- The preset currently applied is marked with a tick, so you can see which style you are on without applying one
 - Selecting a preset resets to clean defaults, disabling third-party entries — re-enable individually
 - **Win10/Win11 style toggle** — switch between classic and modern menu (restarts Explorer)
 - **Visual preview on hover** — real screenshots of each menu style
@@ -992,7 +993,10 @@ offers, "rate us" prompts:
   button appears in the About tab only when a retained copy exists, asks for
   confirmation, and notes that whatever the newer version fixed will come back too.
   One generation is kept, so it never accumulates copies of the app.
-- Full release-note history pulled live from GitHub.
+- Full release-note history pulled live from GitHub — the notes for the newest
+  version appear under the update check, the last ten releases below it, and each
+  card links to its release on GitHub. If GitHub cannot be reached, the section
+  says so instead of going blank.
 - **"Report a problem"** opens the GitHub bug-report form with your SysManager
   version and administrator state already filled in — the two fields reports most
   often miss — and **"Ask a question"** opens Discussions for anything that is not

--- a/SysManager/SysManager.IntegrationTests/SystemHealthMultiDriveTests.cs
+++ b/SysManager/SysManager.IntegrationTests/SystemHealthMultiDriveTests.cs
@@ -96,20 +96,9 @@ public class SystemHealthMultiDriveTests
         Assert.False(d.IsSelected);
     }
 
-    [Fact]
-    public void DriveTarget_Display_IncludesSize()
-    {
-        var d = new DriveTarget { Letter = "D:", Label = "Data", SizeGB = 500, FileSystem = "NTFS" };
-        Assert.Contains("500", d.Display);
-        Assert.Contains("NTFS", d.Display);
-    }
-
-    [Fact]
-    public void DriveTarget_Display_WhenLabelEqualsLetter_Simpler()
-    {
-        var d = new DriveTarget { Letter = "C:", Label = "C:", SizeGB = 500, FileSystem = "NTFS" };
-        Assert.DoesNotContain("  C:  ", d.Display); // no duplicated label
-    }
+    // DriveTarget_Display_IncludesSize / _WhenLabelEqualsLetter_Simpler were removed with DriveTarget.Display
+    // (#2100). No view bound it — the chkdsk row composes that line from the individual properties — so these
+    // two, plus three more in the unit suite, were what made an unreachable property look covered.
 
     [Fact]
     public void DriveTarget_Mutable_Status()

--- a/SysManager/SysManager.Tests/AboutViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AboutViewModelTests.cs
@@ -246,6 +246,22 @@ public class AboutViewModelTests
         Assert.Equal(string.Empty, vm.LatestNotes);
     }
 
+    /// <summary>
+    /// A history card whose release had no <c>html_url</c> must not offer a link that goes nowhere. The
+    /// emptiness decision lives in <c>CanExecute</c> so it is observable here: <c>OpenUrl</c> returns early
+    /// when there is no WPF <c>Application</c>, so a guard inside the command body would assert nothing.
+    /// </summary>
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData("https://github.com/laurentiu021/SystemManager/releases/tag/v1.0.0", true)]
+    public void OpenReleaseCommand_IsOfferedOnlyForAnEntryThatHasAUrl(string? url, bool expected)
+    {
+        var vm = NewVmNoAutoCheck();
+        Assert.Equal(expected, vm.OpenReleaseCommand.CanExecute(url));
+    }
+
     [Fact]
     public void DownloadStatus_DefaultsEmpty()
     {

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2388,6 +2388,227 @@ public partial class ArchitectureTests
             + "empty value to the user. Populate them or remove them:\n  " + string.Join("\n  ", dead));
     }
 
+    /// <summary>
+    /// Every view-model property is shown by a view or read by code — not merely maintained.
+    /// </summary>
+    /// <remarks>
+    /// This repo's dominant recurring defect: surface that is implemented, assigned at several sites, and
+    /// unit-tested, and that no XAML binds and no code reads. The compiler cannot see it, and a view-model
+    /// test cannot either, because the test reads the property exactly the way the missing binding would have.
+    /// <para><b>Not a widening of <see cref="EveryModelProperty_IsEitherWrittenOrShown"/>, and #2100's
+    /// assumption that it was a one-line scope change is where this went wrong.</b> That guard's criterion is
+    /// "written OR shown", and every instance of THIS defect is written — being written is what makes it a
+    /// defect. Pointing it at <c>ViewModels/</c> would have passed all of them. The criterion here is
+    /// therefore "shown in XAML, or READ from C# somewhere other than its own assignment".</para>
+    /// <para>Validated against the state before the fix rather than trusted on a pass: with the two new
+    /// bindings reverted it names <c>AboutViewModel.LatestNotes</c> and
+    /// <c>ContextMenuViewModel.ActivePresetId</c> and nothing else, out of 446 inspected.</para>
+    /// <para>Scope is <c>[ObservableProperty]</c> fields. A plain property is the same defect —
+    /// <c>ReleaseNote.Url</c> was one, and <c>DriveTarget.Display</c> another — but has no generated-name
+    /// convention to key on, so those stay a review judgement.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryViewModelProperty_IsShownOrRead()
+    {
+        var appDir = FindAppProjectDir();
+        var viewModelsDir = Path.Combine(appDir, "ViewModels");
+
+        var xaml = string.Join('\n', Directory
+            .EnumerateFiles(appDir, "*.xaml", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Select(File.ReadAllText));
+
+        var sources = Directory
+            .EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .ToDictionary(f => f, File.ReadAllText);
+
+        var unreachable = new List<string>();
+        var inspected = 0;
+
+        foreach (var (path, source) in sources.Where(kv => kv.Key.StartsWith(viewModelsDir, StringComparison.Ordinal)))
+        {
+            foreach (var m in ObservablePropertyField().Matches(source).Cast<Match>())
+            {
+                var field = m.Groups[1].Value;
+                var property = char.ToUpperInvariant(field[0]) + field[1..];
+                inspected++;
+
+                if (xaml.Contains(property, StringComparison.Ordinal)) continue;
+                if (sources.Values.Any(text => IsReadSomewhere(text, property))) continue;
+
+                unreachable.Add($"{Path.GetFileNameWithoutExtension(path)}.{property}");
+            }
+        }
+
+        // Measured: 446. Set close to it because the failure being guarded against is a pattern that still
+        // matches MOST declarations — the same trap EveryModelProperty_IsEitherWrittenOrShown fell into with
+        // a floor of 40 against 187.
+        Assert.True(inspected >= 400,
+            $"only {inspected} view-model properties were inspected, out of 446 measured — the detection is "
+            + "no longer matching every [ObservableProperty] declaration, so a pass proves nothing.");
+
+        Assert.True(unreachable.Count == 0,
+            "these view-model properties are maintained and nothing reads them: no XAML binds them and no "
+            + "code outside their own assignment consults them, so the work happens on every interaction "
+            + "and the user never sees the result. Bind them, or delete them — a test that reads one is not "
+            + "coverage, it is the reason the defect survives:\n  " + string.Join("\n  ", unreachable));
+    }
+
+    /// <summary>
+    /// True when <paramref name="property"/> is consulted in <paramref name="text"/> — any occurrence that is
+    /// not an assignment target and not the generated-name plumbing.
+    /// </summary>
+    /// <remarks>
+    /// The assignment exclusion is the whole point: <c>ActivePresetId = "custom"</c> is what the defect looks
+    /// like, four times over, and a plain name search calls that a use. <c>nameof</c>,
+    /// <c>NotifyPropertyChangedFor</c> and the generated <c>OnXChanged</c> hook are excluded for the same
+    /// reason — they are the toolkit wiring the property up, not anything reading its value.
+    /// </remarks>
+    private static bool IsReadSomewhere(string text, string property)
+    {
+        foreach (var hit in Regex.Matches(text, $@"\b{Regex.Escape(property)}\b").Cast<Match>())
+        {
+            var tail = text[(hit.Index + hit.Length)..];
+            if (AssignmentTail().IsMatch(tail)) continue;
+            if (PartialChangedHook().IsMatch(tail)) continue;
+
+            var head = text[Math.Max(0, hit.Index - 30)..hit.Index];
+            if (head.Contains("nameof(", StringComparison.Ordinal)
+                || head.Contains("NotifyPropertyChangedFor", StringComparison.Ordinal)
+                || head.Contains($"On{property}", StringComparison.Ordinal)) continue;
+
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// An element must not set a property as an attribute when a trigger on the style it uses also sets it:
+    /// WPF ranks a local value above a style trigger, so the trigger silently loses.
+    /// </summary>
+    /// <remarks>
+    /// Written because the fix for the Menu Style buttons walked straight into it. The three per-preset styles
+    /// carried a <c>DataTrigger</c> setting <c>Content</c> (to prepend a tick) and
+    /// <c>AutomationProperties.Name</c> (so a screen reader hears the state), while the buttons still set both
+    /// as attributes. The fill and border changed, so the tab looked fixed; the tick never appeared and the
+    /// accessible name never changed. The same defect class the change set was closing, one layer down and
+    /// invisible to every other check here — the property is bound, the trigger is present, the build is
+    /// clean.
+    /// <para>Deliberately narrow, and the first attempt was not: attributing every setter reachable under a
+    /// trigger to the outer style, and treating keyless styles as app-wide, reported 2133 conflicts against a
+    /// real count of 2. A trigger can hold an entire <c>ControlTemplate</c>, whose setters belong to the
+    /// template and not to the style; and a keyless <c>Style</c> inside a template's <c>Resources</c> is not
+    /// implicit app-wide, which the tree alone cannot distinguish. So this looks at DIRECT setters under a
+    /// trigger, on KEYED styles only, following <c>BasedOn</c>. Measured on that basis: 10 elements use a
+    /// trigger-bearing keyed style, 0 conflict; reintroducing the two attributes on one button reports
+    /// exactly 2.</para>
+    /// </remarks>
+    [Fact]
+    public void NoLocalValueOutranksAStyleTriggerThatSetsIt()
+    {
+        var appDir = FindAppProjectDir();
+        var views = Directory
+            .EnumerateFiles(appDir, "*.xaml", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .ToArray();
+
+        var xamlNs = XNamespace.Get("http://schemas.microsoft.com/winfx/2006/xaml");
+        var roots = new List<(string File, XElement Root)>();
+        foreach (var view in views)
+        {
+            XDocument document;
+            try { document = XDocument.Load(view); }
+            catch (System.Xml.XmlException) { continue; }
+            if (document.Root is not null) roots.Add((view, document.Root));
+        }
+
+        // key -> (properties its own triggers set directly, the key it is BasedOn)
+        var styles = new Dictionary<string, (HashSet<string> Triggered, string? BasedOn)>(StringComparer.Ordinal);
+        foreach (var (_, root) in roots)
+        {
+            foreach (var style in root.DescendantsAndSelf().Where(e => e.Name.LocalName == "Style"))
+            {
+                var key = (string?)style.Attribute(xamlNs + "Key");
+                if (key is null) continue;
+
+                var triggered = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var triggerList in style.Elements().Where(e => e.Name.LocalName == "Style.Triggers"))
+                {
+                    foreach (var setter in triggerList.Elements().SelectMany(t => t.Elements()))
+                    {
+                        if (setter.Name.LocalName != "Setter") continue;
+                        var property = (string?)setter.Attribute("Property");
+                        if (property is not null) triggered.Add(property);
+                    }
+                }
+
+                var basedOn = StaticResourceReference().Match((string?)style.Attribute("BasedOn") ?? "");
+                styles[key] = (triggered, basedOn.Success ? basedOn.Groups[1].Value : null);
+            }
+        }
+
+        HashSet<string> Resolve(string key)
+        {
+            var result = new HashSet<string>(StringComparer.Ordinal);
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var next = key;
+            while (next is not null && seen.Add(next) && styles.TryGetValue(next, out var entry))
+            {
+                result.UnionWith(entry.Triggered);
+                next = entry.BasedOn!;
+            }
+            return result;
+        }
+
+        var conflicts = new List<string>();
+        var elementsChecked = 0;
+
+        foreach (var (file, root) in roots)
+        {
+            foreach (var element in root.DescendantsAndSelf())
+            {
+                var reference = StaticResourceReference().Match((string?)element.Attribute("Style") ?? "");
+                if (!reference.Success) continue;
+
+                var triggered = Resolve(reference.Groups[1].Value);
+                if (triggered.Count == 0) continue;
+                elementsChecked++;
+
+                foreach (var attribute in element.Attributes())
+                {
+                    if (!triggered.Contains(attribute.Name.LocalName)) continue;
+                    conflicts.Add($"{Path.GetFileName(file)}: <{element.Name.LocalName} "
+                        + $"Style=\"{{StaticResource {reference.Groups[1].Value}}}\"> sets "
+                        + $"{attribute.Name.LocalName} as an attribute");
+                }
+            }
+        }
+
+        Assert.True(elementsChecked >= 8,
+            $"only {elementsChecked} elements using a trigger-bearing keyed style were found, out of 10 "
+            + "measured — either the style map or the Style attribute match stopped working, so a pass "
+            + "proves nothing.");
+
+        Assert.True(conflicts.Count == 0,
+            "these elements set a property locally that a trigger on their own style also sets. WPF ranks a "
+            + "local value above a style trigger, so the trigger never takes effect and the state it was "
+            + "meant to show is invisible. Move the attribute into the style as a plain Setter, which the "
+            + "trigger CAN override:\n  " + string.Join("\n  ", conflicts));
+    }
+
+    /// <summary>A <c>{StaticResource Key}</c> reference, capturing the key.</summary>
+    [GeneratedRegex(@"StaticResource\s+([\w.]+)", RegexOptions.Compiled)]
+    private static partial Regex StaticResourceReference();
+
+    /// <summary>An <c>=</c> that is an assignment rather than a comparison.</summary>
+    [GeneratedRegex(@"^\s*=(?!=)", RegexOptions.Compiled)]
+    private static partial Regex AssignmentTail();
+
+    /// <summary>The tail of the toolkit's generated <c>OnXChanged</c> partial hook.</summary>
+    [GeneratedRegex(@"^\s*Changed\b", RegexOptions.Compiled)]
+    private static partial Regex PartialChangedHook();
+
     /// <summary>A class or record declaration, capturing the type name.</summary>
     [GeneratedRegex(@"(?:class|record)\s+(\w+)", RegexOptions.Compiled)]
     private static partial Regex TypeDeclaration();

--- a/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
@@ -180,31 +180,11 @@ public class SystemHealthViewModelTests
         Assert.False(dt.IsSelected);
     }
 
-    [Fact]
-    public void DriveTarget_Display_WithLabel()
-    {
-        var dt = new DriveTarget { Letter = "D:", Label = "Data", SizeGB = 500, FileSystem = "NTFS" };
-        Assert.Contains("D:", dt.Display);
-        Assert.Contains("Data", dt.Display);
-        Assert.Contains("500", dt.Display);
-    }
-
-    [Fact]
-    public void DriveTarget_Display_WithoutLabel()
-    {
-        var dt = new DriveTarget { Letter = "C:", Label = "", SizeGB = 250, FileSystem = "NTFS" };
-        Assert.Contains("C:", dt.Display);
-        Assert.Contains("250", dt.Display);
-    }
-
-    [Fact]
-    public void DriveTarget_Display_LabelSameAsLetter()
-    {
-        var dt = new DriveTarget { Letter = "C:", Label = "C:", SizeGB = 100, FileSystem = "NTFS" };
-        // Should use the short format (no duplicate label)
-        var display = dt.Display;
-        Assert.DoesNotContain("C:  C:", display);
-    }
+    // DriveTarget_Display_WithLabel / _WithoutLabel / _LabelSameAsLetter were removed with the property
+    // they tested (#2100). All three asserted the composition of a string no view ever bound — the chkdsk
+    // row builds that line from Letter, Label, SizeGB and FileSystem individually — so they were the reason
+    // an unreachable property survived three audits: a property with tests looks covered.
+    // What the row actually shows is pinned by ArchitectureTests.EveryFieldTheChkdskPickerFillsIn_IsShownInItsRow.
 
     [Fact]
     public void DriveTarget_StatusSetter_FiresPropertyChanged()

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.22</Version>
-    <FileVersion>1.76.22.0</FileVersion>
-    <AssemblyVersion>1.76.22.0</AssemblyVersion>
+    <Version>1.76.23</Version>
+    <FileVersion>1.76.23.0</FileVersion>
+    <AssemblyVersion>1.76.23.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -396,6 +396,24 @@ public sealed partial class AboutViewModel : ViewModelBase
         OpenUrl(url);
     }
 
+    /// <summary>
+    /// Open one release-history entry on GitHub.
+    /// </summary>
+    /// <remarks>
+    /// <c>ReleaseNote.Url</c> was populated for all ten entries and read by nothing, so the history cards
+    /// were dead ends: the user could read a note and not reach the release it came from. Takes the url as a
+    /// parameter rather than reading a selected item, because the list is an <c>ItemsControl</c> with no
+    /// selection — each card carries its own.
+    /// <para>Guarded on the value through <c>CanExecute</c> rather than an early return inside the body: an
+    /// entry whose <c>HtmlUrl</c> came back empty greys its link out instead of accepting a click that does
+    /// nothing, and the decision becomes observable to a test (<c>OpenUrl</c> is a no-op without a WPF
+    /// <c>Application</c>, so a guard inside the body would assert nothing).</para>
+    /// </remarks>
+    [RelayCommand(CanExecute = nameof(CanOpenRelease))]
+    private void OpenRelease(string? url) => OpenUrl(url!);
+
+    private static bool CanOpenRelease(string? url) => !string.IsNullOrWhiteSpace(url);
+
     [RelayCommand]
     private void OpenRepo() => OpenUrl($"https://github.com/{UpdateService.Owner}/{UpdateService.Repo}");
 

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -416,7 +416,9 @@ public sealed partial class DriveTarget : ObservableObject
     public string MediaType { get; init; } = "";
     public string BusType { get; init; } = "";
 
-    public string Display => string.IsNullOrWhiteSpace(Label) || Label == Letter
-        ? $"{Letter}  ·  {SizeGB:F0} GB {FileSystem}"
-        : $"{Letter}  {Label}  ·  {SizeGB:F0} GB {FileSystem}";
+    // Display was removed here (#2100). It composed "C:  Windows  ·  476 GB NTFS" and nothing bound it: the
+    // chkdsk row builds that line from Letter, Label, SizeGB and FileSystem individually, so the property was
+    // a second, unused way to say the same thing — kept alive only by five tests that read it exactly the way
+    // the missing binding would have. EveryFieldTheChkdskPickerFillsIn_IsShownInItsRow covers what the row
+    // actually shows.
 }

--- a/SysManager/SysManager/Views/AboutView.xaml
+++ b/SysManager/SysManager/Views/AboutView.xaml
@@ -174,6 +174,20 @@
                             <TextBlock Text="{Binding DownloadStatus}" Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
                         </StackPanel>
 
+                        <!-- What is actually IN the update being offered. LatestNotes was assigned from the
+                             release body on every check and read by nothing, so the tab said a newer version
+                             existed and would not say what changed — the one question a user has before
+                             pressing Download. Same CardInner shape the history list below uses, and only
+                             when there is a body to show. -->
+                        <Border Style="{StaticResource CardInner}" Margin="0,14,0,0" Padding="12"
+                                Visibility="{Binding LatestNotes, Converter={StaticResource FlexVis}}">
+                            <ScrollViewer MaxHeight="180" VerticalScrollBarVisibility="Auto">
+                                <TextBlock Text="{Binding LatestNotes}" Style="{StaticResource Subtle}"
+                                           TextWrapping="Wrap"
+                                           AutomationProperties.Name="What is new in the available update"/>
+                            </ScrollViewer>
+                        </Border>
+
                         <!-- Download completed -->
                         <StackPanel Margin="0,14,0,0" Orientation="Horizontal"
                                     Visibility="{Binding DownloadedPath, Converter={StaticResource FlexVis}}">
@@ -245,6 +259,20 @@
                                                 <TextBlock Text="{Binding Title}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
                                                 <TextBlock Text="  ·  " Foreground="{DynamicResource TextMuted}" VerticalAlignment="Center"/>
                                                 <TextBlock Text="{Binding PublishedAt}" Foreground="{DynamicResource TextMuted}" FontSize="12" VerticalAlignment="Center"/>
+                                                <!-- A named link rather than a card-wide click target: these
+                                                     cards hold selectable text, and a clickable card fights
+                                                     text selection. The arrow marks that it leaves the app,
+                                                     which matters for a product whose pitch is that it does
+                                                     not phone home — the user should be able to tell when a
+                                                     click opens a browser. Hidden when the entry carries no
+                                                     url. -->
+                                                <TextBlock VerticalAlignment="Center" Margin="10,0,0,0" FontSize="12"
+                                                           Visibility="{Binding Url, Converter={StaticResource FlexVis}}">
+                                                    <Hyperlink Command="{Binding DataContext.OpenReleaseCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                               CommandParameter="{Binding Url}"
+                                                               Foreground="{DynamicResource Accent}"
+                                                               AutomationProperties.Name="{Binding Version, StringFormat='View {0} on GitHub'}">View on GitHub ↗</Hyperlink>
+                                                </TextBlock>
                                             </StackPanel>
                                             <TextBlock helpers:MarkdownTextBlock.Markdown="{Binding Body}" Foreground="{DynamicResource TextSecondary}"
                                                        TextWrapping="Wrap" Margin="0,8,0,0"/>

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -10,6 +10,80 @@
              mc:Ignorable="d"
              Background="{DynamicResource Surface0}">
 
+    <UserControl.Resources>
+        <!--
+            The Menu Style buttons had no way to show which style is currently applied.
+            ActivePresetId was maintained at four sites — seeded from the registry on load, set on every
+            Apply, and set to "custom" the moment any individual entry is toggled — and read by nothing, so
+            the tab asked the user to choose between three options without saying which one they were on.
+            The view even carried a comment reading "Custom indicator" above a button that indicated nothing.
+
+            AccentSoft fill plus an Accent border, the pair already used for the highlighted card in Deep
+            Cleanup, and NOT PrimaryButton: a purple fill is reserved for primary ACTIONS, while this is a
+            state. The tick carries the same meaning for anyone who cannot separate the two fills, and it is
+            what the accessible name appends so a screen reader says it too.
+
+            One style, three buttons, discriminated by ConverterParameter — the button's own preset id.
+        -->
+        <Style x:Key="PresetButton" TargetType="Button" BasedOn="{StaticResource SecondaryButton}">
+            <Setter Property="Padding" Value="12,8"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Margin" Value="0,0,8,0"/>
+        </Style>
+
+        <!--
+            Three thin styles rather than one: a DataTrigger's ConverterParameter cannot be a binding, so each
+            button's own preset id has to be a literal. They differ in that one value and nothing else.
+
+            Content and AutomationProperties.Name are SETTERS here, not attributes on the buttons, because a
+            local value on the element outranks a style trigger in WPF's precedence order — leaving them on
+            the buttons made the tick and the state-carrying name silently dead while the fill still changed,
+            which is the same defect this whole change set is closing, one layer down.
+            NoLocalValueOutranksAStyleTriggerThatSetsIt pins it.
+        -->
+        <Style x:Key="PresetButtonWin10" TargetType="Button" BasedOn="{StaticResource PresetButton}">
+            <Setter Property="Content" Value="Win10 Default"/>
+            <Setter Property="AutomationProperties.Name" Value="Apply Win10 Default menu style"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding ActivePresetId, Converter={StaticResource IsEqual}, ConverterParameter=win10}" Value="True">
+                    <Setter Property="Content" Value="✓ Win10 Default"/>
+                    <Setter Property="AutomationProperties.Name" Value="Win10 Default — the menu style currently applied"/>
+                    <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
+                    <Setter Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                    <Setter Property="FontWeight" Value="SemiBold"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="PresetButtonWin11" TargetType="Button" BasedOn="{StaticResource PresetButton}">
+            <Setter Property="Content" Value="Win11 Default"/>
+            <Setter Property="AutomationProperties.Name" Value="Apply Win11 Default menu style"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding ActivePresetId, Converter={StaticResource IsEqual}, ConverterParameter=win11}" Value="True">
+                    <Setter Property="Content" Value="✓ Win11 Default"/>
+                    <Setter Property="AutomationProperties.Name" Value="Win11 Default — the menu style currently applied"/>
+                    <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
+                    <Setter Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                    <Setter Property="FontWeight" Value="SemiBold"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="PresetButtonCustom" TargetType="Button" BasedOn="{StaticResource PresetButton}">
+            <Setter Property="Content" Value="Custom"/>
+            <Setter Property="AutomationProperties.Name" Value="Apply Custom menu style"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding ActivePresetId, Converter={StaticResource IsEqual}, ConverterParameter=custom}" Value="True">
+                    <Setter Property="Content" Value="✓ Custom"/>
+                    <Setter Property="AutomationProperties.Name" Value="Custom — the menu style currently applied"/>
+                    <Setter Property="Background" Value="{DynamicResource AccentSoft}"/>
+                    <Setter Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                    <Setter Property="FontWeight" Value="SemiBold"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
+
     <Grid Margin="28,24,28,16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -66,10 +140,8 @@
                            Foreground="{DynamicResource TextMuted}" Margin="0,0,0,10"/>
                 <StackPanel Orientation="Horizontal">
                     <!-- Win10 button with hover preview -->
-                    <Button Content="Win10 Default" Margin="0,0,8,0"
-                            AutomationProperties.Name="Apply Win10 Default menu style"
-                            Command="{Binding ApplyPresetCommand}" CommandParameter="win10"
-                            Style="{StaticResource SecondaryButton}" Padding="12,8" FontSize="12">
+                    <Button Command="{Binding ApplyPresetCommand}" CommandParameter="win10"
+                            Style="{StaticResource PresetButtonWin10}">
                         <Button.ToolTip>
                             <ToolTip Placement="Bottom" MaxWidth="520">
                                 <StackPanel>
@@ -92,10 +164,8 @@
                         </Button.ToolTip>
                     </Button>
                     <!-- Win11 button with hover preview -->
-                    <Button Content="Win11 Default" Margin="0,0,8,0"
-                            AutomationProperties.Name="Apply Win11 Default menu style"
-                            Command="{Binding ApplyPresetCommand}" CommandParameter="win11"
-                            Style="{StaticResource SecondaryButton}" Padding="12,8" FontSize="12">
+                    <Button Command="{Binding ApplyPresetCommand}" CommandParameter="win11"
+                            Style="{StaticResource PresetButtonWin11}">
                         <Button.ToolTip>
                             <ToolTip Placement="Bottom" MaxWidth="520">
                                 <StackPanel>
@@ -122,10 +192,8 @@
                         </Button.ToolTip>
                     </Button>
                     <!-- Custom indicator -->
-                    <Button Content="Custom" Margin="0,0,8,0"
-                            AutomationProperties.Name="Apply Custom menu style"
-                            Command="{Binding ApplyPresetCommand}" CommandParameter="custom"
-                            Style="{StaticResource SecondaryButton}" Padding="12,8" FontSize="12"
+                    <Button Command="{Binding ApplyPresetCommand}" CommandParameter="custom"
+                            Style="{StaticResource PresetButtonCustom}"
                             ToolTip="Active menu style + your manual entry toggles from the list below. Toggle any entry to switch to Custom mode."/>
                 </StackPanel>
                 <TextBlock Text="ⓘ Hover over Win10/Win11 buttons for a visual preview of each menu style."


### PR DESCRIPTION
Three view-model properties were maintained on every interaction and displayed by nothing, plus a fourth with no home at all. Same defect class as #2121 and #2102, now with a check that closes it.

## What the user sees

**Context menu — which style is applied.** `ActivePresetId` is seeded from the registry on load, set on every Apply, and set to `custom` the moment any individual entry is toggled. Four write sites, zero readers, so the tab asked the user to pick between three menu styles without saying which one they were on — the only way to be sure was to apply one and watch the entries change. The matching button now carries a tick, the `AccentSoft` fill + `Accent` border already used for a highlighted card in Deep Cleanup, and its own accessible name.

Not `PrimaryButton`: a purple fill is reserved for primary *actions*, and this is a *state*. The tick carries the same meaning for anyone who cannot separate the two fills, and it is what the accessible name appends so a screen reader says it too.

**About — the notes it already downloaded.** `LatestNotes` holds the full release notes for the newest version, fetched on every update check and discarded. The section presented the version number and date only. They now appear under the version, scrollable when long.

**About — each history card links to its release.** `ReleaseNote.Url` was populated for all ten entries and read by nothing, so reading a note was a dead end. Each card gets a **View on GitHub** link via a new `OpenReleaseCommand`.

That command is gated with `CanExecute` rather than an early return in the body. `OpenUrl` returns immediately when there is no WPF `Application`, so a guard inside the body would have been untestable — and a greyed link for the rare entry with no URL beats a click that does nothing.

## What was deleted

`SystemHealthViewModel.DriveTarget.Display` composed a one-line drive summary the chkdsk row does not use: the row builds that line from `Letter`, `Label`, `SizeGB` and `FileSystem` individually. Five tests kept it alive by reading it exactly the way the missing binding would have — which is how this defect survives review. Gone, with a comment where it was.

## The two checks

**`EveryViewModelProperty_IsShownOrRead`** asks whether each `[ObservableProperty]` in `ViewModels/` is shown in XAML or read somewhere other than its own assignment.

#2100 assumed widening `EveryModelProperty_IsEitherWrittenOrShown` to `ViewModels/` was enough. It is not, and mutation 4 below is the evidence: that guard's criterion is "written **or** shown", which every instance of this defect satisfies by definition — being written is what makes it a defect. Measured against the pre-fix tree, the new criterion names exactly `ActivePresetId` and `LatestNotes` out of 446 properties inspected; after the fix, none. Population floor set at 400 against the 446 measured, because the detection pattern still matches most declarations — the same trap the `Models/` guard fell into with a floor of 40 against 187.

**`NoLocalValueOutranksAStyleTriggerThatSetsIt`** exists because the first cut of the Menu Style fix walked into a second layer of the same defect. The trigger set `Content` (to prepend the tick) and `AutomationProperties.Name` (so the state is announced), while the buttons still set both as attributes — and WPF ranks a local value above a style trigger. The fill and border changed, so the tab looked fixed; the tick never appeared and the accessible name never changed. Invisible to every other check here: the property is bound, the trigger is present, the build is clean.

The first version of the rule reported **2133 conflicts against a real count of 2**. A trigger can hold an entire `ControlTemplate` whose setters belong to the template, not the style; and a keyless `Style` inside a template's `Resources` is not implicit app-wide, which the element tree alone cannot distinguish. Narrowed to *direct* setters under a trigger on *keyed* styles only, following `BasedOn`: 10 elements qualify, 0 conflict, and reintroducing the two attributes on one button reports exactly those 2.

## Red/green — 8 mutations, all as claimed

| # | Mutation | Expected | Result |
|---|---|---|---|
| 1 | Revert the Menu Style bindings | guard names `ActivePresetId` | RED, named it |
| 2 | Revert the About bindings | guard names `LatestNotes` | RED, named it |
| 3 | Revert both | guard names **both**, not just the first | RED, named both |
| 4 | Loosen the criterion to "written or shown", both reverted | GREEN — so widening the `Models/` guard was never enough | GREEN |
| 5 | Restore a plain non-observable unreachable property | GREEN — the guard's documented limit, not a hole | GREEN |
| 6 | Drop `OpenRelease`'s `CanExecute` | url test reddens on the three empty cases | RED |
| 7 | Put `Content` + name back as attributes | precedence guard names both | RED, named both |
| 8 | Point that guard's `Style` lookup at an attribute no element has | population floor fires, not a silent pass | RED, floor fired |

Every mutation restored from a byte-for-byte hash-verified copy, tree rebuilt after each.

## Verification

- Four projects build in Release: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: clean.
- `ArchitectureTests` + `UiAutomationContractTests` sweep, 98 names: **104 green, 1 red** — the one red is the throwaway local runner's own `Program.cs`, which is not in the repo.
- Leak scan over the full diff against all 43 current patterns: 0 hits, with a population floor asserted so a mis-read terms file cannot report clean on nothing.

Deferred to the secondary workstation: the tick and `AccentSoft` fill seen on a real screen across the twelve theme presets, and the greyed link state.

Closes #2100
