### PR TITLE
ci: run the integration suite as a non-blocking job so its assertions can fail out loud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,3 +490,84 @@ jobs:
           name: ui-test-results
           path: TestResults/**
           retention-days: 14
+
+  # The integration suite was compile-checked and never EXECUTED anywhere in the pipeline, and the
+  # primary workstation cannot run `dotnet test` at all. So a stale expectation in it stayed invisible
+  # indefinitely: nine assertions sat red through a whole rename because compiling them still worked,
+  # and one asserted a sidebar tab that had stopped being last. Both were found by reading the file,
+  # which is not a process.
+  #
+  # Non-blocking, deliberately, and shaped exactly like ui-tests above: these tests touch the live
+  # system (WMI, the filesystem, real processes), so a runner difference must not gate a merge. What
+  # they must do is SPEAK — the warning annotation below is the whole point of the job, and the
+  # session-start health check reads recent runs, so a red surfaces without anyone remembering to look.
+  #
+  # It spoke immediately. The first run found five failures and a hang, none of which anything in the
+  # pipeline could have reported before, because the suite was compile-checked and never executed:
+  #   WindowsUpdateAutoCheckTests.CommandExists(propName: "ListFeatureUpdatesCommand")
+  #   EventLogServiceTests.Read_SeverityFilter_ReturnsOnlyRequested
+  #   EventLogServiceTests.Read_System_ReturnsSomeEntries_Within_ShortWindow
+  #   EventLogServiceTests.Read_EntriesEnrichedWithExplanation
+  #   DeepCleanupViewUiTests.View_BindsToDeepCleanupViewModel  (Cannot find resource named 'Display')
+  # then silence from 00:07:41 to the 30-minute ceiling. So this job starts red on purpose: the failures
+  # are real and are being fixed, and a job that hid them would be the thing worth deleting.
+  #
+  # This is the broader of the two answers the issue proposed. Moving the project's pure assertions
+  # into the blocking unit suite is still worth doing and does not conflict; it just cannot cover the
+  # tests that genuinely need a live system, which this does.
+  integration-tests:
+    name: Integration tests (non-blocking)
+    runs-on: windows-latest
+    needs: build-and-test
+    timeout-minutes: 30
+    # Fork PRs have no secrets and no reason to run a live-system suite.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup .NET 10 SDK
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: |
+          dotnet restore SysManager/SysManager/SysManager.csproj
+          dotnet restore SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
+
+      - name: Build integration tests
+        run: dotnet build SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj -c Release --no-restore
+
+      # --blame-hang is not optional here, it is the whole reason this job is usable. The first run of this
+      # job proved the suite HANGS on a clean runner: it reported five failures in the first eight minutes and
+      # then produced no output at all for twenty-one, until the job's own 30-minute ceiling cancelled it. A
+      # cancelled job reports `cancelled`, which `gh pr checks` renders as `fail` — indistinguishable from a
+      # broken pipeline, and permanently red, which is how a non-blocking job teaches everyone to ignore it.
+      #
+      # With a hang timeout, the run stops at five minutes of silence, NAMES the test that stopped responding,
+      # and writes a dump next to the results. A hang becomes a finding instead of a timeout.
+      - name: Run integration tests
+        id: integration-tests
+        run: >
+          dotnet test SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
+          -c Release --no-build
+          --blame-hang --blame-hang-timeout 5m
+          --logger "trx;LogFileName=integration-results.trx"
+          --results-directory TestResults
+        continue-on-error: true
+
+      # `outcome`, NOT `conclusion`: continue-on-error forces the step's conclusion to 'success', so a
+      # conclusion check never fires and the failure is masked completely. Same trap as ui-tests.
+      - name: Annotate integration test failures
+        if: steps.integration-tests.outcome == 'failure'
+        run: echo "::warning::Integration tests failed — review the integration-test-results artifact. This job is non-blocking, so the merge is not gated; the failure is still real."
+
+      - name: Upload integration test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: integration-test-results
+          path: TestResults/**
+          retention-days: 14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ SysManager/
 │   ├── Helpers/               # small utilities, converters
 │   └── Resources/             # icons, generated assets
 ├── SysManager.Tests/          # xUnit unit tests
-├── SysManager.IntegrationTests/ # integration tests (local only, not CI)
+├── SysManager.IntegrationTests/ # integration tests (CI, non-blocking)
 └── SysManager.UITests/        # FlaUI UI-automation tests
 ```
 
@@ -169,10 +169,13 @@ dotnet test SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.c
 dotnet test SysManager/SysManager.UITests/SysManager.UITests.csproj -c Release
 ```
 
-The integration tests touch the live system, so CI only compile-checks them —
-run them locally, not over SSH/Remote PowerShell. CI runs the unit tests as the
-merge gate and the UI-automation tests as a separate, non-blocking job (they need
-the interactive desktop a `windows-latest` runner provides).
+The integration tests touch the live system, so run them locally rather than over
+SSH/Remote PowerShell. CI runs the unit tests as the merge gate, and both the
+integration and UI-automation suites as separate **non-blocking** jobs — a failure
+there raises a warning annotation and uploads its results, but does not block a
+merge, because a runner difference should not. Put a test that needs the live
+system in the integration project; put anything pure in `SysManager.Tests`, where
+it gates merges.
 
 Filter to one class while iterating (pass the project the class lives in —
 `PingMonitorServiceTests` is an integration test):

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,7 +7,7 @@ SysManager has three test projects, each with a distinct scope and runner.
 | Project | What it tests | Runs on CI |
 |---|---|---|
 | `SysManager.Tests` | Unit tests — mostly pure logic, but some tests touch lightweight OS APIs (registry reads, process enumeration, Task Scheduler queries) and a few exercise STA/UI-thread code via `Xunit.StaFact` (`[StaFact]`). No WMI, no network I/O, no admin required. | ✅ Every push / PR |
-| `SysManager.IntegrationTests` | Integration tests — real Windows APIs (Event Log, WMI, PowerShell, ICMP, WPF dispatcher) | ❌ Local only |
+| `SysManager.IntegrationTests` | Integration tests — real Windows APIs (Event Log, WMI, PowerShell, ICMP, WPF dispatcher) | ⚠️ CI (non-blocking) |
 | `SysManager.UITests` | End-to-end UI automation via FlaUI — needs an interactive desktop session; runs in CI on a desktop-enabled runner, non-blocking (`continue-on-error`) and skipped on fork PRs | ⚠️ CI (non-blocking) |
 
 ## Running unit tests (CI-equivalent)
@@ -18,14 +18,18 @@ dotnet test SysManager/SysManager.Tests/SysManager.Tests.csproj -c Release
 
 ## Running integration tests locally
 
-Requires a real Windows machine (not a headless CI runner).
-
 ```powershell
 dotnet test SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj -c Release
 ```
 
 Some integration tests require admin rights (WMI storage queries, ICMP sockets).
 Run from an elevated PowerShell prompt if you see access-denied failures.
+
+CI also runs this suite as a **non-blocking** job, so a stale expectation surfaces as a
+warning annotation instead of sitting invisible. It is not a merge gate: these tests touch
+the live system, so a runner difference must not block a merge. A red here is still real —
+read the `integration-test-results` artifact. Anything that fails only on a runner belongs
+in this suite; anything pure belongs in `SysManager.Tests`, where it gates merges.
 
 ## Running UI automation tests locally
 


### PR DESCRIPTION
#2101's two concrete rots were both **already fixed** when I re-derived them against current source. What remained is the part that matters most: the structural reason they were able to rot at all.

| #2101 item | State when checked |
|---|---|
| Nine assertions comparing against pre-migration hex literals | already fixed — all nine reference `StatusColors.Good` / `.Bad` / `.Warning` / `.Info` / `.Neutral` |
| `NavItems_CorrectOrder_AboutLast` asserting the wrong last tab | already fixed — rewritten as `NavItems_AboutIsLastInTheInfoGroup`, an invariant an appended group cannot rot |
| "a project whose assertions cannot run anywhere in the pipeline will rot again" | **open — this PR** |

The 8 hex literals left in the project are the pass-in-and-read-back kind the issue itself called unaffected, and `ci.yml:311` still only compile-checks the project. Both re-verified here rather than taken from the issue text.

## The change

A separate `integration-tests` job, shaped exactly like the `ui-tests` job above it:

- `needs: build-and-test`, `windows-latest`, 30-minute ceiling
- `continue-on-error: true` on the `dotnet test` step
- a warning annotation keyed on **`outcome`**, not `conclusion` — `continue-on-error` forces the step's `conclusion` to `success`, so a conclusion check never fires and the failure is masked completely. The same trap is already documented on `ui-tests`.
- results uploaded as an artifact, 14-day retention
- skipped on fork PRs, which have no secrets and no reason to run a live-system suite

**Non-blocking is deliberate.** These tests touch WMI, the filesystem and real processes, so a runner difference must not gate a merge — and a job that blocks on environment noise gets ignored, which is the failure mode being fixed, not a cure for it. What the job must do is *speak*: the annotation is the point, and the session-start health check reads recent runs, so a red surfaces without anyone remembering to look.

No `junit` logger on this step: that package is referenced only by `SysManager.Tests`, and nothing consumes junit output from this suite. Asking for it would fail the step for the wrong reason and emit a permanent false warning — checked rather than assumed.

## Why this option

The issue offered two: run it somewhere, or move the pure assertions into the blocking unit suite. This is the broader one — it covers every test in the project immediately, including the ones that genuinely need a live system and could never move. Migrating the pure assertions is still worth doing and does not conflict; it is a `test:`-scoped follow-up, not a substitute, and I have not folded it in here to keep this diff to the mechanism.

I cannot predict whether the suite is green on a GitHub runner — this workstation cannot run `dotnet test`, so the first run of this job is also the measurement. That is precisely why it lands non-blocking rather than as a gate.

## Docs

`TESTING.md` and `CONTRIBUTING.md` said "local only, not CI" in three places. Corrected, plus an explicit statement of where a new test belongs: live-system in the integration project, pure in `SysManager.Tests` where it gates merges.

## Verification

- All five workflow files parse; `integration-tests` is registered with the intended `needs`, timeout, seven steps and `continue-on-error: true` — asserted by parsing the YAML, not by reading the diff.
- Actions are SHA-pinned, reusing the exact pins already in this file.
- No code change, so `ci:` — no version bump, no release.
- Leak scan over the staged diff against all 43 current patterns: 0 hits.

Closes #2101
