### PR TITLE
fix: three corner radii were off the scale, and nothing would have caught a fourth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.76.28] - 2026-09-07
+
+Three rounded corners were slightly the wrong roundness, which is the kind of thing nobody notices one at a
+time and everybody notices in aggregate: a panel that looks almost, but not quite, like the panel above it.
+
+### Fixed
+- **The update notice and the "all clear" card now have the same corners as every other panel.** Both were
+  2px squarer than their neighbours. Same for the small verdict badge on the Landing tab after a Tune-Up.
+
+### Changed
+- **Four circles and pills now say they are circles and pills.** Their roundness was written as a number that
+  happened to be half the element's size — correct today, quietly wrong the moment the element is resized.
+  No visible change: the app rounds them to exactly the same pixels.
+
+### Added
+- **A check that a corner radius has to be one of the app's own five sizes.** These sizes exist because the
+  corners drifted once before; the check covers the places that were left out of that fix, so they cannot
+  drift again.
+
 ## [1.76.27] - 2026-09-07
 
 Four result messages were being cut off at the edge of their box instead of continuing onto a second line.

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2141,6 +2141,72 @@ public partial class ArchitectureTests
         return end.Success ? rest[..end.Index] : rest;
     }
 
+    /// <summary>
+    /// Every corner radius is either a token or one of the scale's own numbers. Nothing in between.
+    /// </summary>
+    /// <remarks>
+    /// The radius tokens exist because the radii had already drifted once — the commit that added them says
+    /// the scale killed "per-style radius drift (was 5/6/8/10/999 scattered)". App.xaml adopted them; the
+    /// views and the shell did not, so the drift could come back there unnoticed, and it had:
+    /// <list type="bullet">
+    ///   <item><c>10</c> three times — the update banner and the success card in the shell, where every
+    ///   neighbouring surface is 12, and the Tune-Up verdict badge on the Landing tab;</item>
+    ///   <item><c>9</c>, <c>11</c>, <c>14</c> and <c>45</c> — each of them half of its element's own size,
+    ///   which is a pill or a circle written as a number. They now say <c>RadiusPill</c>, which WPF clamps to
+    ///   exactly the same pixels, so the intent is stated and the arithmetic cannot go stale if the element is
+    ///   resized.</item>
+    /// </list>
+    /// <para>This guard deliberately does NOT require a token. Asking for one across 175 call sites is a
+    /// separate, purely mechanical migration; asking for an on-scale VALUE is the part that prevents a
+    /// regression, and it is checkable without touching a single view. <c>2</c> is on the list because it is
+    /// the accent stripe on the elevation and preview banners — a deliberate hairline, not a surface radius.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void EveryCornerRadius_IsOnTheScale()
+    {
+        // The scale from App.xaml (RadiusSm/Md/Lg/Xl/Pill) plus the stripe hairline.
+        var allowed = new HashSet<string>(StringComparer.Ordinal) { "2", "4", "8", "12", "16", "999" };
+
+        var appDir = FindAppProjectDir();
+        var offenders = new List<string>();
+        var literals = 0;
+
+        foreach (var file in Directory
+                     .EnumerateFiles(appDir, "*.xaml", SearchOption.AllDirectories)
+                     .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                                             StringComparison.Ordinal)))
+        {
+            var text = File.ReadAllText(file);
+            foreach (var hit in NumericCornerRadius().Matches(text).Cast<Match>())
+            {
+                literals++;
+                var value = hit.Groups["value"].Value;
+                if (allowed.Contains(value)) continue;
+                offenders.Add($"{Path.GetFileName(file)}: CornerRadius=\"{value}\"");
+            }
+        }
+
+        // Vacuity floor. RE-MEASURED at 90 on the same day it was written: 177 was the count before the
+        // elevation banner was extracted into one control, and that removed 60 banner Borders plus 27 of the
+        // stripe hairlines. The floor fired on the rebase, which is the floor working — a population is a
+        // measurement, and another change moved it. Current spread: 8 x39, 2 x20, 12 x19, 4 x9, 999 x2, 16 x1.
+        Assert.True(literals >= 80,
+            $"only {literals} numeric CornerRadius values were read, out of 90 measured — the pattern is out "
+            + "of date, so a pass proves nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "these corner radii are not on the scale. The tokens exist because the radii drifted once already "
+            + "(5/6/8/10/999 scattered), and a number that is half of its element's own size is a pill or a "
+            + "circle — say so with {StaticResource RadiusPill}, which clamps to the same pixels and cannot go "
+            + "stale if the element is resized. Otherwise pick the nearest scale step (4, 8, 12, 16):\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>A <c>CornerRadius</c> written as a plain number rather than a token.</summary>
+    [GeneratedRegex(@"CornerRadius=""(?<value>\d+)""", RegexOptions.Compiled)]
+    private static partial Regex NumericCornerRadius();
+
     /// <summary>A <c>DataGrid</c> or <c>ItemsControl</c> bound to a collection.</summary>
     [GeneratedRegex(@"<(?:DataGrid|ItemsControl)\b[^>]*ItemsSource=""\{Binding", RegexOptions.Compiled)]
     private static partial Regex CollectionItemsSource();

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -564,13 +564,13 @@
                                      Surface4 stays a neutral grey in both modes, keeping OFF clearly distinct. -->
                                 <!-- BorderThickness reserved at 1.5 (transparent) so the IsKeyboardFocused
                                      trigger can light the Accent ring without shifting the thumb/track layout. -->
-                                <Border x:Name="Track" CornerRadius="11" Background="{DynamicResource Surface4}"
+                                <Border x:Name="Track" CornerRadius="{StaticResource RadiusPill}" Background="{DynamicResource Surface4}"
                                         BorderThickness="1.5" BorderBrush="Transparent"/>
                                 <!-- OFF thumb: derived from the track it sits on, not White. Surface4 is
                                      near-white on the light presets, where a white thumb measured 1.33-1.67:1
                                      and the switch had no readable state. The ON thumb is set in the IsChecked
                                      trigger instead, because the track becomes Accent there. -->
-                                <Border x:Name="Thumb" Width="18" Height="18" CornerRadius="9"
+                                <Border x:Name="Thumb" Width="18" Height="18" CornerRadius="{StaticResource RadiusPill}"
                                         Background="{DynamicResource ToggleThumb}" HorizontalAlignment="Left" Margin="2,2,0,2"
                                         VerticalAlignment="Center">
                                     <Border.Effect>

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -461,7 +461,7 @@
                 </Grid.RowDefinitions>
 
                 <!-- Update banner — only when a newer release is available. -->
-                <Border Grid.Row="0" Margin="24,16,24,0" Padding="14,10" CornerRadius="10"
+                <Border Grid.Row="0" Margin="24,16,24,0" Padding="14,10" CornerRadius="{StaticResource RadiusLg}"
                         Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Accent}" BorderThickness="1"
                         Visibility="{Binding About.UpdateAvailable, Converter={StaticResource FlexVis}}">
                     <Grid>
@@ -504,7 +504,7 @@
                  7.66:1 on midnight-indigo where it was chosen. ThemeService already seeds Success per mode
                  (#22C55E dark, #166534 light) for exactly this reason; its own comment beside those values
                  calls the failure "one crisp card beside two washed-out ones". -->
-            <Border Background="{DynamicResource Surface2}" CornerRadius="10"
+            <Border Background="{DynamicResource Surface2}" CornerRadius="{StaticResource RadiusLg}"
                     BorderBrush="{DynamicResource SuccessBorder}" BorderThickness="1"
                     Padding="14,12,18,12">
                 <Border.Effect>
@@ -516,7 +516,7 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <Border Grid.Column="0" Width="28" Height="28" CornerRadius="14"
+                    <Border Grid.Column="0" Width="28" Height="28" CornerRadius="{StaticResource RadiusPill}"
                             Background="{DynamicResource SuccessBgSubtle}" Margin="0,0,10,0">
                         <TextBlock Text="&#xE73E;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                    FontSize="14" Foreground="{DynamicResource Success}"

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.27</Version>
-    <FileVersion>1.76.27.0</FileVersion>
-    <AssemblyVersion>1.76.27.0</AssemblyVersion>
+    <Version>1.76.28</Version>
+    <FileVersion>1.76.28.0</FileVersion>
+    <AssemblyVersion>1.76.28.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -100,7 +100,7 @@
                                        VerticalAlignment="Center" Margin="0,0,8,0"
                                        Foreground="{Binding TuneUpResult.OverallColorHex, Converter={StaticResource HexBrush}}"/>
                             <TextBlock Text="Tune-Up complete" FontWeight="SemiBold" FontSize="15" VerticalAlignment="Center"/>
-                            <Border Background="{DynamicResource Surface2}" CornerRadius="10" Padding="8,2" Margin="10,0,0,0"
+                            <Border Background="{DynamicResource Surface2}" CornerRadius="{StaticResource RadiusMd}" Padding="8,2" Margin="10,0,0,0"
                                     VerticalAlignment="Center">
                                 <TextBlock Text="{Binding TuneUpResult.OverallVerdict}" FontSize="11" FontWeight="SemiBold"
                                            Foreground="{Binding TuneUpResult.OverallColorHex, Converter={StaticResource HexBrush}}"/>
@@ -198,7 +198,7 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
-                    <Border Grid.Column="0" Width="90" Height="90" CornerRadius="45"
+                    <Border Grid.Column="0" Width="90" Height="90" CornerRadius="{StaticResource RadiusPill}"
                             BorderThickness="5" Margin="0,0,20,0"
                             HorizontalAlignment="Center" VerticalAlignment="Center"
                             BorderBrush="{Binding HealthResult.ColorHex, Converter={StaticResource HexBrush}}">


### PR DESCRIPTION
The radius tokens (`RadiusSm/Md/Lg/Xl/Pill`) exist because the radii drifted once already — the commit that added them says the scale killed *"per-style radius drift (was 5/6/8/10/999 scattered)"*. App.xaml adopted them. **The views and the shell did not**, so the drift could return there unnoticed. It had.

## The seven off-scale values

All found by counting, not by eye.

| Value | Where | What it is |
|---|---|---|
| `10` | MainWindow's update banner | drift — every neighbouring surface is 12 |
| `10` | MainWindow's success card | drift — same |
| `10` | Tune-Up verdict badge, Landing tab | drift |
| `9` | toggle thumb | half of its own 18px height |
| `11` | toggle track | half of its own 22px height |
| `14` | shell icon disc | half of its own 28px |
| `45` | health-score disc | half of its own 90px |

**The three 10s are corrected** to the nearest scale step: `RadiusLg` for the two surfaces whose neighbours are 12, `RadiusMd` for the badge — 12 would clamp to nearly a pill on a 19px-tall element. Those are 2px visible changes, and the reason this is `fix:` rather than `refactor:`.

**The other four are a pill or a circle written as a number.** They now say `RadiusPill`, which WPF clamps to exactly the same pixels — no visual change, the intent is stated, and the arithmetic cannot go stale if the element is ever resized.

## The guard asks for a value, not a token

`EveryCornerRadius_IsOnTheScale` requires an **on-scale value**. Requiring a *token* across 175 call sites is a separate, purely mechanical migration; requiring the value is what prevents the regression, and it is checkable without touching a single view.

`2` is on the allowed list because it is the accent stripe on the elevation and preview banners — a deliberate hairline, not a surface radius.

## Three corrections to #1633

Each re-derived from source.

| The issue says | Current source says |
|---|---|
| `CornerRadius="8"` ×61, `"12"` ×46 | **39 and 77** |
| Three values are off-scale: `2`, `45`, `999` | It missed **`10` ×3, `9`, `11`, `14`** — the four that are actually drift, and the three that are actually *wrong* |
| Add a `RadiusStripe` token, because "49 uses is not noise" | Invalidated by #1618: the stripe now lives in `AdminBanner`, `DevelopmentBanner` and Uninstaller — about **three** uses. Not worth a token; the allowed-value list carries it |

## Deliberately not here

The bulk migration of the 175 on-scale literals to tokens. It is visually inert, touches 63 files, and the issue itself rates it **value 2/5**. It belongs in its own `refactor:` PR after #2134 lands, so the two do not collide across 30 shared view files. That is why this closes nothing and only refs #1633.

## Red/green — 6 mutations, all as claimed

| # | Mutation | Expected | Result |
|---|---|---|---|
| 1 | Restore one `10` | names the file and the value | RED, both |
| 2 | Restore all three `10`s | names all three, across two files | RED, 3/3 |
| 3 | Restore the `45` | named too — geometry is not special-cased | RED |
| 4 | Add a plausible-but-off-scale `6` | named — the rule is the **scale**, not a list of past mistakes | RED |
| 5 | Add an on-scale `16` | **stays green** — not an allowlist of what the tree happens to contain | GREEN |
| 6 | Break the pattern | vacuity floor fires, not every value passing | RED, floor |

Mutations 4 and 5 are the pair that matters: together they show the guard encodes the scale rather than the current contents of the tree.

## Verification

- Four projects build in Release: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: clean.
- Guard sweep over 107 names: **113 green, 1 red** — the throwaway local runner's own `Program.cs`, not in the repo.
- Leak scan over the staged diff against all 43 current patterns: 0 hits.

Deferred to the secondary workstation: the three 2px changes seen side by side with their neighbours, and the four pill/circle conversions confirmed pixel-identical.

## Ordering note

This, #2134 and #2135 all claim 1.76.26, because CI checks the version against a bump from the newest tag (`v1.76.25`) and there is only one next number. Whichever merges second and third get rebased and renumbered; they are independent and none blocks the others.

Refs #1633
