### PR TITLE
fix: the Landing tab's live numbers cost syscalls, not two WMI round-trips every 300 ms

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -202,7 +202,12 @@ Key services:
   run on the same engine. Pure and static like `HealthAnalyzer`, so the
   judgement is unit-testable without a network; deliberately never emits the
   failure colour, because a slow plan is not a fault.
-- `SystemInfoService` — OS / CPU / RAM / uptime snapshot.
+- `SystemInfoService` — OS / CPU / RAM / uptime snapshot. Static hardware (OS caption,
+  CPU model, disk models, DIMM inventory) is queried once via WMI and cached; the three
+  DYNAMIC values are syscalls, because the Landing tab polls this every 300 ms —
+  `GetSystemTimes` deltas for CPU load, `GlobalMemoryStatusEx` for memory,
+  `Environment.TickCount64` for uptime. The syscalls are constructor-injected, so the
+  delta arithmetic is unit-testable without a real machine.
 - `BiosService` — read-only BIOS/firmware + motherboard info (Win32_BIOS,
   Win32_BaseBoard, UEFI/Secure-Boot registry) plus a pure manufacturer
   support-URL resolver for BIOS updates; never flashes firmware. Consumed by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.24] - 2026-09-07
+
+The Landing tab used to ask Windows the same two questions 3.3 times a second, the expensive way, for three
+numbers Windows hands over instantly. CPU load, memory and uptime now cost a few microseconds each instead of
+two WMI round-trips, and the CPU figure is genuinely live rather than a one-second average being redrawn three
+times.
+
+### Changed
+- **The Landing tab's live numbers cost syscalls instead of WMI queries.** The vitals poll runs every 300 ms
+  for as long as the tab is open, and each pass made two WMI round-trips: one for CPU load, one for memory and
+  uptime. All three now come from the kernel directly — `GetSystemTimes`, `GlobalMemoryStatusEx` and the
+  monotonic tick count.
+- **The CPU percentage is now a real measurement of the interval just elapsed.** The old source was a
+  WMI-throttled one-second average, so at a 300 ms poll the chart spent two passes out of three redrawing a
+  number that had not changed. It is now the busy share of the ticks that actually passed since the previous
+  reading.
+- **Uptime no longer jumps when the clock changes.** It was computed as "now minus the boot timestamp", so
+  changing the system clock or a DST shift moved it. It now comes from a counter that only ever goes forward.
+  On a machine where the reading is unavailable the tab holds the last known figure rather than showing a zero
+  that reads as "idle".
+
+### Added
+- **A check that the 300 ms path cannot go back to WMI.** Pinned by the WMI column names rather than by method
+  names, because the regression to guard against is someone adding the query back in a new method. It also
+  asserts the syscall path is still *called* — without that half, deleting the live values entirely would have
+  satisfied the rule.
+
 ## [1.76.23] - 2026-09-07
 
 Three things the app already knew and never told you. The Context menu tab worked out which menu style was

--- a/SysManager/SysManager.IntegrationTests/SystemInfoServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/SystemInfoServiceTests.cs
@@ -93,6 +93,46 @@ public class SystemInfoServiceTests
         Assert.Equal(a.Memory.TotalGB, b.Memory.TotalGB, 3); // total RAM is stable within a session
     }
 
+    /// <summary>
+    /// Uptime comes from the monotonic clock, not from a WMI timestamp. This is the assertion that would have
+    /// caught the value being read from the CACHED static query, where it was frozen at first-query time: a
+    /// frozen uptime drifts from <c>TickCount64</c> the longer the process runs, so a tight window catches it.
+    /// </summary>
+    [Fact]
+    public async Task CaptureAsync_UptimeTracksTheMonotonicClock()
+    {
+        var before = Environment.TickCount64;
+        var snap = await new SystemInfoService().CaptureAsync();
+        var after = Environment.TickCount64;
+
+        Assert.InRange(snap.Os.Uptime.TotalMilliseconds, before - 1000, after + 1000);
+    }
+
+    /// <summary>
+    /// The real <c>GetSystemTimes</c> path, end to end. The unit tests pin the arithmetic against fed
+    /// readings; this proves the syscall actually returns usable counters on a real machine, so a marshalling
+    /// mistake cannot hide behind green unit tests.
+    /// </summary>
+    [Fact]
+    public async Task CaptureAsync_CpuLoadIsAUsablePercentage()
+    {
+        var snap = await new SystemInfoService().CaptureAsync();
+
+        Assert.False(double.IsNaN(snap.Cpu.LoadPercent));
+        Assert.InRange(snap.Cpu.LoadPercent, 0, 100);
+    }
+
+    /// <summary>The real <c>GlobalMemoryStatusEx</c> path: available cannot exceed total, and used is the gap.</summary>
+    [Fact]
+    public async Task CaptureAsync_MemoryTotalsAreInternallyConsistent()
+    {
+        var snap = await new SystemInfoService().CaptureAsync();
+
+        Assert.True(snap.Memory.TotalGB > 0);
+        Assert.InRange(snap.Memory.AvailableGB, 0, snap.Memory.TotalGB);
+        Assert.Equal(snap.Memory.TotalGB - snap.Memory.AvailableGB, snap.Memory.UsedGB, 6);
+    }
+
     [Fact]
     public async Task CaptureAsync_RespectsCancellation()
     {

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -6464,9 +6464,11 @@ public partial class ArchitectureTests
     /// </summary>
     /// <remarks>
     /// <c>SystemInfoService.Capture</c> takes <c>_cacheLock</c> to serialise four <c>??=</c> caches, each of
-    /// which runs its WMI query once per process. <c>QueryCpuLoad</c> ran inside that block too, so every
-    /// concurrent <c>CaptureAsync</c> queued behind a WMI round-trip it had no interest in — and the Dashboard
-    /// polls this at 300 ms, so the queue was rarely empty.
+    /// which runs its WMI query once per process. The dynamic CPU-load query ran inside that block too, so
+    /// every concurrent <c>CaptureAsync</c> queued behind a WMI round-trip it had no interest in — and the
+    /// Dashboard polls this at 300 ms, so the queue was rarely empty. That query is now a syscall
+    /// (<c>NoWmiRunsOnTheSnapshotPollPath</c> keeps it one), but the rule still holds for whatever is added
+    /// next.
     /// <para>The rule is expressed as a shape rather than as two method names: inside the block, a
     /// <c>Query…</c> call must sit on a line that also caches its result with <c>??=</c>. That catches a
     /// third dynamic query added later, which a name list could not.</para>
@@ -6492,13 +6494,57 @@ public partial class ArchitectureTests
 
         Assert.True(offenders.Count == 0,
             "these queries run while holding _cacheLock, so every other CaptureAsync caller waits for them. "
-            + "The lock exists for the ??= caches; a per-poll query belongs after the block, beside "
-            + "QueryDynamicOs:\n  " + string.Join("\n  ", offenders));
+            + "The lock exists for the ??= caches; a per-poll query belongs after the block, beside the "
+            + "Sample* calls:\n  " + string.Join("\n  ", offenders));
     }
 
     /// <summary>A call to one of the service's own Query* methods.</summary>
     [GeneratedRegex(@"\bQuery[A-Z]\w*\(")]
     private static partial Regex QueryCallInLock();
+
+    /// <summary>
+    /// The three values the 300 ms snapshot poll refreshes must come from syscalls, never from WMI.
+    /// </summary>
+    /// <remarks>
+    /// CPU load, physical memory and uptime were two WMI round-trips per pass — 3.3 of them a second for as
+    /// long as the Landing tab is open — for numbers <c>GetSystemTimes</c>, <c>GlobalMemoryStatusEx</c> and
+    /// <c>Environment.TickCount64</c> hand over directly. Pinned by the WMI COLUMN names rather than by method
+    /// names, because the regression is "someone adds the query back", and a method-name list would not see a
+    /// new method. <c>LastBootUpTime</c> is included: it was still selected in the CACHED static query, where
+    /// the parsed uptime was frozen at first-query time and overwritten on every snapshot regardless.
+    /// <para>The positive half matters as much: without it, deleting the whole dynamic path would pass.</para>
+    /// </remarks>
+    [Fact]
+    public void NoWmiRunsOnTheSnapshotPollPath()
+    {
+        var source = WithoutComments(File.ReadAllText(
+            Path.Combine(FindAppProjectDir(), "Services", "SystemInfoService.cs")));
+
+        // Vacuity floor: the STATIC queries must still be here. An empty or mis-read file would satisfy every
+        // absence below while proving nothing.
+        foreach (var stillExpected in new[] { "Win32_OperatingSystem", "Win32_Processor", "Caption", "NumberOfCores" })
+        {
+            Assert.True(source.Contains(stillExpected, StringComparison.Ordinal),
+                $"'{stillExpected}' is missing from SystemInfoService.cs, so the file was not read as expected "
+                + "and the absence assertions below prove nothing.");
+        }
+
+        var dynamicColumns = new[] { "LoadPercentage", "TotalVisibleMemorySize", "FreePhysicalMemory", "LastBootUpTime" }
+            .Where(column => source.Contains(column, StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(dynamicColumns.Count == 0,
+            "these WMI columns are back in SystemInfoService. All three dynamic snapshot values have cheap "
+            + "syscall equivalents, and the Landing tab polls the snapshot every 300 ms, so a WMI round-trip "
+            + "here costs 3.3 of them a second: " + string.Join(", ", dynamicColumns));
+
+        foreach (var seam in new[] { "SampleCpuLoad()", "SampleMemory(", "_millisecondsSinceBoot()" })
+        {
+            Assert.True(source.Contains(seam, StringComparison.Ordinal),
+                $"'{seam}' is gone from SystemInfoService, so the dynamic value it produced is no longer "
+                + "being refreshed at all — which would satisfy the no-WMI rule for the wrong reason.");
+        }
+    }
 
     /// <summary>
     /// Every call into a temp-tree walker must pass the own-extraction exclusion.

--- a/SysManager/SysManager.Tests/SystemInfoServiceTests.cs
+++ b/SysManager/SysManager.Tests/SystemInfoServiceTests.cs
@@ -1,0 +1,178 @@
+// SysManager · SystemInfoServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// The three values the Landing tab refreshes every 300 ms. They used to be two WMI round-trips per pass;
+/// they are now syscalls behind constructor-injected seams, so the arithmetic — and every way it can be
+/// handed nothing usable — is assertable without a real machine.
+/// </summary>
+public class SystemInfoServiceTests
+{
+    /// <summary>Feeds successive readings, then repeats the last one, so a test controls each sample.</summary>
+    private static Func<SystemInfoService.SystemTimes?> Times(params SystemInfoService.SystemTimes?[] readings)
+    {
+        var index = 0;
+        return () => readings[Math.Min(index++, readings.Length - 1)];
+    }
+
+    private static SystemInfoService.SystemTimes At(ulong idle, ulong kernel, ulong user) => new(idle, kernel, user);
+
+    private static SystemInfoService NewService(
+        Func<SystemInfoService.SystemTimes?>? times = null,
+        Func<SystemInfoService.PhysicalMemory?>? memory = null,
+        Func<long>? uptimeMs = null)
+        => new(times ?? Times(At(0, 0, 0)),
+               memory ?? (() => new SystemInfoService.PhysicalMemory(0, 0)),
+               uptimeMs ?? (() => 0));
+
+    // ---- CPU load ----
+
+    /// <summary>
+    /// Busy is <c>(kernelΔ + userΔ) - idleΔ</c>, because GetSystemTimes counts idle time inside kernel time.
+    /// Here: idle rises 50, kernel 100, user 100 — so 50 of 200 ticks were idle and 75% were busy. Reading it
+    /// as "kernel + user are both busy" would report 100%, which is why the row is exact rather than a range.
+    /// </summary>
+    [Fact]
+    public void CpuLoad_IsTheBusyShareOfTheTicksSinceThePreviousSample()
+    {
+        var service = NewService(Times(At(1000, 2000, 1000), At(1050, 2100, 1100)));
+        Assert.Equal(75.0, service.SampleCpuLoad(), precision: 6);
+    }
+
+    [Theory]
+    // A fully idle interval: every one of the 100 kernel ticks was idle.
+    [InlineData(100ul, 100ul, 0ul, 0.0)]
+    // A fully busy interval: no idle ticks at all.
+    [InlineData(0ul, 100ul, 0ul, 100.0)]
+    // Half the interval idle, and user time carrying part of the load.
+    [InlineData(100ul, 100ul, 100ul, 50.0)]
+    public void CpuLoad_CoversTheEndsOfTheRange(ulong idleDelta, ulong kernelDelta, ulong userDelta, double expected)
+    {
+        var service = NewService(Times(At(0, 0, 0), At(idleDelta, kernelDelta, userDelta)));
+        Assert.Equal(expected, service.SampleCpuLoad(), precision: 6);
+    }
+
+    /// <summary>
+    /// A failed syscall must not flash 0 into the chart: 0% is a legible reading that means "idle machine",
+    /// and the machine's load is simply unknown for this pass.
+    /// </summary>
+    [Fact]
+    public void CpuLoad_WhenTheSyscallFails_HoldsTheLastKnownValue()
+    {
+        var service = NewService(Times(At(1000, 2000, 1000), At(1050, 2100, 1100), null));
+        Assert.Equal(75.0, service.SampleCpuLoad(), precision: 6);
+        Assert.Equal(75.0, service.SampleCpuLoad(), precision: 6);
+    }
+
+    /// <summary>
+    /// With no baseline — the constructor's seeding syscall failed too — the totals since boot ARE a delta
+    /// measured from zero, so the since-boot average is the honest answer. Here 250 of 1000 ticks were idle.
+    /// </summary>
+    [Fact]
+    public void CpuLoad_WithNoBaseline_ReportsTheSinceBootAverage()
+    {
+        var service = NewService(Times(null, At(250, 1000, 0)));
+        Assert.Equal(75.0, service.SampleCpuLoad(), precision: 6);
+    }
+
+    [Fact]
+    public void CpuLoad_WhenTheSyscallNeverSucceeds_ReportsZeroRatherThanNaN()
+    {
+        var service = NewService(Times(null, null));
+        var load = service.SampleCpuLoad();
+        Assert.False(double.IsNaN(load));
+        Assert.Equal(0.0, load, precision: 6);
+    }
+
+    /// <summary>
+    /// Two samples inside one timer tick give a zero-tick-wide interval. 0 idle of 0 total is not 0% busy, so
+    /// the last real value stands rather than the chart dropping to the floor.
+    /// </summary>
+    [Fact]
+    public void CpuLoad_WhenTwoSamplesLandInTheSameTick_HoldsTheLastValue()
+    {
+        var service = NewService(Times(At(1000, 2000, 1000), At(1050, 2100, 1100), At(1050, 2100, 1100)));
+        Assert.Equal(75.0, service.SampleCpuLoad(), precision: 6);
+        Assert.Equal(75.0, service.SampleCpuLoad(), precision: 6);
+    }
+
+    /// <summary>
+    /// These counters only advance, but a backwards step would wrap the unsigned subtraction into an enormous
+    /// delta and a nonsense percentage — so the ordering is checked rather than assumed.
+    /// </summary>
+    [Fact]
+    public void CpuLoad_WhenTheCountersStepBackwards_HoldsTheLastValueInsteadOfWrapping()
+    {
+        var service = NewService(Times(At(1000, 2000, 1000), At(1050, 2100, 1100), At(900, 1900, 900)));
+        Assert.Equal(75.0, service.SampleCpuLoad(), precision: 6);
+        Assert.Equal(75.0, service.SampleCpuLoad(), precision: 6);
+    }
+
+    /// <summary>Idle can never exceed the total, but if it did the result must stay a percentage.</summary>
+    [Fact]
+    public void CpuLoad_StaysWithinAPercentageEvenIfIdleExceedsTheTotal()
+    {
+        var service = NewService(Times(At(0, 0, 0), At(500, 100, 0)));
+        var load = service.SampleCpuLoad();
+        Assert.InRange(load, 0.0, 100.0);
+    }
+
+    /// <summary>Each pass measures the interval just elapsed, not a running average of every interval.</summary>
+    [Fact]
+    public void CpuLoad_MeasuresEachIntervalIndependently()
+    {
+        var service = NewService(Times(At(0, 0, 0), At(100, 100, 0), At(100, 200, 0)));
+        Assert.Equal(0.0, service.SampleCpuLoad(), precision: 6);
+        Assert.Equal(100.0, service.SampleCpuLoad(), precision: 6);
+    }
+
+    // ---- memory ----
+
+    [Fact]
+    public void Memory_ComesFromTheSyscallAndIsReportedInGigabytes()
+    {
+        const ulong gib = 1024ul * 1024 * 1024;
+        var service = NewService(memory: () => new SystemInfoService.PhysicalMemory(8 * gib, 2 * gib));
+
+        var memory = service.SampleMemory([]);
+
+        Assert.Equal(8.0, memory.TotalGB, precision: 6);
+        Assert.Equal(2.0, memory.AvailableGB, precision: 6);
+        Assert.Equal(6.0, memory.UsedGB, precision: 6);
+        Assert.Equal(75.0, memory.UsedPercent, precision: 6);
+    }
+
+    /// <summary>A failed syscall zeroes the totals without dividing by zero, and keeps the DIMM list.</summary>
+    [Fact]
+    public void Memory_WhenTheSyscallFails_ZeroesTheTotalsAndStillListsTheModules()
+    {
+        var modules = new List<MemoryModule> { new("DIMM0", "Vendor", 8, 3200, 3200, "PN") };
+        var service = NewService(memory: () => null);
+
+        var memory = service.SampleMemory(modules);
+
+        Assert.Equal(0.0, memory.TotalGB, precision: 6);
+        Assert.Equal(0.0, memory.AvailableGB, precision: 6);
+        Assert.Equal(0.0, memory.UsedPercent, precision: 6);
+        Assert.Single(memory.Modules);
+    }
+
+    [Fact]
+    public void Memory_PassesTheStaticModuleInventoryThrough()
+    {
+        var modules = new List<MemoryModule>
+        {
+            new("DIMM0", "Vendor", 8, 3200, 3200, "PN-A"),
+            new("DIMM1", "Vendor", 8, 3200, 3200, "PN-B"),
+        };
+        var service = NewService();
+
+        Assert.Equal(2, service.SampleMemory(modules).Modules.Count);
+    }
+}

--- a/SysManager/SysManager/Services/SystemInfoService.cs
+++ b/SysManager/SysManager/Services/SystemInfoService.cs
@@ -3,6 +3,8 @@
 // License: MIT
 
 using System.Management;
+using System.Runtime.InteropServices;
+using Serilog;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -12,7 +14,22 @@ namespace SysManager.Services;
 /// PERF-M1: Static data (OS caption, CPU name, disk models) is cached on first
 /// query and reused — only dynamic data (CPU load, RAM, uptime) is refreshed.
 /// </summary>
-public sealed class SystemInfoService
+/// <remarks>
+/// The three DYNAMIC values are syscalls, not WMI. The Landing tab polls this every 300 ms, and each pass
+/// used to make two WMI round-trips for numbers the kernel hands over directly:
+/// <list type="bullet">
+///   <item>CPU load — <c>GetSystemTimes</c> deltas instead of <c>Win32_Processor.LoadPercentage</c>, which is
+///   a WMI-throttled one-second average. At a 300 ms poll the chart was redrawing a value that had not
+///   changed; the delta is a true average over the interval actually elapsed.</item>
+///   <item>Physical memory — <c>GlobalMemoryStatusEx</c>, one syscall, instead of
+///   <c>Win32_OperatingSystem.TotalVisibleMemorySize</c>/<c>FreePhysicalMemory</c>.</item>
+///   <item>Uptime — <c>Environment.TickCount64</c>, no query at all, and monotonic: the old
+///   <c>DateTime.Now - LastBootUpTime</c> warped whenever the clock was changed or DST shifted.</item>
+/// </list>
+/// The syscalls are constructor-injected so the delta arithmetic is unit-testable without a real machine —
+/// the same seam shape <c>ProcessManagerService</c> uses for its window enumeration.
+/// </remarks>
+public sealed partial class SystemInfoService
 {
     // Cached static data — queried once, never changes during app lifetime.
     private OsInfo? _cachedOs;
@@ -20,6 +37,48 @@ public sealed class SystemInfoService
     private List<DiskInfo>? _cachedDisks;
     private IReadOnlyList<MemoryModule>? _cachedModules;
     private readonly Lock _cacheLock = new();
+
+    private readonly Func<SystemTimes?> _systemTimes;
+    private readonly Func<PhysicalMemory?> _physicalMemory;
+    private readonly Func<long> _millisecondsSinceBoot;
+
+    // Guards the CPU delta's previous sample. Separate from _cacheLock, and safe to hold across the work it
+    // covers because that work is one cheap syscall — the reason the CPU query was moved OUT of _cacheLock
+    // was that a WMI round-trip under a shared lock stalls every other caller.
+    private readonly Lock _sampleLock = new();
+    private SystemTimes? _previousTimes;
+    private double _lastLoad = double.NaN;
+
+    public SystemInfoService()
+        : this(QuerySystemTimes, QueryPhysicalMemory, static () => Environment.TickCount64) { }
+
+    /// <summary>Test seam: builds the service over supplied syscalls instead of the real ones.</summary>
+    /// <param name="systemTimes">Idle/kernel/user tick totals since boot, or null if the syscall failed.</param>
+    /// <param name="physicalMemory">Total and available physical bytes, or null if the syscall failed.</param>
+    /// <param name="millisecondsSinceBoot">Monotonic milliseconds since the system started.</param>
+    /// <remarks>
+    /// The CPU baseline is seeded HERE rather than on the first capture, so the first number the user sees is
+    /// a real measurement over the interval between construction and that capture. Seeding lazily would have
+    /// made the first reading the since-boot average — correct, but not what the machine is doing right now.
+    /// </remarks>
+    internal SystemInfoService(Func<SystemTimes?> systemTimes, Func<PhysicalMemory?> physicalMemory,
+                              Func<long> millisecondsSinceBoot)
+    {
+        _systemTimes = systemTimes;
+        _physicalMemory = physicalMemory;
+        _millisecondsSinceBoot = millisecondsSinceBoot;
+        _previousTimes = systemTimes();
+    }
+
+    /// <summary>Idle, kernel and user tick totals since boot, in 100-nanosecond units.</summary>
+    /// <remarks>
+    /// <paramref name="Kernel"/> INCLUDES idle time, per <c>GetSystemTimes</c>, so busy time is
+    /// <c>(Kernel + User) - Idle</c> rather than a sum of the two non-idle figures.
+    /// </remarks>
+    internal readonly record struct SystemTimes(ulong Idle, ulong Kernel, ulong User);
+
+    /// <summary>Total and available physical memory, in bytes.</summary>
+    internal readonly record struct PhysicalMemory(ulong TotalBytes, ulong AvailableBytes);
 
     public Task<SystemSnapshot> CaptureAsync(CancellationToken ct = default)
         => Task.Run(() => Capture(), ct);
@@ -43,7 +102,8 @@ public sealed class SystemInfoService
             _cachedOs ??= QueryOsStatic();
             osStatic = _cachedOs ?? new OsInfo("Windows", "", "", TimeSpan.Zero, "");
 
-            // CPU name/cores/threads/clock are static; only LoadPercentage is dynamic.
+            // CPU name/cores/threads/clock are static; only the load is dynamic, and it comes from
+            // GetSystemTimes below rather than a second Win32_Processor query.
             _cachedCpuStatic ??= QueryCpuStatic();
             cpuStatic = _cachedCpuStatic ?? new CpuInfo("Unknown", 0, 0, 0, 0);
 
@@ -58,16 +118,133 @@ public sealed class SystemInfoService
             modules = _cachedModules ?? [];
         }
 
-        // Outside the lock, with QueryDynamicOs below. The lock exists to serialise the ??= caches, and a
-        // dynamic query needs none of it — while it was inside, every concurrent CaptureAsync waited on a WMI
-        // round-trip it had no interest in. The Dashboard polls this at 300 ms, so the wait was frequent.
-        var cpu = cpuStatic with { LoadPercent = QueryCpuLoad() };
+        // Outside the lock. The lock exists to serialise the ??= caches and the dynamic values need none of
+        // it — while the CPU query was inside, every concurrent CaptureAsync waited on a round-trip it had no
+        // interest in. The Dashboard polls this at 300 ms, so the wait was frequent.
+        var cpu = cpuStatic with { LoadPercent = SampleCpuLoad() };
+        var os = osStatic with { Uptime = TimeSpan.FromMilliseconds(_millisecondsSinceBoot()) };
+        return new SystemSnapshot(os, cpu, SampleMemory(modules), disks, DateTime.Now);
+    }
 
-        // One Win32_OperatingSystem query for BOTH the dynamic uptime and memory totals —
-        // previously two separate round-trips (QueryUptime + QueryMemory) to the same class.
-        var (uptime, mem) = QueryDynamicOs(modules);
-        var os = osStatic with { Uptime = uptime };
-        return new SystemSnapshot(os, cpu, mem, disks, DateTime.Now);
+    /// <summary>
+    /// CPU load as the busy share of the ticks elapsed since the previous sample.
+    /// </summary>
+    /// <remarks>
+    /// Three cases have to answer with something honest rather than zero, because zero is a legible number
+    /// that means "idle machine":
+    /// <list type="bullet">
+    ///   <item>the syscall failed — hold the last known value instead of flashing 0 into the chart;</item>
+    ///   <item>no previous sample at all (the constructor's seeding syscall failed too) — report the
+    ///   since-boot average, which is what a delta measured from zero actually is;</item>
+    ///   <item>two samples inside one timer tick, so the delta is 0 ticks wide — hold the last value, since
+    ///   0/0 is not 0% busy.</item>
+    /// </list>
+    /// </remarks>
+    internal double SampleCpuLoad()
+    {
+        lock (_sampleLock)
+        {
+            var current = _systemTimes();
+            if (current is null) return double.IsNaN(_lastLoad) ? 0 : _lastLoad;
+
+            var now = current.Value;
+            var previous = _previousTimes;
+            _previousTimes = now;
+
+            if (previous is { } was)
+            {
+                // Unsigned subtraction: these counters only ever advance, but a spurious backwards step
+                // would wrap to an enormous delta and produce a nonsense percentage, so the arithmetic is
+                // done in doubles after an explicit ordering check.
+                if (now.Idle >= was.Idle && now.Kernel >= was.Kernel && now.User >= was.User)
+                {
+                    var busyTicks = (now.Kernel - was.Kernel) + (now.User - was.User);
+                    if (busyTicks > 0)
+                    {
+                        _lastLoad = BusyPercent(now.Idle - was.Idle, busyTicks);
+                        return _lastLoad;
+                    }
+                }
+            }
+
+            if (double.IsNaN(_lastLoad)) _lastLoad = BusyPercent(now.Idle, now.Kernel + now.User);
+            return _lastLoad;
+        }
+    }
+
+    /// <summary>Busy share of <paramref name="total"/> ticks, clamped to a percentage.</summary>
+    private static double BusyPercent(ulong idle, ulong total)
+        => total == 0 ? 0 : Math.Clamp((1.0 - (double)idle / total) * 100.0, 0, 100);
+
+    /// <summary>
+    /// Physical memory totals from one syscall. The static DIMM inventory is passed through unchanged.
+    /// </summary>
+    /// <remarks>A failed syscall degrades to zeroed totals with the modules still listed, matching what the
+    /// WMI path did when the query faulted.</remarks>
+    internal MemoryInfo SampleMemory(IReadOnlyList<MemoryModule> modules)
+    {
+        var memory = _physicalMemory();
+        var totalGB = memory is { } m ? m.TotalBytes / 1024d / 1024d / 1024d : 0;
+        var freeGB = memory is { } available ? available.AvailableBytes / 1024d / 1024d / 1024d : 0;
+        var usedGB = totalGB - freeGB;
+        var pct = totalGB > 0 ? usedGB / totalGB * 100.0 : 0;
+        return new MemoryInfo(totalGB, freeGB, usedGB, pct, modules);
+    }
+
+    private static SystemTimes? QuerySystemTimes()
+    {
+        if (NativeMethods.GetSystemTimes(out var idle, out var kernel, out var user))
+            return new SystemTimes(ToTicks(idle), ToTicks(kernel), ToTicks(user));
+
+        Log.Debug("GetSystemTimes failed: {Code}", Marshal.GetLastPInvokeError());
+        return null;
+    }
+
+    private static ulong ToTicks(NativeMethods.FILETIME time)
+        => ((ulong)time.dwHighDateTime << 32) | time.dwLowDateTime;
+
+    private static PhysicalMemory? QueryPhysicalMemory()
+    {
+        var status = new NativeMethods.MEMORYSTATUSEX { dwLength = (uint)Marshal.SizeOf<NativeMethods.MEMORYSTATUSEX>() };
+        if (NativeMethods.GlobalMemoryStatusEx(ref status))
+            return new PhysicalMemory(status.ullTotalPhys, status.ullAvailPhys);
+
+        Log.Debug("GlobalMemoryStatusEx failed: {Code}", Marshal.GetLastPInvokeError());
+        return null;
+    }
+
+    private static partial class NativeMethods
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct FILETIME
+        {
+            public uint dwLowDateTime;
+            public uint dwHighDateTime;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct MEMORYSTATUSEX
+        {
+            public uint dwLength;
+            public uint dwMemoryLoad;
+            public ulong ullTotalPhys;
+            public ulong ullAvailPhys;
+            public ulong ullTotalPageFile;
+            public ulong ullAvailPageFile;
+            public ulong ullTotalVirtual;
+            public ulong ullAvailVirtual;
+            public ulong ullAvailExtendedVirtual;
+        }
+
+        // No A/W variants, so no explicit EntryPoint is needed on either.
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool GetSystemTimes(out FILETIME lpIdleTime, out FILETIME lpKernelTime,
+                                                   out FILETIME lpUserTime);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool GlobalMemoryStatusEx(ref MEMORYSTATUSEX lpBuffer);
     }
 
     // Returns null on a WMI fault so the caller's ??= cache retries next poll (see Capture).
@@ -79,7 +256,10 @@ public sealed class SystemInfoService
         // is retried on the next poll — Capture() supplies a transient default for this snapshot.
         try
         {
-            using var searcher = new ManagementObjectSearcher("SELECT Caption,Version,BuildNumber,OSArchitecture,LastBootUpTime FROM Win32_OperatingSystem");
+            // No LastBootUpTime: this result is CACHED for the process lifetime, so an uptime parsed here
+            // would be frozen at first-query time — and Capture overwrites it from the monotonic clock on
+            // every snapshot anyway. Selecting and parsing it was work whose result could never be read.
+            using var searcher = new ManagementObjectSearcher("SELECT Caption,Version,BuildNumber,OSArchitecture FROM Win32_OperatingSystem");
             using var osCollection = searcher.Get();
             foreach (ManagementObject mo in osCollection)
             {
@@ -89,15 +269,7 @@ public sealed class SystemInfoService
                     var version = mo["Version"]?.ToString() ?? "";
                     var build = mo["BuildNumber"]?.ToString() ?? "";
                     var arch = mo["OSArchitecture"]?.ToString() ?? "";
-                    var lastBootRaw = mo["LastBootUpTime"]?.ToString();
-                    var uptime = TimeSpan.Zero;
-                    if (!string.IsNullOrEmpty(lastBootRaw))
-                    {
-                        try { uptime = DateTime.Now - ManagementDateTimeConverter.ToDateTime(lastBootRaw); }
-                        catch (FormatException) { /* WMI date string malformed — keep zero uptime */ }
-                        catch (InvalidCastException) { /* WMI returned unexpected type — keep zero uptime */ }
-                    }
-                    return new OsInfo(caption, version, build, uptime, arch);
+                    return new OsInfo(caption, version, build, TimeSpan.Zero, arch);
                 }
             }
         }
@@ -108,46 +280,6 @@ public sealed class SystemInfoService
         }
         // Query succeeded but returned no rows — a valid (if unusual) answer; cache it.
         return new OsInfo("Windows", "", "", TimeSpan.Zero, "");
-    }
-
-    // Single Win32_OperatingSystem query for BOTH the dynamic uptime and the memory totals, so
-    // the per-poll path makes one round-trip instead of two (QueryUptime + QueryMemory previously
-    // queried the same class separately). The static DIMM modules are passed through unchanged.
-    private static (TimeSpan Uptime, MemoryInfo Memory) QueryDynamicOs(IReadOnlyList<MemoryModule> modules)
-    {
-        var uptime = TimeSpan.Zero;
-        double totalKb = 0, freeKb = 0;
-        try
-        {
-            using var searcher = new ManagementObjectSearcher(
-                "SELECT LastBootUpTime,TotalVisibleMemorySize,FreePhysicalMemory FROM Win32_OperatingSystem");
-            using var osCollection = searcher.Get();
-            foreach (ManagementObject mo in osCollection)
-            {
-                using (mo)
-                {
-                    var lastBootRaw = mo["LastBootUpTime"]?.ToString();
-                    if (!string.IsNullOrEmpty(lastBootRaw))
-                    {
-                        try { uptime = DateTime.Now - ManagementDateTimeConverter.ToDateTime(lastBootRaw); }
-                        catch (FormatException) { /* WMI date string malformed — keep zero uptime */ }
-                        catch (InvalidCastException) { /* WMI returned unexpected type — keep zero uptime */ }
-                    }
-                    totalKb = Convert.ToDouble(mo["TotalVisibleMemorySize"] ?? 0);
-                    freeKb = Convert.ToDouble(mo["FreePhysicalMemory"] ?? 0);
-                }
-            }
-        }
-        catch (Exception ex) when (ex is ManagementException or System.Runtime.InteropServices.COMException)
-        {
-            /* WMI unavailable — degrade to zero uptime + zeroed totals (modules still shown) */
-        }
-
-        double totalGB = totalKb / 1024d / 1024d;
-        double freeGB = freeKb / 1024d / 1024d;
-        double usedGB = totalGB - freeGB;
-        double pct = totalGB > 0 ? usedGB / totalGB * 100.0 : 0;
-        return (uptime, new MemoryInfo(totalGB, freeGB, usedGB, pct, modules));
     }
 
     // Returns null on a WMI fault so the caller's ??= cache retries next poll (see Capture).
@@ -177,27 +309,6 @@ public sealed class SystemInfoService
         }
         // Query succeeded but returned no rows — cache the "unknown" answer.
         return new CpuInfo("Unknown", 0, 0, 0, 0);
-    }
-
-    private static double QueryCpuLoad()
-    {
-        try
-        {
-            using var searcher = new ManagementObjectSearcher("SELECT LoadPercentage FROM Win32_Processor");
-            using var cpuCollection = searcher.Get();
-            foreach (ManagementObject mo in cpuCollection)
-            {
-                using (mo)
-                {
-                    return Convert.ToDouble(mo["LoadPercentage"] ?? 0.0);
-                }
-            }
-        }
-        catch (Exception ex) when (ex is ManagementException or System.Runtime.InteropServices.COMException)
-        {
-            /* WMI unavailable — degrade to zero load */
-        }
-        return 0;
     }
 
     // Physical DIMM inventory — static hardware, enumerated once and cached. Kept separate

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.23</Version>
-    <FileVersion>1.76.23.0</FileVersion>
-    <AssemblyVersion>1.76.23.0</AssemblyVersion>
+    <Version>1.76.24</Version>
+    <FileVersion>1.76.24.0</FileVersion>
+    <AssemblyVersion>1.76.24.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
#2104's four items, re-derived against current source before touching anything. Items 2, 3 and 4 were already fixed in earlier work; **item 1 is what this PR does**, so the issue closes here.

| Item | State when checked | Where |
|---|---|---|
| 1. Two WMI round-trips every 300 ms | **open — this PR** | `SystemInfoService.Capture` |
| 2. Dynamic query under the static-cache lock | already fixed | `SystemInfoService.cs:120-123`, pinned by `TheSnapshotCacheLock_HoldsOnlyCachedQueries` |
| 3. Window handle resolved twice per process | already fixed (#2123) | one `EnumWindows` pass + `IsHungAppWindow` |
| 4. Prune re-serialising every kept line | already fixed | `ResourceHistoryService.Prune` / `BandwidthHistoryService.Prune` — kept lines are handed back verbatim |

## The change

The vitals poll runs every 300 ms for as long as the tab is open. The static parts were cached; two queries stayed dynamic and ran 3.3 times a second:

```
SELECT LoadPercentage FROM Win32_Processor
SELECT LastBootUpTime,TotalVisibleMemorySize,FreePhysicalMemory FROM Win32_OperatingSystem
```

- **CPU load → `GetSystemTimes` deltas.** `LoadPercentage` is a WMI-throttled one-second average, so at a 300 ms poll the chart spent two passes in three redrawing a number that had not changed. The delta is the busy share of the ticks that actually elapsed.
- **Memory → `GlobalMemoryStatusEx`,** one syscall.
- **Uptime → `Environment.TickCount64`,** no query, and monotonic — `DateTime.Now` minus a boot timestamp moved whenever the clock changed or DST shifted.

Kernel time **includes** idle time, so busy is `(kernelΔ + userΔ) - idleΔ`. Reading it as "kernel and user are both busy" is the classic mistake and reports 100% on an idle machine, which is why the test asserts an exact percentage rather than a range.

### Four ways this can be handed nothing usable

0% is a legible number meaning "idle machine", not "unknown", so none of these may return it:

| Case | Answer |
|---|---|
| syscall failed | hold the last reading |
| no baseline at all (the constructor's seeding call failed too) | since-boot average — what a delta measured from zero actually is |
| two samples inside one timer tick | hold; 0 idle of 0 total is not 0% busy |
| counters stepped backwards | hold, rather than let unsigned subtraction wrap |

The baseline is seeded in the **constructor**, not lazily on first capture, so the first number the user sees is a real measurement over the interval between construction and that capture. Mutation 6 makes it lazy and lands on exactly 66.666% where 75% is required — that is the difference, quantified.

### Also removed

`LastBootUpTime` is gone from the **cached static** query. That result is cached for the process lifetime, so the uptime parsed there was frozen at first-query time — and `Capture` overwrote it on every snapshot regardless. A WMI column, a date parse and two `catch` clauses whose result could never be read.

## Testability

The three syscalls are constructor-injected, matching the seam shape `ProcessManagerService` uses for its window enumeration. 14 unit tests cover the arithmetic and all four degradation paths with fed readings — no real machine, no WMI, no `dotnet test` needed to reason about them.

Three integration assertions cover the syscalls end to end, so a marshalling mistake cannot hide behind green unit tests: uptime against `TickCount64` in a one-second window (a frozen value drifts, which is exactly what catches a regression to the cached read), the load as a usable percentage, and total/available/used memory being internally consistent.

`NoWmiRunsOnTheSnapshotPollPath` pins this by WMI **column** name rather than method name, because the regression is someone adding the query back — possibly in a new method a name list would not see. Its positive half matters as much: without asserting the syscall path is still *called*, deleting the dynamic values entirely would satisfy the rule. Mutation 10 proves that half fires.

## Red/green — 10 mutations, all as claimed

| # | Mutation | Test | Result |
|---|---|---|---|
| 1 | kernel+user read as busy time | exact-percentage | RED (80 vs 75) |
| 2 | flash 0 on syscall failure | holds-on-failure | RED (0 vs 75) |
| 3 | drop the backwards-step check | backwards-counters | RED (0 vs 75) |
| 4 | drop the since-boot fallback | no-baseline | RED (0 vs 75) |
| 5 | drop the zero-width-interval guard | same-tick | RED (0 vs 75) |
| 6 | seed the baseline lazily | exact-percentage | RED (66.666 vs 75) |
| 7 | swap total and available memory | memory-in-GB | RED (2 vs 8) |
| 8 | divide unconditionally for used-percent | memory-failure | RED (NaN vs 0) |
| 9 | put the WMI CPU query back | no-WMI guard | RED, named `LoadPercentage` |
| 10 | delete the uptime seam call | no-WMI guard | RED, named `_millisecondsSinceBoot` |

`SystemInfoService.cs` restored from a byte-for-byte hash-verified copy after each, tree rebuilt.

## Verification

- Four projects build in Release: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: clean.
- Guard sweep over 172 names (`ArchitectureTests`, `UiAutomationContractTests`, and the CPU/memory, dashboard and history-service tests): **271 green, 2 red** — both harness artefacts, `Dispose` (an `IDisposable` method, not a test) and the throwaway runner's own `Program.cs`, neither in the repo.
- One genuine red surfaced mid-sweep and was fixed: `EveryDocumentedMember_CarriesASummary` caught the new internal constructor documenting its parameters without a `<summary>`.
- Leak scan over the staged diff against all 43 current patterns: 0 hits, with a population floor asserted so a mis-read terms file cannot report clean on nothing.

## Not done here

The issue also asks for a **measurement** — idle CPU% with the Landing tab open, and the wall-clock of one Process Manager refresh on a machine with 300+ processes. Both need the application running, which this workstation does not do, so they are deferred to the secondary workstation. Calling that out rather than letting it pass as complete: the code items are all closed, the numbers are not yet taken.

Closes #2104
