### PR TITLE
fix: route the last seven hand-rolled empty states through the shared control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.25] - 2026-09-07
+
+Six tabs told you a list was empty with one small grey sentence floating in a large blank card, while thirty
+others gave you an icon, a headline and a plain-English next step. They now all look the same, and three of
+them explain the thing that actually confuses people: the list is empty because a search or filter is hiding
+everything, not because the feature is broken.
+
+### Fixed
+- **Services, Startup, Task Manager, Windows Features, DNS & Hosts and Speed Test use the same empty state as
+  every other tab.** These six drew their own one-line message instead of the shared control, so they had no
+  icon and no headline — and two of them were not even centred, reading as a stray caption rather than an
+  empty state. Seven places in total; the shared control is now used everywhere.
+- **Three of them now say *why* the list is empty.** "No processes to show" on its own is alarming. Where the
+  list is empty because a search term or a filter matches nothing, it now says so and tells you to clear it —
+  Task Manager, Windows Features and Services.
+- **DNS & Hosts explains what an empty hosts file means** instead of just noting there is nothing to show.
+
+### Added
+- **A check that no tab can hand-roll its own empty state again.** The six were not an oversight of taste:
+  none of them declared the namespace the shared control lives in, so it was simply unreachable when they
+  were written. The check now catches that, and it is scoped so the "No battery detected" and "No NVIDIA GPU
+  detected" notices — which are facts about your hardware inside a working card, not empty lists — are
+  correctly left alone.
+
 ## [1.76.24] - 2026-09-07
 
 The Landing tab used to ask Windows the same two questions 3.3 times a second, the expensive way, for three

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1729,6 +1729,96 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// A view that has something to say when a list is empty must say it through the shared
+    /// <c>EmptyState</c> control, not a hand-rolled <c>TextBlock</c>.
+    /// </summary>
+    /// <remarks>
+    /// A DIFFERENT question from the guard above, which is why it is a second test and not a tightening of
+    /// that one. That guard asks whether a view says anything at all, and deliberately accepts three forms
+    /// that are not the control — a domain flag and a zero-count <c>DataTrigger</c> — because three views got
+    /// it right that way. Requiring the control there would have failed them. This asks the narrower
+    /// question: when the affordance IS a plain TextBlock gated on a list's emptiness, it is the control's job.
+    /// <para>Seven blocks across six views bypassed it, all five identical lines with a different string, and
+    /// none of the six even declared the <c>xmlns:v</c> namespace — the control was unreachable when they were
+    /// written. Against the control they rendered differently three ways: no glyph, one flat 12px
+    /// <c>Subtle</c> line instead of a 14px SemiBold title over a 12px message, and <c>MaxWidth</c> 360
+    /// against the control's 420.</para>
+    /// <para><b>Why the rule ties the path to an ItemsSource.</b> "Any emptiness-Inverse TextBlock" was the
+    /// first draft, and across all views it also matched three notices that are correctly plain text: "No
+    /// battery detected" (<c>Battery.HasBattery</c>), "No NVIDIA GPU detected" (<c>HasNvidiaGpu</c>) and the
+    /// Tune-up card's good-news line (<c>TuneUpResult.WarningCount</c>) — inline facts inside populated cards,
+    /// not list empty states. Two of the three are screened out anyway by the <c>listed.Count == 0</c> skip,
+    /// since Battery Health and Performance bind no <c>ItemsSource</c> at all; it is the ItemsSource-PATH tie
+    /// that screens the third, in a view that does list six collections. Measured: 7 offenders before the fix,
+    /// 0 after, and no notice caught either way — with no exception list to rot, because a hardware flag is
+    /// not the Count of a list.</para>
+    /// </remarks>
+    [Fact]
+    public void NoViewHandRollsAnEmptyStateTheSharedControlAlreadyProvides()
+    {
+        var viewsDir = Path.Combine(FindAppProjectDir(), "Views");
+        var files = Directory.GetFiles(viewsDir, "*.xaml");
+
+        var offenders = new List<string>();
+        var listing = 0;
+
+        foreach (var file in files)
+        {
+            var xaml = File.ReadAllText(file);
+
+            var listed = ItemsSourceBinding().Matches(xaml)
+                .Select(m => m.Groups["path"].Value)
+                .ToHashSet(StringComparer.Ordinal);
+            if (listed.Count == 0) continue;
+            listing++;
+
+            foreach (var block in SelfClosingTextBlock().Matches(xaml).Cast<Match>())
+            {
+                var gate = CountInverseVisibility().Match(block.Value);
+                if (!gate.Success || !listed.Contains(gate.Groups["path"].Value)) continue;
+
+                var label = TextAttribute().Match(block.Value);
+                offenders.Add($"{Path.GetFileName(file)} — TextBlock gated on {gate.Groups["path"].Value}"
+                    + $".Count: \"{(label.Success ? label.Groups[1].Value : "<bound>")}\"");
+            }
+        }
+
+        // Vacuity floor: 44 views bind an ItemsSource. A collapse means the binding pattern stopped matching
+        // and every absence below is an absence of scanning.
+        Assert.True(listing >= 40,
+            $"only {listing} views were found binding an ItemsSource — the pattern is out of date, so a pass "
+            + "proves nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "These views hand-roll an empty state as a plain TextBlock for a list they display, instead of the "
+            + "shared <v:EmptyState/> whose own comment calls it the single source of truth for the "
+            + "icon-title-message idiom. The hand-rolled form has no glyph and no title/message hierarchy, so "
+            + "a future contrast, spacing or screen-reader fix to empty states will miss these. Add "
+            + "xmlns:v=\"clr-namespace:SysManager.Views\" and use the control, keeping the binding path "
+            + "verbatim:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>A self-closing <c>TextBlock</c> element, however many lines it spans.</summary>
+    [GeneratedRegex(@"<TextBlock\b[^>]*?/>", RegexOptions.Singleline | RegexOptions.Compiled)]
+    private static partial Regex SelfClosingTextBlock();
+
+    /// <summary>An <c>ItemsSource</c> bound to a path, capturing the path.</summary>
+    [GeneratedRegex(@"ItemsSource=""\{Binding\s+(?<path>[\w.]+)\s*[},]", RegexOptions.Compiled)]
+    private static partial Regex ItemsSourceBinding();
+
+    /// <summary>
+    /// An <c>Inverse</c> visibility binding on some path's <c>.Count</c>, capturing the path without it.
+    /// </summary>
+    /// <remarks>
+    /// <c>[^"]*</c> rather than <c>[^}]*</c>: the binding nests <c>Converter={StaticResource FlexVis}</c>, so
+    /// a run that cannot cross a brace stops before <c>ConverterParameter</c> and the whole guard matches
+    /// nothing. That exact mistake made the first measurement report 0 offenders where there were 7.
+    /// </remarks>
+    [GeneratedRegex(@"Visibility=""\{Binding\s+(?<path>[\w.]+)\.Count[^""]*ConverterParameter=Inverse",
+                    RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex CountInverseVisibility();
+
+    /// <summary>
     /// Every empty-state flag is set where the data it describes arrives, on all of that method's paths.
     /// </summary>
     /// <remarks>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.24</Version>
-    <FileVersion>1.76.24.0</FileVersion>
-    <AssemblyVersion>1.76.24.0</AssemblyVersion>
+    <Version>1.76.25</Version>
+    <FileVersion>1.76.25.0</FileVersion>
+    <AssemblyVersion>1.76.25.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/CliInterfaceView.xaml
+++ b/SysManager/SysManager/Views/CliInterfaceView.xaml
@@ -43,7 +43,11 @@
             </DockPanel>
         </Border>
 
-        <!-- Command reference -->
+        <!-- Command reference.
+             Deliberately no v:EmptyState: Commands is filled from CliRunner.Commands, a static list compiled
+             into the app, so the grid cannot be empty and an empty state here could never render. Said out
+             loud because a uniformity sweep otherwise adds one that no user will ever see — this grid was
+             flagged as a candidate for exactly that reason. -->
         <Border Grid.Row="3" Style="{StaticResource Card}">
             <DataGrid ItemsSource="{Binding Commands}" AutoGenerateColumns="False" IsReadOnly="True"
                       HeadersVisibility="Column" GridLinesVisibility="None" Background="Transparent"

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -1,7 +1,8 @@
 <!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.DnsHostsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views">
     <Grid Background="{DynamicResource Surface0}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -171,10 +172,10 @@
                 </DataGrid>
 
                 <!-- Empty state -->
-                <TextBlock Text="No host entries to show. Add one above to get started."
-                           Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
-                           HorizontalAlignment="Center" VerticalAlignment="Center"
-                           Visibility="{Binding HostEntries.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                <v:EmptyState Glyph="&#xE946;"
+                              Title="No host entries yet"
+                              Message="Your hosts file has no redirects in it. Add one above to point a name at a different address."
+                              Visibility="{Binding HostEntries.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                 </Grid>
 
                 <!-- Add entry row — a single left-to-right labelled group so both inputs read in

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:ProcessManagerViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -291,10 +292,10 @@
             </DataGrid>
 
             <!-- Empty state -->
-            <TextBlock Text="No processes to show."
-                       Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
-                       HorizontalAlignment="Center" VerticalAlignment="Center"
-                       Visibility="{Binding FilteredProcesses.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            <v:EmptyState Glyph="&#xE946;"
+                          Title="No processes to show"
+                          Message="Nothing matches the current search. Clear it to see every running process."
+                          Visibility="{Binding FilteredProcesses.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
             </Grid>
         </Border>
 

--- a/SysManager/SysManager/Views/ProfileView.xaml
+++ b/SysManager/SysManager/Views/ProfileView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:ProfileViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -44,9 +45,10 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
-                <TextBlock Text="No exportable settings found yet. Change something you would want on another PC — pick a theme, set a dark-mode schedule, save a volume preset — then refresh."
-                           Style="{StaticResource Subtle}" TextWrapping="Wrap" Margin="0,0,0,8"
-                           Visibility="{Binding HasSections, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                <v:EmptyState Glyph="&#xE946;"
+                              Title="No exportable settings found yet"
+                              Message="Change something you would want on another PC — pick a theme, set a dark-mode schedule, save a volume preset — then refresh."
+                              Visibility="{Binding HasSections, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
 
                 <WrapPanel>
                     <Button Content="Export profile…" Command="{Binding ExportCommand}"

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:ServicesViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -301,10 +302,10 @@
         </DataGrid>
 
             <!-- Empty state -->
-            <TextBlock Text="No services to show. If this looks wrong, use Refresh."
-                       Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
-                       HorizontalAlignment="Center" VerticalAlignment="Center"
-                       Visibility="{Binding Services.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            <v:EmptyState Glyph="&#xE946;"
+                          Title="No services to show"
+                          Message="If this looks wrong, use Refresh. A filter or search term may also be hiding everything."
+                          Visibility="{Binding Services.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
         </Grid>
         </Border>
 

--- a/SysManager/SysManager/Views/SpeedTestView.xaml
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml
@@ -1,7 +1,8 @@
 <!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.SpeedTestView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views">
 
     <UserControl.Resources>
         <!-- The verdict callout, defined once and used by both engine cards. Two hand-written copies of
@@ -174,9 +175,10 @@
                                 <DataGridTextColumn Header="Server" Binding="{Binding Server}" Width="*" MinWidth="80"/>
                             </DataGrid.Columns>
                         </DataGrid>
-                        <TextBlock Text="No history yet — run a test to start tracking."
-                                   Style="{StaticResource Subtle}" Margin="0,8,0,0"
-                                   Visibility="{Binding OoklaHistory.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                        <v:EmptyState Glyph="&#xE9D9;"
+                                      Title="No history yet"
+                                      Message="Run a test to start tracking how this connection changes over time."
+                                      Visibility="{Binding OoklaHistory.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                     </StackPanel>
                 </Border>
 
@@ -205,9 +207,10 @@
                                 <DataGridTextColumn Header="Server" Binding="{Binding Server}" Width="*" MinWidth="80"/>
                             </DataGrid.Columns>
                         </DataGrid>
-                        <TextBlock Text="No history yet — run a test to start tracking."
-                                   Style="{StaticResource Subtle}" Margin="0,8,0,0"
-                                   Visibility="{Binding HttpHistory.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+                        <v:EmptyState Glyph="&#xE9D9;"
+                                      Title="No history yet"
+                                      Message="Run a test to start tracking how this connection changes over time."
+                                      Visibility="{Binding HttpHistory.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                     </StackPanel>
                 </Border>
             </Grid>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:StartupViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -260,10 +261,10 @@
             </DataGrid>
 
             <!-- Empty state -->
-            <TextBlock Text="No startup programs to show. If this looks wrong, use Refresh."
-                       Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
-                       HorizontalAlignment="Center" VerticalAlignment="Center"
-                       Visibility="{Binding Entries.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            <v:EmptyState Glyph="&#xE946;"
+                          Title="No startup programs to show"
+                          Message="If this looks wrong, use Refresh. &quot;Hide Windows entries&quot; may also be hiding everything."
+                          Visibility="{Binding Entries.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
             </Grid>
         </Border>
 

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:WindowsFeaturesViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -267,10 +268,10 @@
             </DataGrid>
 
             <!-- Empty state -->
-            <TextBlock Text="No Windows features to show."
-                       Style="{StaticResource Subtle}" TextWrapping="Wrap" MaxWidth="360"
-                       HorizontalAlignment="Center" VerticalAlignment="Center"
-                       Visibility="{Binding FilteredFeatures.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
+            <v:EmptyState Glyph="&#xE946;"
+                          Title="No Windows features to show"
+                          Message="Nothing matches the current search. Clear it to see every optional feature."
+                          Visibility="{Binding FilteredFeatures.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
             </Grid>
         </Border>
 


### PR DESCRIPTION
`Views/EmptyState.xaml` calls itself *"the single source of truth for the icon + title + message idiom so the look can never drift between views"*, and 30 views use it. Six bypassed it across seven blocks — five of them the same five lines with a different string.

**None of the six declared `xmlns:v`.** The control was not reachable when those views were written, so this was never a choice of taste.

## What changed for the user

Against the shared control, the hand-rolled version rendered differently three ways: no glyph, one flat 12px `Subtle` line where the control gives a 14px SemiBold title over a 12px message, and `MaxWidth` 360 against 420. Speed Test's and Profile's were not even centred — left-aligned with a stray margin, reading as a caption rather than an empty state.

Five of the six are the DataGrid list tabs a non-technical user lands on and finds blank: Services, Startup, Task Manager, Windows Features, DNS & Hosts.

Three of those are empty for a reason worth saying out loud. The collection they bind is the **filtered** one, so a search matching nothing empties it — and "No processes to show" on its own reads as a broken feature. The copy now names the cause and the fix. DNS & Hosts explains what an empty hosts file means rather than only noting there is nothing there.

Glyphs are reused, not invented: `E946` is what six existing empty states use for a generic empty list, `E9D9` is the history glyph in three views, so Speed Test's two history tables take it. Every binding path is kept verbatim, including `ProfileView`'s `HasSections`, which is a bool rather than a count.

## Two corrections to the issues as filed

Both re-derived from source rather than taken on trust.

**#2111 claimed five of these views cannot be empty.** It said Services, Startup, Task Manager, Windows Features and DNS & Hosts are "populated the moment the tab opens, so an empty state would never show", and that their omission was correct. They were not omissions at all — all five had a hand-rolled one — and the premise is wrong: `Services` and `Entries` are the **filtered** collections (`_allServices` / `_allEntries` are the raw backing lists `ApplyFilter` draws from), and `HostEntries` comes from a hosts file that can legitimately hold no redirects.

**#2111 listed `CliInterfaceView` as "needs a look".** It needs none: `Commands` is `CliRunner.Commands`, a static list compiled into the binary, so an empty state there could never render. It gets the comment the issue itself proposed for that group, so the next uniformity sweep does not add one nobody will see.

## Why a second guard rather than tightening the existing one

`EveryViewThatListsACollection_HasSomethingToSayWhenItIsEmpty` asks whether a view says anything at all, and **deliberately accepts three forms that are not the control** — a domain flag and a zero-count `DataTrigger` — because three views got it right that way. Requiring the control there would have failed them, so tightening in place was not available.

`NoViewHandRollsAnEmptyStateTheSharedControlAlreadyProvides` asks the narrower question: when the affordance *is* a plain TextBlock gated on a list's emptiness, that is the control's job. Mutation 6 proves the two are not duplicates — deleting an empty state outright reddens the sibling and leaves this one green.

### Scoping it without an exception list

The rule ties the bound path to a collection the same view binds as an `ItemsSource`. "Any emptiness-Inverse TextBlock" was the first draft, and across all views it also matched three notices that are correctly plain text: "No battery detected" (`Battery.HasBattery`), "No NVIDIA GPU detected" (`HasNvidiaGpu`), and the Tune-up card's good-news line (`TuneUpResult.WarningCount`) — facts inside working cards, not empty lists.

Two of those three are screened out anyway, because Battery Health and Performance bind no `ItemsSource` at all (verified: 0 each). The path tie screens the third. So there is nothing to maintain by hand — a hardware flag is not the `Count` of a list. **Measured: 7 offenders before, 0 after, no notice caught either way.**

## Red/green — 6 mutations, all as claimed

| # | Mutation | Expected | Result |
|---|---|---|---|
| 1 | Revert one view | names the file **and** the collection | RED, both |
| 2 | Revert all six | names all six views and **both** Speed Test tables | RED, 6/6 + both |
| 3 | Loosen to any emptiness-Inverse | falsely names the Tune-up line; the two collection-less views stay screened out | RED, exactly that |
| 4 | Restore the nested-brace regex bug | guard passes **vacuously** on 7 real offenders | GREEN |
| 5 | One view stops binding an ItemsSource | still green — one view cannot breach a floor of 40 against 44 | GREEN |
| 6 | **Delete** an empty state instead of reverting it | sibling guard catches it, this one correctly does not | sibling RED, this GREEN |

Mutation 4 is the one worth reading: `[^}]*` where the binding nests `Converter={StaticResource FlexVis}` stops the match dead before `ConverterParameter`. That exact mistake made my first measurement report **0 offenders where there were 7**, and it is why the regex carries a comment saying so.

## Verification

- Four projects build in Release: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: clean.
- Guard sweep over 100 names: **106 green, 1 red** — the throwaway local runner's own `Program.cs`, which is not in the repo.
- Leak scan over the staged diff against all 43 current patterns: 0 hits, population floor asserted.

Deferred to the secondary workstation: the seven new empty states seen on a real screen, and the two Speed Test history tables where the control now sits as a flow sibling in a `StackPanel` rather than a `Grid` overlay.

Closes #1627
Closes #2111
