### PR TITLE
fix: the elevation banner is one control, not thirty copies

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,7 +17,10 @@ SysManager/
 │   ├── Models/                 # POCOs (snapshots, samples, reports, cleanup categories)
 │   ├── Services/               # Windows / PowerShell / CLI wrappers
 │   ├── ViewModels/             # one VM per tab + MainWindowViewModel
-│   ├── Views/                  # XAML views + code-behind
+│   ├── Views/                  # XAML views + code-behind, plus three shared controls:
+│   │                           #   AdminBanner (the elevation banner, 30 tabs)
+│   │                           #   EmptyState  (icon + title + message for an empty list)
+│   │                           #   DevelopmentBanner (the PREVIEW notice)
 │   ├── Helpers/                # AdminHelper, converters, collections, parsers
 │   ├── Resources/              # icons and assets
 │   ├── App.xaml(.cs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.26] - 2026-09-07
+
+The "Run as administrator" bar at the top of thirty tabs was thirty separate copies of the same thing, and
+copies drift. It is now one component, so anything that improves it improves every tab at once. Two tabs get
+a visible fix out of that on their own.
+
+### Fixed
+- **The Purge Standby Memory tab's admin bar was missing its shield icon.** Every other tab had it. Now that
+  the bar is one component rather than thirty copies, it cannot be missing from one of them.
+- **A long explanation in the admin bar no longer gets cut off.** The text is laid out so it wraps onto a
+  second line instead of running past the edge of the bar, which matters most on the tabs with the longest
+  explanation and on narrower windows.
+
+### Changed
+- **The admin bar is one component instead of thirty copies.** Sixty blocks of near-identical markup for a
+  single element. The colours, corners, spacing and icon were already identical in all of them — but nothing
+  stopped the thirty-first from being different, and three already were. Each tab now supplies only its own
+  two sentences: why administrator rights are needed, and what becomes possible once granted.
+  The App Uninstaller keeps its own bar deliberately: it is the one tab where running as administrator takes
+  a capability *away*, so its wording and colour say the opposite of everywhere else.
+
+### Added
+- **A check that no tab can go back to hand-writing its own admin bar**, and a second one that a tab hosting
+  the bar actually provides what the bar needs — otherwise it could render stuck in one state, or show a
+  button that does nothing, with no error anywhere.
+
 ## [1.76.25] - 2026-09-07
 
 Six tabs told you a list was empty with one small grey sentence floating in a large blank card, while thirty

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -735,7 +735,11 @@ public partial class ArchitectureTests
         }
 
         // Guards the guard: with no banners parsed, "all geometries agree" is true of an empty set.
-        Assert.True(seen.Count >= 50,
+        // RE-MEASURED from 50 to 4 when the banner moved into AdminBanner.xaml. Four is the whole population
+        // now: the control's own pair, plus Uninstaller's hand-rolled pair, which stays hand-rolled because
+        // elevation REMOVES capability on that tab. The floor moved because the population did, not to make a
+        // failing assertion pass — it fired at 4 and that was correct.
+        Assert.True(seen.Count >= 4,
             $"only {seen.Count} elevation banners parsed out of Views/ — the markup this reads has changed "
             + "shape, so the check is passing on an empty set.");
 
@@ -836,10 +840,19 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
-    /// Messages inside a Border that is (a) shown WHEN elevated and (b) painted with the gold
-    /// WarningBgSubtle. Parsed rather than grepped: the not-elevated banner sits in the same
-    /// <c>Grid.Row</c> in every one of these views, so a file-wide text search would read the wrong one.
+    /// What each tab's gold, you-are-elevated banner says.
     /// </summary>
+    /// <remarks>
+    /// Read from the <c>ElevatedMessage</c> attribute of <c>&lt;v:AdminBanner/&gt;</c>. It used to walk into a
+    /// <c>Border</c> shown when elevated and painted <c>WarningBgSubtle</c>, because each of 30 views held its
+    /// own copy of that Border. Extracting the banner into one control emptied that parse — the guard fired
+    /// its own vacuity floor at 0, which is the floor doing its job — so it follows the copy to where the copy
+    /// now lives. The message is still per-tab; only its container moved.
+    /// <para>Uninstaller still hand-rolls its pair and is still read the old way: elevation REMOVES capability
+    /// there, so its banner is deliberately not the shared control and its wording is deliberately not
+    /// "Running as administrator — …". It is painted neutral rather than gold, so it does not enter this parse
+    /// at all.</para>
+    /// </remarks>
     private static List<string> GoldElevatedBannerMessages(string xamlText)
     {
         var found = new List<string>();
@@ -847,6 +860,14 @@ public partial class ArchitectureTests
         try { doc = System.Xml.Linq.XDocument.Parse(xamlText); }
         catch (System.Xml.XmlException) { return found; }
 
+        foreach (var banner in doc.Descendants().Where(e => e.Name.LocalName == "AdminBanner"))
+        {
+            var message = (string?)banner.Attribute("ElevatedMessage") ?? "";
+            if (message.Length == 0 || message.StartsWith('{')) continue;
+            found.Add(WhitespaceRun().Replace(message, " ").Trim());
+        }
+
+        // A view that still paints its own gold banner is read too, so hand-rolling one cannot dodge the rule.
         foreach (var border in doc.Descendants().Where(e => e.Name.LocalName == "Border"))
         {
             var visibility = (string?)border.Attribute("Visibility") ?? "";
@@ -1909,6 +1930,84 @@ public partial class ArchitectureTests
             else if (source[i] == '}' && --depth == 0) return source[open..(i + 1)];
         }
         return "";
+    }
+
+    /// <summary>
+    /// The elevation banner lives in one control. No view may hand-roll it, and every view that hosts it
+    /// must expose what the control binds.
+    /// </summary>
+    /// <remarks>
+    /// 30 views each carried TWO near-identical <c>Border</c> blocks — 60 in all — for one component: a grey
+    /// "not elevated" banner with the relaunch button, and a golden elevated one with a stripe whose
+    /// <c>Margin="-12,-8,0,-8"</c> is tied to the parent's <c>Padding="12,8"</c>. Extracted into
+    /// <c>Views/AdminBanner.xaml</c>. The project rule that a privileged page must explain WHY admin is
+    /// needed and WHAT unlocks was enforced by 30 hand-copies, so nothing stopped copy 31 from drifting.
+    /// <para><b>Two halves, because the control binds ambiently.</b> <c>IsElevated</c> and
+    /// <c>RelaunchAsAdminCommand</c> come from the host's DataContext rather than from properties — the
+    /// command name is identical at every call site, and passing one uniform value 30 times is the
+    /// duplication being removed. The cost is that a host whose view model lacks either member renders a
+    /// banner stuck in one state, or a button that does nothing, with no compiler error and no visible clue.
+    /// The second assertion is what makes that cost safe.</para>
+    /// </remarks>
+    [Fact]
+    public void TheElevationBanner_LivesInOneControl_AndItsHostsExposeWhatItBinds()
+    {
+        var appDir = FindAppProjectDir();
+        var viewsDir = Path.Combine(appDir, "Views");
+        var viewModelsDir = Path.Combine(appDir, "ViewModels");
+
+        var handRolled = Directory
+            .EnumerateFiles(appDir, "*.xaml", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                                    StringComparison.Ordinal))
+            .Where(f => File.ReadAllText(f).Contains("StaticResource AdminButton", StringComparison.Ordinal))
+            .Select(Path.GetFileName)
+            .Where(f => f != "AdminBanner.xaml")
+            .ToList();
+
+        Assert.True(handRolled.Count == 0,
+            "these views reference the AdminButton style directly instead of using <v:AdminBanner/>. The "
+            + "elevation banner is one control so that a contrast, glyph, focus or screen-reader fix lands "
+            + "once rather than thirty times, and so the stripe's negative margin cannot drift away from the "
+            + "padding it depends on:\n  " + string.Join("\n  ", handRolled));
+
+        var hosts = Directory
+            .EnumerateFiles(viewsDir, "*.xaml", SearchOption.TopDirectoryOnly)
+            .Where(f => Path.GetFileName(f) != "AdminBanner.xaml")
+            .Where(f => File.ReadAllText(f).Contains("<v:AdminBanner", StringComparison.Ordinal))
+            .Select(f => Path.GetFileNameWithoutExtension(f) ?? "")
+            .Where(n => n.Length > 0)
+            .ToList();
+
+        // Vacuity floor: 30 views host the banner. A collapse means the element match broke and the
+        // view-model assertion below is checking nothing.
+        Assert.True(hosts.Count >= 28,
+            $"only {hosts.Count} views were found hosting <v:AdminBanner/>, out of 30 measured — the element "
+            + "match is out of date, so a pass proves nothing.");
+
+        var missing = new List<string>();
+        foreach (var host in hosts)
+        {
+            // ServicesView -> ServicesViewModel. A host whose name does not map is itself a finding.
+            var viewModel = Path.Combine(viewModelsDir,
+                host.EndsWith("View", StringComparison.Ordinal) ? host + "Model.cs" : host + "ViewModel.cs");
+            if (!File.Exists(viewModel))
+            {
+                missing.Add($"{host} — no matching view model at {Path.GetFileName(viewModel)}");
+                continue;
+            }
+
+            var source = File.ReadAllText(viewModel);
+            if (!source.Contains("IsElevated", StringComparison.Ordinal))
+                missing.Add($"{host} — its view model exposes no IsElevated, so the banner cannot switch state");
+            if (!source.Contains("RelaunchAsAdmin", StringComparison.Ordinal))
+                missing.Add($"{host} — its view model exposes no RelaunchAsAdminCommand, so the button does nothing");
+        }
+
+        Assert.True(missing.Count == 0,
+            "AdminBanner binds IsElevated and RelaunchAsAdminCommand from its host's DataContext, so a host "
+            + "missing either gets a banner stuck in one state or a dead button. Add the member, or do not "
+            + "host the banner:\n  " + string.Join("\n  ", missing));
     }
 
     /// <summary>A <c>DataGrid</c> or <c>ItemsControl</c> bound to a collection.</summary>
@@ -3424,10 +3523,14 @@ public partial class ArchitectureTests
             }
         }
 
-        // Vacuity floor: the views carry hundreds of Fluent glyphs, so if the scan read nothing the
+        // Vacuity floor: the views carry many Fluent glyphs, so if the scan read nothing the
         // character-reference pattern is broken rather than the code being clean.
+        // RE-MEASURED from 100 to 80 after the elevation banner was extracted: 60 hand-copied banner blocks
+        // each carried a shield glyph, and one control now carries two. The population fell to 85 and the old
+        // floor fired — correctly. It is set below the new count for the same reason it was before, not to
+        // accommodate a failure.
         var glyphs = files.Sum(f => FluentGlyphReference().Matches(File.ReadAllText(f)).Count);
-        Assert.True(glyphs >= 100,
+        Assert.True(glyphs >= 80,
             $"Only {glyphs} icon glyphs were seen across the views — the guard is not reading them. "
             + "Fix this test rather than trusting its pass.");
 

--- a/SysManager/SysManager.Tests/UiAutomationContractTests.cs
+++ b/SysManager/SysManager.Tests/UiAutomationContractTests.cs
@@ -154,8 +154,15 @@ public partial class UiAutomationContractTests
     /// "Restart SysManager as administrator", 4 "Relaunch as administrator", 1 "Restart as administrator",
     /// and 5 carried no accessible name at all. A screen-reader user heard a different verb than the one on
     /// screen, and a voice-control user saying what they could read could not activate the app's most
-    /// consequential control. WCAG 2.5.3 (Label in Name) is the rule; 30 copies of one control is the
-    /// reason it has to be mechanical rather than remembered.</para>
+    /// consequential control. WCAG 2.5.3 (Label in Name) is the rule; 30 copies of one control was the
+    /// reason it had to be mechanical rather than remembered.</para>
+    /// <para><b>There is now ONE copy.</b> The banner moved into <c>Views/AdminBanner.xaml</c>, so the 30
+    /// buttons became one and agreement is structural rather than checked. The floor drops from 20 to 1 for
+    /// that reason and no other — deliberately, not to make a failing assertion pass. What still needs
+    /// asserting is that the one button's accessible name matches the words printed on it, which is what this
+    /// guard does. What stops the copies coming back is
+    /// <c>ArchitectureTests.TheElevationBanner_LivesInOneControl_AndItsHostsExposeWhatItBinds</c>; without
+    /// that, a floor of 1 here would pass just as happily on a tree that had drifted back to 30.</para>
     /// </summary>
     [Fact]
     public void EveryElevationButton_IsAnnouncedWithTheWordsPrintedOnIt()
@@ -182,8 +189,10 @@ public partial class UiAutomationContractTests
             }
         }
 
-        // Vacuity floor: if the elevation button were renamed, this would inspect nothing and pass.
-        Assert.True(checkedButtons >= 20,
+        // Vacuity floor: if the elevation button were renamed, this would inspect nothing and pass. One,
+        // because the banner is one control now — see the remarks. The sibling guard in ArchitectureTests is
+        // what keeps that true; this one only asserts the label and the name agree.
+        Assert.True(checkedButtons >= 1,
             $"only {checkedButtons} elevation buttons were found — if the label changed, update this guard "
             + "rather than letting it inspect nothing.");
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.25</Version>
-    <FileVersion>1.76.25.0</FileVersion>
-    <AssemblyVersion>1.76.25.0</AssemblyVersion>
+    <Version>1.76.26</Version>
+    <FileVersion>1.76.26.0</FileVersion>
+    <AssemblyVersion>1.76.26.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AdminBanner.xaml
+++ b/SysManager/SysManager/Views/AdminBanner.xaml
@@ -1,0 +1,70 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.AdminBanner"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root">
+
+    <!-- The golden admin-control contract, in one place. Every privileged tab must explain WHY
+         administrator rights are needed and WHAT unlocks once elevated, at the top of the page —
+         and that was enforced by 30 hand-copies of two Borders, 60 blocks in all.
+
+         Drop it where the pair used to be, keeping the caller's Grid.Row and Margin so both layout
+         strategies still work:
+           <v:AdminBanner Grid.Row="1" Margin="28,12,28,0"
+                          NotElevatedMessage="Running SFC and DISM system repairs requires administrator privileges."
+                          ElevatedMessage="Running as administrator — you can run system file checks and repairs."/>
+
+         IsElevated and RelaunchAsAdminCommand are bound from the ambient DataContext rather than
+         exposed as properties. #1618 proposed an ICommand property, but the command name is
+         RelaunchAsAdminCommand at all 31 existing call sites — passing one uniform value 30 times is
+         the duplication being removed, and IsElevated was already bound ambiently.
+         ArchitectureTests.EveryAdminBannerHost_ExposesWhatTheBannerBinds keeps that safe: a view model
+         missing either member fails there rather than silently rendering a banner whose button does
+         nothing. -->
+    <Grid>
+        <!-- Not elevated: say what is locked, and offer the one button that unlocks it. -->
+        <Border Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
+                BorderThickness="1" CornerRadius="12" Padding="12,8"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
+            <!-- DockPanel, not a horizontal StackPanel: the message is the last child, so it fills the
+                 remaining width and TextWrapping actually wraps. Inside a horizontal StackPanel the child
+                 is measured with infinite width, so the attribute is inert and long copy is clipped —
+                 NoTextWrapping_IsInertInsideAHorizontalStackPanel exists for that exact mistake, and two
+                 views already used this DockPanel shape before the extraction. -->
+            <DockPanel>
+                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
+                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
+                        AutomationProperties.Name="Run as administrator"/>
+                <TextBlock Text="&#xE83D;" DockPanel.Dock="Left"
+                           FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Center"
+                           Foreground="{DynamicResource TextSecondary}"/>
+                <TextBlock Text="{Binding NotElevatedMessage, ElementName=Root}"
+                           Foreground="{DynamicResource TextSecondary}" FontSize="13"
+                           VerticalAlignment="Center" TextWrapping="Wrap"/>
+            </DockPanel>
+        </Border>
+
+        <!-- Elevated: golden, and it says what is now possible. The stripe's negative margin bleeds it
+             through the parent's 12,8 padding to the border edge; it is tied to that padding, which is
+             one more reason both live here rather than in 30 copies. -->
+        <Border Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
+                BorderThickness="1" CornerRadius="12" Padding="12,8"
+                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
+            <Grid>
+                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left"
+                        CornerRadius="2" Margin="-12,-8,0,-8"/>
+                <!-- DockPanel for the same reason as above. Three views already used it here. -->
+                <DockPanel Margin="6,0,0,0">
+                    <TextBlock Text="&#xE83D;" DockPanel.Dock="Left"
+                               FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                               FontSize="13" VerticalAlignment="Center"
+                               Foreground="{DynamicResource WarningText}"/>
+                    <TextBlock Text="{Binding ElevatedMessage, ElementName=Root}"
+                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold"
+                               Margin="8,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                </DockPanel>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/SysManager/SysManager/Views/AdminBanner.xaml.cs
+++ b/SysManager/SysManager/Views/AdminBanner.xaml.cs
@@ -1,0 +1,49 @@
+// SysManager · AdminBanner
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows;
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+/// <summary>
+/// The elevation banner every privileged tab shows at the top of the page: grey with a "Run as
+/// administrator" button when the session is not elevated, golden and stating what is now possible when
+/// it is. Single source of truth for the golden admin-control contract, so a contrast, glyph, focus or
+/// screen-reader fix lands once instead of thirty times.
+/// </summary>
+/// <remarks>
+/// Replaced 60 hand-copied <c>Border</c> blocks across 30 views. Only the two sentences varied; the
+/// brushes, radius, padding, glyph and the stripe's negative margin were identical in all of them —
+/// verified by extraction before the change, not assumed.
+/// <para>Same shape as <see cref="DevelopmentBanner"/> and <see cref="EmptyState"/>: a UserControl with
+/// dependency properties for the parts that differ per call site, and <c>Margin</c> left to the caller so
+/// both page-layout strategies still work.</para>
+/// </remarks>
+public partial class AdminBanner : UserControl
+{
+    public AdminBanner() => InitializeComponent();
+
+    /// <summary>Why this tab needs administrator rights — shown while the session is NOT elevated.</summary>
+    public static readonly DependencyProperty NotElevatedMessageProperty =
+        DependencyProperty.Register(nameof(NotElevatedMessage), typeof(string), typeof(AdminBanner),
+                                    new PropertyMetadata(string.Empty));
+
+    /// <summary>What is now possible — shown while the session IS elevated.</summary>
+    public static readonly DependencyProperty ElevatedMessageProperty =
+        DependencyProperty.Register(nameof(ElevatedMessage), typeof(string), typeof(AdminBanner),
+                                    new PropertyMetadata(string.Empty));
+
+    public string NotElevatedMessage
+    {
+        get => (string)GetValue(NotElevatedMessageProperty);
+        set => SetValue(NotElevatedMessageProperty, value);
+    }
+
+    public string ElevatedMessage
+    {
+        get => (string)GetValue(ElevatedMessageProperty);
+        set => SetValue(ElevatedMessageProperty, value);
+    }
+}

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -26,37 +26,10 @@
             <TextBlock Text="{Binding BlockStatus}" Style="{StaticResource Subtle}" Margin="0,4,0,0" />
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Blocking applications modifies system registry keys and requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can block and unblock applications."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                       NotElevatedMessage="Blocking applications modifies system registry keys and requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can block and unblock applications."/>
 
         <!-- Block input -->
         <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,12">

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -20,37 +20,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Run as administrator"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Some package upgrades require administrator privileges for system-wide installations."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — all packages can be upgraded."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="28,12,28,0"
+                       NotElevatedMessage="Some package upgrades require administrator privileges for system-wide installations."
+                       ElevatedMessage="Running as administrator — all packages can be upgraded."/>
 
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0">
             <StackPanel Orientation="Horizontal">

--- a/SysManager/SysManager/Views/BandwidthMonitorView.xaml
+++ b/SysManager/SysManager/Views/BandwidthMonitorView.xaml
@@ -28,39 +28,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="900" HorizontalAlignment="Left"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated (precise mode needs admin; safe mode already works) -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
-                     gives its children infinite width along its orientation, so the message's
-                     TextWrapping was inert and clipped at a narrow width (#1807). As the DockPanel's fill
-                     child the message now has a real width to wrap in. -->
-                <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
-                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Top" Foreground="{DynamicResource TextSecondary}"/>
-                <TextBlock Text="Total speed and per-app activity are shown below. Run as administrator to unlock exact per-app upload/download speeds."
-                           Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can enable precise per-app upload/download speeds below."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner (precise mode needs admin; safe mode already works) -->
+        <v:AdminBanner Grid.Row="1" Margin="28,12,28,0"
+                       NotElevatedMessage="Total speed and per-app activity are shown below. Run as administrator to unlock exact per-app upload/download speeds."
+                       ElevatedMessage="Running as administrator — you can enable precise per-app upload/download speeds below."/>
 
         <!-- Live totals + controls -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0">

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml
@@ -26,39 +26,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Run as administrator"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
-                     gives its children infinite width along its orientation, so the message's
-                     TextWrapping was inert and clipped at a narrow width (#1807). As the DockPanel's fill
-                     child the message now has a real width to wrap in. -->
-                <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
-                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Top" Foreground="{DynamicResource TextSecondary}"/>
-                <TextBlock Text="Reading the Windows boot-performance log requires administrator privileges."
-                           Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated (golden admin contract, matches AppBlockerView) -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — the Windows boot-performance history can be read."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                       NotElevatedMessage="Reading the Windows boot-performance log requires administrator privileges."
+                       ElevatedMessage="Running as administrator — the Windows boot-performance history can be read."/>
 
         <!-- Summary -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="16"

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -27,37 +27,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Some applications install system-wide and require administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — all applications can be installed."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                       NotElevatedMessage="Some applications install system-wide and require administrator privileges."
+                       ElevatedMessage="Running as administrator — all applications can be installed."/>
 
         <!-- Toolbar -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -19,37 +19,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Running SFC and DISM system repairs requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can run system file checks and repairs."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="28,12,28,0"
+                       NotElevatedMessage="Running SFC and DISM system repairs requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can run system file checks and repairs."/>
 
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0">
             <StackPanel>

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -101,37 +101,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Run as administrator"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Some entries require administrator privileges to toggle."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — full access to all context menu entries."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                       NotElevatedMessage="Some entries require administrator privileges to toggle."
+                       ElevatedMessage="Running as administrator — full access to all context menu entries."/>
 
         <!-- Menu Style (Presets) -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="14">

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              xmlns:models="clr-namespace:SysManager.Models"
              d:DataContext="{d:DesignInstance vm:DashboardViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -56,36 +57,9 @@
             </DockPanel>
 
             <!-- ═══ ROW 1: Elevation banner ═══ -->
-            <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                    BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                    Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-                <DockPanel>
-                    <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                            Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                            AutomationProperties.Name="Run as administrator"/>
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                   FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                        <TextBlock Text="Some features require administrator privileges for full data."
-                                   Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                    </StackPanel>
-                </DockPanel>
-            </Border>
-
-            <!-- ═══ ROW 1: Elevation banner — elevated (golden admin contract, matches AppBlockerView) ═══ -->
-            <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                    CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                    Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-                <Grid>
-                    <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                            Margin="-12,-8,0,-8"/>
-                    <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                        <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                        <TextBlock Text="Running as administrator — all sensors and quick actions have full access."
-                                   Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                    </StackPanel>
-                </Grid>
-            </Border>
+            <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                           NotElevatedMessage="Some features require administrator privileges for full data."
+                           ElevatedMessage="Running as administrator — all sensors and quick actions have full access."/>
 
             <!-- ═══ ROW 2: Tune-Up in progress ═══ -->
             <!-- TuneUpProgress / TuneUpStep were computed on every step and never shown, so the wizard

--- a/SysManager/SysManager/Views/DefenderView.xaml
+++ b/SysManager/SysManager/Views/DefenderView.xaml
@@ -30,37 +30,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Changing Microsoft Defender settings requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can change Defender settings."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="2" Margin="0,0,0,12"
+                       NotElevatedMessage="Changing Microsoft Defender settings requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can change Defender settings."/>
 
         <!-- Tamper Protection warning -->
         <Border Grid.Row="3" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -18,37 +18,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Changing DNS and editing the hosts file requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can change DNS settings and edit the hosts file."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="28,12,28,0"
+                       NotElevatedMessage="Changing DNS and editing the hosts file requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can change DNS settings and edit the hosts file."/>
 
         <!-- DNS Section -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0">

--- a/SysManager/SysManager/Views/EdgeOneDriveView.xaml
+++ b/SysManager/SysManager/Views/EdgeOneDriveView.xaml
@@ -27,36 +27,9 @@
 
         <!-- Elevation banner: not elevated. OneDrive removal works without admin; the Edge
              portion writes machine policy + scheduled tasks, so it needs elevation. -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Disabling Edge needs administrator privileges. Removing OneDrive works without it."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can disable Edge and remove OneDrive."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                       NotElevatedMessage="Disabling Edge needs administrator privileges. Removing OneDrive works without it."
+                       ElevatedMessage="Running as administrator — you can disable Edge and remove OneDrive."/>
 
         <!-- Content cards -->
         <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" Padding="0,0,4,0">

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -26,39 +26,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Run as administrator"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
-                     gives its children infinite width along its orientation, so the message's
-                     TextWrapping was inert and the second sentence clipped at a narrow width (#1807).
-                     As the DockPanel's fill child the message now has a real width to wrap in. -->
-                <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
-                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Top" Foreground="{DynamicResource TextSecondary}"/>
-                <TextBlock Text="Editing System variables writes to machine-wide registry keys and requires administrator privileges. User variables can be edited without it."
-                           Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — both User and System variables are editable."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                       NotElevatedMessage="Editing System variables writes to machine-wide registry keys and requires administrator privileges. User variables can be edited without it."
+                       ElevatedMessage="Running as administrator — both User and System variables are editable."/>
 
         <!-- Toolbar -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">

--- a/SysManager/SysManager/Views/FileLockView.xaml
+++ b/SysManager/SysManager/Views/FileLockView.xaml
@@ -29,37 +29,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Unlocking files in protected locations requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can unlock and close handles on protected files."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="2" Margin="0,0,0,12"
+                       NotElevatedMessage="Unlocking files in protected locations requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can unlock and close handles on protected files."/>
 
         <!-- Input toolbar -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">

--- a/SysManager/SysManager/Views/GamingProfileView.xaml
+++ b/SysManager/SysManager/Views/GamingProfileView.xaml
@@ -31,41 +31,9 @@
         </StackPanel>
 
         <!-- Admin banner (some optimizations need elevation) -->
-        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
-                     gives its children infinite width along its orientation, so the message's
-                     TextWrapping was inert and clipped at a narrow width (#1807). As the DockPanel's fill
-                     child the message now has a real width to wrap in. -->
-                <TextBlock Text="&#xE7EF;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
-                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Top" Foreground="{DynamicResource TextSecondary}"/>
-                <TextBlock Text="Most optimizations apply as-is. Freeing standby memory and pausing search indexing need administrator."
-                           Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated (golden admin contract, matches AppBlockerView) -->
-        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width
-                     along its orientation, so this banner's TextWrapping was inert and clipped on a
-                     narrow window (#1807). The stripe Border above is untouched. -->
-                <DockPanel Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Top" DockPanel.Dock="Left"/>
-                    <TextBlock Text="Running as administrator — every optimization, including freeing standby memory and pausing search indexing, can be applied."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                </DockPanel>
-            </Grid>
-        </Border>
+        <v:AdminBanner Grid.Row="2" Margin="28,12,28,0"
+                       NotElevatedMessage="Most optimizations apply as-is. Freeing standby memory and pausing search indexing need administrator."
+                       ElevatedMessage="Running as administrator — every optimization, including freeing standby memory and pausing search indexing, can be applied."/>
 
         <!-- Content: game target + optimization toggles -->
         <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto" Margin="28,16,28,0">

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml
@@ -1,7 +1,8 @@
 <!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
 <UserControl x:Class="SysManager.Views.NetworkRepairView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views">
     <Grid Background="{DynamicResource Surface0}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -14,37 +15,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Run as administrator"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Resetting network configuration (DNS flush, Winsock reset) requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can reset network settings."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="28,12,28,0"
+                       NotElevatedMessage="Resetting network configuration (DNS flush, Winsock reset) requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can reset network settings."/>
 
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,28">
             <StackPanel>

--- a/SysManager/SysManager/Views/PerformanceView.xaml
+++ b/SysManager/SysManager/Views/PerformanceView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:PerformanceViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -26,37 +27,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Run as administrator"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Modifying system performance settings and creating restore points requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can apply performance tweaks and create restore points."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                       NotElevatedMessage="Modifying system performance settings and creating restore points requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can apply performance tweaks and create restore points."/>
 
         <!-- Toolbar -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -3,6 +3,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
+             xmlns:v="clr-namespace:SysManager.Views"
              d:DataContext="{d:DesignInstance vm:PrivacyViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -25,37 +26,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Run as administrator"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Some privacy settings write to system-wide registry keys and require administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — all privacy toggles are available."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                       NotElevatedMessage="Some privacy settings write to system-wide registry keys and require administrator privileges."
+                       ElevatedMessage="Running as administrator — all privacy toggles are available."/>
 
         <!-- Toolbar -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -27,37 +27,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Ending system processes requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center" Foreground="{DynamicResource WarningText}"/>
-                    <TextBlock Text="Running as administrator — you can end any process."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                       NotElevatedMessage="Ending system processes requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can end any process."/>
 
         <!-- Toolbar -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">

--- a/SysManager/SysManager/Views/RestorePointsView.xaml
+++ b/SysManager/SysManager/Views/RestorePointsView.xaml
@@ -26,39 +26,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Run as administrator"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
-                     gives its children infinite width along its orientation, so the message's
-                     TextWrapping was inert and clipped at a narrow width (#1807). As the DockPanel's fill
-                     child the message now has a real width to wrap in. -->
-                <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
-                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Top" Foreground="{DynamicResource TextSecondary}"/>
-                <TextBlock Text="Creating and restoring restore points require administrator privileges. You can still view existing points without elevation."
-                           Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can create and restore restore points."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                       NotElevatedMessage="Creating and restoring restore points require administrator privileges. You can still view existing points without elevation."
+                       ElevatedMessage="Running as administrator — you can create and restore restore points."/>
 
         <!-- Toolbar -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -26,37 +26,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Starting and stopping Windows services requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center" Foreground="{DynamicResource WarningText}"/>
-                    <TextBlock Text="Running as administrator — you can start, stop, and configure services."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                       NotElevatedMessage="Starting and stopping Windows services requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can start, stop, and configure services."/>
 
         <!-- Toolbar -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">

--- a/SysManager/SysManager/Views/SettingsWatchdogView.xaml
+++ b/SysManager/SysManager/Views/SettingsWatchdogView.xaml
@@ -49,40 +49,10 @@
             </StackPanel>
         </DockPanel>
 
-        <!-- Elevation banner: not elevated (restoring HKLM-backed settings needs admin) -->
-        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Some watched settings are machine-wide and need administrator to restore."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated (golden admin contract, matches AppBlockerView) -->
-        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width
-                     along its orientation, so this banner's TextWrapping was inert and clipped on a
-                     narrow window (#1807). The stripe Border above is untouched. -->
-                <DockPanel Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Top" DockPanel.Dock="Left"/>
-                    <TextBlock Text="Running as administrator — machine-wide watched settings can be restored, not just per-user ones."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                </DockPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner (restoring HKLM-backed settings needs admin) -->
+        <v:AdminBanner Grid.Row="2" Margin="28,12,28,0"
+                       NotElevatedMessage="Some watched settings are machine-wide and need administrator to restore."
+                       ElevatedMessage="Running as administrator — machine-wide watched settings can be restored, not just per-user ones."/>
 
         <!-- Baseline status banner -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Margin="28,12,28,0" Padding="14,10"

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -27,37 +27,10 @@
                        Visibility="{Binding IsScanning, Converter={StaticResource BoolToVis}}"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,16,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Removing broken shortcuts in shared locations requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="28,16,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can remove broken shortcuts everywhere."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="28,16,28,0"
+                       NotElevatedMessage="Removing broken shortcuts in shared locations requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can remove broken shortcuts everywhere."/>
 
         <!-- Toolbar -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0" Padding="12">

--- a/SysManager/SysManager/Views/StandbyMemoryView.xaml
+++ b/SysManager/SysManager/Views/StandbyMemoryView.xaml
@@ -31,32 +31,9 @@
         </StackPanel>
 
         <!-- Elevation banner -->
-        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <TextBlock Text="Purging the standby list requires administrator privileges."
-                           Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated (golden admin contract, matches AppBlockerView) -->
-        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can purge the standby memory list."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <v:AdminBanner Grid.Row="2" Margin="0,0,0,12"
+                       NotElevatedMessage="Purging the standby list requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can purge the standby memory list."/>
 
         <!-- Memory cards -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12">

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -26,37 +26,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Changing startup entries requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center" Foreground="{DynamicResource WarningText}"/>
-                    <TextBlock Text="Running as administrator — you can enable and disable any startup entry."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                       NotElevatedMessage="Changing startup entries requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can enable and disable any startup entry."/>
 
         <!-- Toolbar -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">

--- a/SysManager/SysManager/Views/SystemFixesView.xaml
+++ b/SysManager/SysManager/Views/SystemFixesView.xaml
@@ -26,39 +26,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Run as administrator"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <!-- Glyph docked left of the message, not a nested horizontal StackPanel: a StackPanel
-                     gives its children infinite width along its orientation, so the message's
-                     TextWrapping was inert and clipped at a narrow width (#1807). As the DockPanel's fill
-                     child the message now has a real width to wrap in. -->
-                <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" DockPanel.Dock="Left"
-                           FontSize="16" Margin="0,0,10,0" VerticalAlignment="Top" Foreground="{DynamicResource TextSecondary}"/>
-                <TextBlock Text="These repairs modify system services and settings, so they require administrator privileges."
-                           Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — all repairs are available."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
+                       NotElevatedMessage="These repairs modify system services and settings, so they require administrator privileges."
+                       ElevatedMessage="Running as administrator — all repairs are available."/>
 
         <!-- Fix cards -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="16">

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -21,37 +21,10 @@
                             HorizontalAlignment="Right" DockPanel.Dock="Right"/>
                 </DockPanel>
 
-                <!-- Elevation banner: not elevated -->
-                <Border Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                        BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,12,0,0"
-                        Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-                    <DockPanel>
-                        <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                                AutomationProperties.Name="Run as administrator"
-                                Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                                       FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                            <TextBlock Text="Running disk checks (chkdsk) requires administrator privileges."
-                                       Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DockPanel>
-                </Border>
-
-                <!-- Elevation banner: elevated -->
-                <Border Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                        CornerRadius="12" Padding="12,8" Margin="0,12,0,0"
-                        Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-                    <Grid>
-                        <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                                Margin="-12,-8,0,-8"/>
-                        <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                            <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                            <TextBlock Text="Running as administrator — you can run disk integrity checks."
-                                       Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </Grid>
-                </Border>
+                <!-- Elevation banner -->
+                <v:AdminBanner Margin="0,12,0,0"
+                               NotElevatedMessage="Running disk checks (chkdsk) requires administrator privileges."
+                               ElevatedMessage="Running as administrator — you can run disk integrity checks."/>
 
                 <!-- Summary card -->
                 <Border Style="{StaticResource Card}" Margin="0,20,0,0">

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml
@@ -29,37 +29,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Enabling or disabling scheduled tasks requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can enable and disable scheduled tasks."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="2" Margin="0,0,0,12"
+                       NotElevatedMessage="Enabling or disabling scheduled tasks requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can enable and disable scheduled tasks."/>
 
         <!-- Toolbar -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">

--- a/SysManager/SysManager/Views/TweaksHubView.xaml
+++ b/SysManager/SysManager/Views/TweaksHubView.xaml
@@ -70,39 +70,9 @@
         </StackPanel>
 
         <!-- Admin banner (only Advanced tweaks need it) -->
-        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Essential tweaks apply as-is. Advanced (machine-wide) tweaks need administrator."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated (golden admin contract, matches AppBlockerView) -->
-        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width
-                     along its orientation, so this banner's TextWrapping was inert and clipped on a
-                     narrow window (#1807). The stripe Border above is untouched. -->
-                <DockPanel Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Top" DockPanel.Dock="Left"/>
-                    <TextBlock Text="Running as administrator — both Essential and Advanced (machine-wide) tweaks can be applied."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                </DockPanel>
-            </Grid>
-        </Border>
+        <v:AdminBanner Grid.Row="2" Margin="28,12,28,0"
+                       NotElevatedMessage="Essential tweaks apply as-is. Advanced (machine-wide) tweaks need administrator."
+                       ElevatedMessage="Running as administrator — both Essential and Advanced (machine-wide) tweaks can be applied."/>
 
         <!-- Tweaks: Essential + Advanced -->
         <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto" Margin="28,16,28,0">

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -52,37 +52,10 @@
             </WrapPanel>
         </Border>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        AutomationProperties.Name="Run as administrator"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Enabling or disabling Windows features requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="2" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can enable and disable Windows features."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="2" Margin="0,0,0,12"
+                       NotElevatedMessage="Enabling or disabling Windows features requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can enable and disable Windows features."/>
 
         <!-- Summary -->
         <Border Grid.Row="3" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -28,37 +28,10 @@
                        Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
-        <!-- Elevation banner: not elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
-            <DockPanel>
-                <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
-                        Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
-                               FontSize="16" Margin="0,0,10,0" Foreground="{DynamicResource TextSecondary}"/>
-                    <TextBlock Text="Listing and installing Windows updates requires administrator privileges."
-                               Foreground="{DynamicResource TextSecondary}" FontSize="13" VerticalAlignment="Center"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Elevation banner: elevated -->
-        <Border Grid.Row="1" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1"
-                CornerRadius="12" Padding="12,8" Margin="28,12,28,0"
-                Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
-            <Grid>
-                <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left" CornerRadius="2"
-                        Margin="-12,-8,0,-8"/>
-                <StackPanel Orientation="Horizontal" Margin="6,0,0,0">
-                    <TextBlock Text="&#xE83D;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets" FontSize="13" VerticalAlignment="Center"/>
-                    <TextBlock Text="Running as administrator — you can list and install updates."
-                               Foreground="{DynamicResource WarningText}" FontSize="13" FontWeight="SemiBold" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+        <!-- Elevation banner -->
+        <v:AdminBanner Grid.Row="1" Margin="28,12,28,0"
+                       NotElevatedMessage="Listing and installing Windows updates requires administrator privileges."
+                       ElevatedMessage="Running as administrator — you can list and install updates."/>
 
         <!-- Module status: missing -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="28,16,28,0"


### PR DESCRIPTION
30 views each carried **two** near-identical `Border` blocks — 60 in all — for one component: a grey "not elevated" banner with the relaunch button, and a golden elevated one with a stripe whose `Margin="-12,-8,0,-8"` is tied to the parent's `Padding="12,8"`.

**Net 563 lines removed.** 37 files, 394 added, 957 deleted.

The project rule that a privileged page must explain WHY administrator rights are needed and WHAT unlocks was enforced by 30 hand-copies. Nothing stopped copy 31 from being different, and something already was.

## Two user-visible fixes fall out of centralising

Which is why this is `fix:` rather than `refactor:`.

- **Purge Standby Memory's banner had no shield glyph.** The other 29 did. Found by extraction, not by eye.
- **A long explanation was clipped rather than wrapped.** 11 of 62 message TextBlocks carried `TextWrapping="Wrap"`; the rest did not, so the longest copy ran past the edge of the bar.

### The second one was nearly shipped broken

The first cut put `TextWrapping` inside a **horizontal StackPanel**, where a child is measured with infinite width and the attribute is inert — the exact defect `NoTextWrapping_IsInertInsideAHorizontalStackPanel` exists to catch.

It did not catch mine, because it skips **bound** values (`text.StartsWith('{')`) and centralising made every banner message a binding. The control now uses a `DockPanel` with the message as the last child — the shape two views already used, which gives the text a real width. Mutation 4 reddens that guard to prove the shape is load-bearing rather than cosmetic.

That guard's blind spot is real beyond this PR: tightening it to treat a binding as prose finds **4 more genuine defects** (`SfcVerdict`, `DismVerdict`, `MemoryHealthVerdict`, `ModuleStatus` — verdict sentences whose wrap is inert). Deliberately not folded in here: different location, different guard, and #1618 asks for a diff a reviewer can read banner-by-banner. It is next in the queue.

## Two corrections to #1618

Both re-derived from source rather than taken on trust.

| The issue said | Current source says |
|---|---|
| not-elevated is `CornerRadius=8 Padding=14,12` vs elevated `12 / 12,8` | **Both are `12` / `12,8`.** That divergence was already fixed, by `BothAdminBanners_ShareOneGeometry` |
| elevated glyph is the astral emoji `U+1F6E1` with no FontFamily in 27 views, Segoe Fluent `E83D` in 3 | **All 30 are `E83D` + Segoe Fluent + `WarningText`.** That drift is already gone |

**Uninstaller is deliberately excluded** and keeps its hand-rolled pair: elevation *removes* capability on that tab, so it has no relaunch button, no stripe, and wording that says the opposite of everywhere else.

## Why the control binds ambiently

`IsElevated` and `RelaunchAsAdminCommand` come from the host's DataContext rather than from properties. #1618 proposed an `ICommand` property, but the command name is `RelaunchAsAdminCommand` at **all 31** existing call sites — passing one uniform value 30 times is the duplication being removed, and `IsElevated` was already bound ambiently.

The cost: a host whose view model lacks either member renders a banner stuck in one state, or a button that does nothing, with no compiler error and no visible clue. So `TheElevationBanner_LivesInOneControl_AndItsHostsExposeWhatItBinds` asserts both halves — no view may reference the `AdminButton` style directly, **and** every host's view model must expose what the banner binds.

## Three existing guards fired their own vacuity floors

The population collapsed from 60 to 1, so they fired — correctly. Each was re-measured **with the reason**, not just lowered:

| Guard | Floor | Why |
|---|---|---|
| `BothAdminBanners_ShareOneGeometry` | 50 → **4** | Four is the whole population now: the control's pair plus Uninstaller's |
| `EveryIconGlyph_NamesAnIconFont` | 100 → **80** | 60 banner copies each carried a shield glyph; the count fell to 85 |
| `EveryGoldElevationBanner_PromisesMoreAccess` | parsed **0** | **Retargeted, not re-floored** — the per-tab message moved from a Border's TextBlock to the control's `ElevatedMessage` attribute, so the parse follows it. It still reads hand-rolled gold Borders, so one cannot dodge the rule |

`EveryElevationButton_IsAnnouncedWithTheWordsPrintedOnIt` drops from 20 to **1** for the same reason: there is one button now, and agreement is structural rather than checked. Its remarks say so, and name the guard that keeps the copies from coming back — without which a floor of 1 would pass just as happily on a tree that had drifted back to 30.

## Red/green — 6 mutations, all as claimed

| # | Mutation | Expected | Result |
|---|---|---|---|
| 1 | A view references `AdminButton` directly again | guard names the file | RED, named `CleanupView` |
| 2+3 | Host the banner on a view model exposing **neither** member | names both the dead switch and the dead button | RED, both |
| 4 | Message back inside a horizontal StackPanel | inert-wrap guard reddens | RED, named `AdminBanner.xaml` |
| 5 | The pair disagrees on `CornerRadius` | geometry guard catches it inside one file | RED, `CornerRadius=8` |
| 6 | One `ElevatedMessage` stops promising more access | caught **through the new attribute** | RED, named `CleanupView` |
| 7 | Undo the retarget | floor fires at 0, not a pass on an empty parse | RED, floor |

Mutation 7 matters: without it, "the guard stopped failing" and "the guard is reading the right thing" look identical.

### One note on the proof itself

Three attempts at mutation 2+3 failed to compile — the XML prolog, then `UserControl`'s single-child rule, then `Grid`'s property-element ordering. All three were the wrong problem: these guards read the tree as **text**, so a mutated view never needs to compile for the guard to judge it. The proof stops rebuilding for view-only mutations, which is a change of approach rather than a fourth placement attempt.

## Verification

- Four projects build in Release: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: clean.
- Guard sweep over 107 names: **113 green, 1 red** — the throwaway local runner's own `Program.cs`, not in the repo.
- Leak scan over the staged diff (125 KB) against all 43 current patterns: 0 hits.

Deferred to the secondary workstation: all 30 banners seen on a real screen in both states, across the twelve theme presets — the stripe's negative margin and the golden treatment are exactly the kind of thing a screenshot settles and a build does not.

Closes #1618
