### PR TITLE
test: pin the hand-written keyboard support on the two Border-buttons

### DIFF
--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2010,6 +2010,128 @@ public partial class ArchitectureTests
             + "host the banner:\n  " + string.Join("\n  ", missing));
     }
 
+    /// <summary>
+    /// Anything clickable by mouse that is not a <c>Button</c> must also be operable by keyboard — focusable,
+    /// a tab stop, and activated by BOTH Enter and Space.
+    /// </summary>
+    /// <remarks>
+    /// A <c>Border</c> with a <c>MouseLeftButtonUp</c> handler is a button to a mouse and furniture to a
+    /// keyboard: it gets no focus, no tab stop and no Enter/Space for free. Two such controls exist and both
+    /// were given all of it by hand — the theme chip in the shell, and each preset card in the Appearance
+    /// popup. That hand-written support is the fragile kind: three attributes and an event handler that a
+    /// template edit removes without a compiler noticing, and nothing pinned it.
+    /// <para><b>Enter AND Space, checked in the handler body.</b> "Has a KeyDown handler" is not the contract —
+    /// a handler testing only <c>Key.Enter</c> would satisfy it while leaving Space dead, and Space is what
+    /// most keyboard users press on something that looks like a button. Both handlers are read for both keys.
+    /// </para>
+    /// <para><b>Why the four colour swatches are exempt rather than fixed.</b> Their handler is
+    /// <c>FocusHex</c>: it focuses and selects the hex box immediately beside them, and that box is already
+    /// the next tab stop with its own accessible name. A tab stop on the swatch would focus the control you
+    /// are about to Tab to anyway — a keystroke that does nothing — so adding one would make the keyboard path
+    /// worse, not better. Listed with the reason so the exemption is a decision rather than an oversight, the
+    /// same shape the empty-state guard uses.</para>
+    /// <para>This is the source-readable half of #1552. The other half — driving real Tab presses through
+    /// FlaUI — cannot be authored here: it needs the application running to validate, and an unvalidated test
+    /// in the non-blocking UI job reports "pass" whether or not it asserts anything. This half runs in the
+    /// BLOCKING suite and catches the deletion the issue is actually worried about.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryMouseClickableElement_IsAlsoKeyboardOperable()
+    {
+        // handler name -> why keyboard support would add nothing.
+        var mouseOnlyByDesign = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["CustomAccent_Click"] = "focuses the adjacent Accent hex box, already the next tab stop",
+            ["CustomBg_Click"] = "focuses the adjacent Background hex box, already the next tab stop",
+            ["CustomSurface_Click"] = "focuses the adjacent Surface hex box, already the next tab stop",
+            ["CustomText_Click"] = "focuses the adjacent Text hex box, already the next tab stop",
+        };
+
+        var appDir = FindAppProjectDir();
+        var xamlNs = XNamespace.Get("http://schemas.microsoft.com/winfx/2006/xaml");
+        var offenders = new List<string>();
+        var clickables = 0;
+
+        foreach (var file in Directory
+                     .EnumerateFiles(appDir, "*.xaml", SearchOption.AllDirectories)
+                     .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                                             StringComparison.Ordinal)))
+        {
+            XDocument document;
+            try { document = XDocument.Load(file); }
+            catch (System.Xml.XmlException) { continue; }
+
+            foreach (var element in document.Descendants())
+            {
+                var handler = (string?)element.Attribute("MouseLeftButtonUp")
+                              ?? (string?)element.Attribute("MouseLeftButtonDown");
+                if (handler is null) continue;
+                clickables++;
+                if (mouseOnlyByDesign.ContainsKey(handler)) continue;
+
+                var name = (string?)element.Attribute(xamlNs + "Name") ?? handler;
+                var where = $"{Path.GetFileName(file)}: <{element.Name.LocalName} {name}>";
+
+                if ((string?)element.Attribute("Focusable") != "True")
+                    offenders.Add($"{where} is clickable by mouse but not Focusable");
+                if ((string?)element.Attribute("KeyboardNavigation.IsTabStop") != "True")
+                    offenders.Add($"{where} is clickable by mouse but not a tab stop");
+                if (element.Attribute("KeyDown") is null)
+                    offenders.Add($"{where} is clickable by mouse but has no KeyDown handler");
+            }
+        }
+
+        // Vacuity floor: five mouse-clickable elements in XAML, plus one attached in code-behind. A collapse
+        // means the attribute match broke and every absence below is an absence of scanning.
+        Assert.True(clickables >= 5,
+            $"only {clickables} mouse-clickable elements were found, out of 5 in XAML — the attribute match is "
+            + "out of date, so a pass proves nothing.");
+
+        // The handlers themselves: both keys, not just Enter.
+        foreach (var (source, handler) in new[]
+                 {
+                     (Path.Combine(appDir, "MainWindow.xaml.cs"), "ThemeBtn_KeyDown"),
+                     (Path.Combine(appDir, "Views", "ThemePopup.xaml.cs"), "Preset_KeyDown"),
+                 })
+        {
+            Assert.True(File.Exists(source),
+                $"{Path.GetFileName(source)} is gone — this guard cannot read {handler}, so it would pass "
+                + "without checking it.");
+
+            var body = KeyHandlerBody(File.ReadAllText(source), handler);
+            Assert.True(body.Length > 0,
+                $"{handler} was not found in {Path.GetFileName(source)}. It is the only thing that makes that "
+                + "Border activatable from the keyboard; if it was renamed, update this guard rather than "
+                + "letting it check nothing.");
+
+            foreach (var key in new[] { "Key.Enter", "Key.Space" })
+            {
+                Assert.True(body.Contains(key, StringComparison.Ordinal),
+                    $"{handler} does not handle {key}. A keyboard user pressing it on something that looks "
+                    + "like a button gets nothing, and \"has a KeyDown handler\" would still be satisfied — "
+                    + "which is why both keys are checked in the body rather than on the attribute.");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "these elements are buttons to a mouse and furniture to a keyboard. A Border gets no focus, no "
+            + "tab stop and no Enter/Space for free, so each has to be given all three — or listed in this "
+            + "test with a reason why keyboard support would add nothing:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The body of a key handler, sliced from its declaration to the next member. Empty when not found, so
+    /// the caller can tell "renamed" apart from "present but wrong".
+    /// </summary>
+    private static string KeyHandlerBody(string source, string methodName)
+    {
+        var declaration = Regex.Match(source, $@"\b{Regex.Escape(methodName)}\s*\([^)]*\)\s*\r?\n?\s*\{{");
+        if (!declaration.Success) return "";
+        var rest = source[declaration.Index..];
+        var end = NextMemberDeclaration().Match(rest, 1);
+        return end.Success ? rest[..end.Index] : rest;
+    }
+
     /// <summary>A <c>DataGrid</c> or <c>ItemsControl</c> bound to a collection.</summary>
     [GeneratedRegex(@"<(?:DataGrid|ItemsControl)\b[^>]*ItemsSource=""\{Binding", RegexOptions.Compiled)]
     private static partial Regex CollectionItemsSource();

--- a/SysManager/SysManager/Views/ThemePopup.xaml
+++ b/SysManager/SysManager/Views/ThemePopup.xaml
@@ -75,6 +75,14 @@
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Text="Accent" Foreground="{DynamicResource TextSecondary}"
                                            FontSize="12" VerticalAlignment="Center"/>
+                                <!-- The four colour swatches are deliberately NOT tab stops. Their only
+                                     action is to focus and select the hex box immediately beside them, and
+                                     that box is already the next tab stop with its own accessible name — so a
+                                     tab stop here would focus the thing you are about to Tab to anyway, which
+                                     is a keystroke that does nothing. A Border is non-focusable by default,
+                                     so this is the default being correct rather than a setting.
+                                     EveryMouseClickableElement_IsAlsoKeyboardOperable lists them with this
+                                     reason, so the exemption is visible rather than assumed. -->
                                 <Border Grid.Column="1" x:Name="CustomAccentPreview"
                                         Width="24" Height="24" CornerRadius="8" Background="#6366F1"
                                         Margin="0,0,10,0" Cursor="Hand"


### PR DESCRIPTION
#1552 asks for FlaUI keyboard tests. **That half cannot be authored here**, and the issue says why itself:

> authoring them from source alone is blind and each one must be validated by an actual run

This workstation does not run the application. An unvalidated test in the non-blocking UI job reports "pass" whether or not it asserts anything — that is the worse outcome, not the safer one. So the FlaUI half stays open and is recorded as deferred to the workstation that can run the app.

## The half that is readable from source

Two controls are buttons to a mouse and furniture to a keyboard — the theme chip in the shell and each preset card in the Appearance popup, both `Border`s with a `MouseLeftButtonUp` handler.

A Border gets **no focus, no tab stop and no Enter/Space for free**, so all of it was added by hand: three attributes and an event handler that a template edit removes without a compiler noticing. Nothing pinned any of it. That is precisely the fragility the issue names.

`EveryMouseClickableElement_IsAlsoKeyboardOperable` asserts, for every element with a mouse-click handler:

- `Focusable="True"`
- `KeyboardNavigation.IsTabStop="True"`
- a `KeyDown` attribute
- and then reads the handler **body** for both `Key.Enter` and `Key.Space`

**The body check is the part that matters.** A handler testing only Enter satisfies "has a KeyDown handler" while leaving Space dead — and Space is what most keyboard users press on something that looks like a button. Mutations 4 and 5 narrow each handler to Enter, and both are caught.

## One correction to #1552

The issue implies the gap is untested code that works. Measuring found **six** mouse-clickable elements, and the four custom-colour swatches in the Appearance popup have no keyboard support at all.

They are **exempt rather than fixed**, and the reason is worth stating: their handler is `FocusHex`, which focuses and selects the hex box immediately beside them — and that box is already the next tab stop, with its own accessible name. A tab stop on the swatch would focus the control you are about to Tab to anyway. That is a keystroke that does nothing, so adding it would make the keyboard path *worse*.

The exemption is listed in the test with that reason, and stated in the markup, so the next uniformity sweep does not "fix" it into existence.

## Red/green — 8 mutations, all as claimed

| # | Mutation | Expected | Result |
|---|---|---|---|
| 1 | Chip loses `Focusable` | named individually | RED |
| 2 | Chip loses its tab stop | named individually | RED |
| 3 | Chip loses its `KeyDown` attribute | named individually | RED |
| 4 | `ThemeBtn_KeyDown` narrowed to Enter | caught **in the body** — an attribute check cannot | RED |
| 5 | `Preset_KeyDown` narrowed to Enter | caught too, so both handlers are genuinely read | RED |
| 6 | Handler renamed | guard says it is *missing*, not "checked and fine" | RED |
| 7 | An exempt swatch given real keyboard support and dropped from the list | **GREEN on its merits** | GREEN |
| 8 | Break the attribute match | population floor fires | RED, floor |

Mutation 7 is the one that keeps the exemption list honest: it is a reason, not a permanent hole.

## Verification

- Four projects build in Release: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: clean.
- Guard sweep over 108 names: **114 green, 1 red** — the throwaway local runner's own `Program.cs`, not in the repo.
- Leak scan over the staged diff against all 43 current patterns: 0 hits.

`test:` — no version bump, no CHANGELOG, no release. The only app-file change is a comment.

Refs #1552
