### PR TITLE
fix: four result messages were clipped instead of wrapped, and the guard for it was blind to them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.27] - 2026-09-07
+
+Four result messages were being cut off at the edge of their box instead of continuing onto a second line.
+They are the messages that explain what a repair or a check actually found, so the part that got cut was
+usually the part worth reading.
+
+### Fixed
+- **The SFC and DISM result lines on the Cleanup tab now wrap.** Both report a full sentence, and a long one
+  ran off the edge of its box. Same for **the memory health verdict** on the System Health tab and **the
+  module status** on the Windows Update tab.
+
+### Added
+- **The check that catches this now looks at messages filled in while the app runs.** It only examined text
+  written directly into the layout, and every one of these four is filled in at runtime — so the check was
+  looking straight past all of them. It now treats a message whose length it cannot know as if it were long,
+  which is the safe assumption and the reason all four were found at once.
+
 ## [1.76.26] - 2026-09-07
 
 The "Run as administrator" bar at the top of thirty tabs was thirty separate copies of the same thing, and

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -794,10 +794,19 @@ public partial class ArchitectureTests
                 if (!InsideHorizontalStackPanel(tb)) continue;
 
                 var text = WhitespaceRun().Replace((string?)tb.Attribute("Text") ?? "", " ").Trim();
-                // Bound values and short glyphs cannot meaningfully clip; only real prose does.
-                if (text.Length < 40 || text.StartsWith('{')) continue;
 
-                offenders.Add($"{Path.GetFileName(file)}: \"{(text.Length > 60 ? text[..60] + "…" : text)}\"");
+                // A short LITERAL cannot meaningfully clip, so it stays out of scope. A BINDING does not:
+                // its length is unknown at build time, and treating unknown as short is how four real
+                // instances survived — SfcVerdict and DismVerdict on Cleanup, MemoryHealthVerdict on System
+                // Health, ModuleStatus on Windows Update, every one of them a full sentence produced at
+                // runtime. The exclusion was written when banner messages were literals; centralising the
+                // elevation banner turned them into bindings and left the rule looking at nothing.
+                var bound = text.StartsWith('{');
+                if (!bound && text.Length < 40) continue;
+                if (text.Length == 0) continue;
+
+                offenders.Add($"{Path.GetFileName(file)}: \"{(text.Length > 60 ? text[..60] + "…" : text)}\""
+                    + (bound ? " (bound — length unknown at build time, so assumed to be prose)" : ""));
             }
         }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.26</Version>
-    <FileVersion>1.76.26.0</FileVersion>
-    <AssemblyVersion>1.76.26.0</AssemblyVersion>
+    <Version>1.76.27</Version>
+    <FileVersion>1.76.27.0</FileVersion>
+    <AssemblyVersion>1.76.27.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -95,12 +95,16 @@
                 <Border Margin="0,8,0,0" Padding="12,10" CornerRadius="8"
                         Background="{DynamicResource Surface1}"
                         Visibility="{Binding SfcVerdict, Converter={StaticResource FlexVis}}">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="SFC result:" FontWeight="SemiBold" Foreground="{DynamicResource TextSecondary}"
+                    <!-- DockPanel, not a horizontal StackPanel: the verdict is a full sentence, and inside a
+                         horizontal StackPanel its TextWrapping is inert — the child is measured with infinite
+                         width, so long verdicts were clipped rather than wrapped. -->
+                    <DockPanel>
+                        <TextBlock Text="SFC result:" DockPanel.Dock="Left" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextSecondary}"
                                    VerticalAlignment="Center" Margin="0,0,8,0"/>
                         <TextBlock Text="{Binding SfcVerdict}" TextWrapping="Wrap" VerticalAlignment="Center"
                                    Foreground="{Binding SfcVerdictColorHex, Converter={StaticResource HexBrush}}"/>
-                    </StackPanel>
+                    </DockPanel>
                 </Border>
                 <StackPanel Orientation="Horizontal" Margin="0,6,0,0"
                             Visibility="{Binding IsDismRunning, Converter={StaticResource FlexVis}}">
@@ -114,12 +118,14 @@
                 <Border Margin="0,8,0,0" Padding="12,10" CornerRadius="8"
                         Background="{DynamicResource Surface1}"
                         Visibility="{Binding DismVerdict, Converter={StaticResource FlexVis}}">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="DISM result:" FontWeight="SemiBold" Foreground="{DynamicResource TextSecondary}"
+                    <!-- DockPanel for the same reason as the SFC verdict above. -->
+                    <DockPanel>
+                        <TextBlock Text="DISM result:" DockPanel.Dock="Left" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextSecondary}"
                                    VerticalAlignment="Center" Margin="0,0,8,0"/>
                         <TextBlock Text="{Binding DismVerdict}" TextWrapping="Wrap" VerticalAlignment="Center"
                                    Foreground="{Binding DismVerdictColorHex, Converter={StaticResource HexBrush}}"/>
-                    </StackPanel>
+                    </DockPanel>
                 </Border>
             </StackPanel>
         </Border>

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -87,13 +87,20 @@
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0">
                             <TextBlock Text="Memory health" Style="{StaticResource SectionTitle}"/>
-                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                                <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,10,0"
+                            <!-- DockPanel, not a horizontal StackPanel: the verdict is a full sentence, and
+                                 inside a horizontal StackPanel its TextWrapping is inert — the child is
+                                 measured with infinite width, so a long verdict was clipped. MaxWidth stays
+                                 as a readability cap on line length, which is what it is good for; it was
+                                 never a substitute for a real width to wrap against. -->
+                            <DockPanel Margin="0,8,0,0">
+                                <Ellipse Width="10" Height="10" DockPanel.Dock="Left" VerticalAlignment="Center"
+                                         Margin="0,0,10,0"
                                          Fill="{Binding MemoryHealthColorHex, Converter={StaticResource HexBrush}}"/>
                                 <TextBlock Text="{Binding MemoryHealthVerdict}"
                                            Foreground="{Binding MemoryHealthColorHex, Converter={StaticResource HexBrush}}"
-                                           FontWeight="SemiBold" TextWrapping="Wrap" MaxWidth="620" VerticalAlignment="Center"/>
-                            </StackPanel>
+                                           FontWeight="SemiBold" TextWrapping="Wrap" MaxWidth="620"
+                                           HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                            </DockPanel>
                             <TextBlock Text="Scans the last 30 days of the System event log for hardware errors (WHEA) and Windows Memory Diagnostic results."
                                        Style="{StaticResource Subtle}" Margin="0,6,0,0" TextWrapping="Wrap"/>
                         </StackPanel>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -77,10 +77,16 @@
                         ToolTip="Confirm now whether the PSWindowsUpdate module is available"
                         Style="{StaticResource GhostButton}" Padding="12,4" Margin="16,0,0,0"
                         VerticalAlignment="Center"/>
-                <StackPanel Orientation="Horizontal">
-                    <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,10,0" Fill="{DynamicResource Info}"/>
-                    <TextBlock Text="{Binding ModuleStatus}" FontWeight="SemiBold" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                </StackPanel>
+                <!-- DockPanel, not a horizontal StackPanel: ModuleStatus is a sentence, and inside a
+                     horizontal StackPanel its TextWrapping is inert — the child is measured with infinite
+                     width, so a long status was clipped rather than wrapped. -->
+                <DockPanel>
+                    <Ellipse Width="10" Height="10" DockPanel.Dock="Left" VerticalAlignment="Center"
+                             Margin="0,0,10,0" Fill="{DynamicResource Info}"/>
+                    <TextBlock Text="{Binding ModuleStatus}" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"
+                               TextWrapping="Wrap"/>
+                </DockPanel>
             </DockPanel>
         </Border>
 


### PR DESCRIPTION
Found while extracting the elevation banner (#1618, PR #2134). That change put `TextWrapping="Wrap"` on a message inside a **horizontal StackPanel**, where a child is measured with infinite width — so the attribute is inert and long text is clipped rather than wrapped.

`NoTextWrapping_IsInertInsideAHorizontalStackPanel` exists for exactly that defect. It did not catch it.

## Why the guard was blind

One line:

```csharp
if (text.Length < 40 || text.StartsWith('{')) continue;
```

Bound values were excluded outright. That was defensible when the banner messages were literals — a binding's length is unknown at build time, and the rule needs a length. **Centralising the banner turned every banner message into a binding**, and the exclusion turned the rule into one that looks past the case it was written for.

Treating a binding as prose rather than as short finds **four real instances**, every one a full sentence produced at runtime and clipped at the edge of its box:

| View | Binding | What it says |
|---|---|---|
| `CleanupView` | `SfcVerdict` | "SFC result:" + the verdict |
| `CleanupView` | `DismVerdict` | "DISM result:" + the verdict |
| `SystemHealthView` | `MemoryHealthVerdict` | the memory health verdict |
| `WindowsUpdateView` | `ModuleStatus` | whether the PSWindowsUpdate module is available |

These are the messages that explain what a repair or a check actually **found**, so the part that got cut was usually the part worth reading.

## The fix

Each enclosing horizontal StackPanel becomes a `DockPanel` with the label or status dot docked left and the message last, so the message fills the remaining width and wraps. That is the shape the guard's own failure message prescribes.

`SystemHealthView` keeps its `MaxWidth="620"` — as a readability cap on line length, which is what it is good for. It was never a substitute for a real width to wrap against, and with the StackPanel it was the only constraint present.

## Red/green — 5 mutations, all as claimed

| # | Mutation | Expected | Result |
|---|---|---|---|
| 1 | Revert Cleanup's two | names both bindings **and** quotes the reason a bound value counts | RED, both |
| 2 | Revert all four | names all four, across three files | RED, 4/4 |
| 3 | Restore the old exclusion | **GREEN on four real defects** — the hole, demonstrated | GREEN |
| 4 | Same tree + a **literal** long sentence | old rule still catches the literal | RED, named it |
| 5 | Break the TextBlock parse | vacuity floor fires, not a pass on nothing | RED, floor |

Mutation 4 is the one that keeps this honest: it separates "the old rule was blind to bindings" from "the old rule was broken". It was only ever blind.

## Verification

- Four projects build in Release: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: clean.
- Guard sweep over 100 names: **106 green, 1 red** — the throwaway local runner's own `Program.cs`, not in the repo.
- Leak scan over the staged diff against all 43 current patterns: 0 hits.

Deferred to the secondary workstation: the four messages seen wrapping on a real screen, ideally at a narrow window width where the clipping was worst.

## Ordering note

Both this and #2134 claim version 1.76.26. Whichever merges second gets rebased and renumbered — they are independent changes and neither blocks the other.
