### PR TITLE
test: the one tab with no smoke coverage was the one flagged in development

### DIFF
--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2206,6 +2206,57 @@ public partial class ArchitectureTests
     /// <summary>A <c>CornerRadius</c> written as a plain number rather than a token.</summary>
     [GeneratedRegex(@"CornerRadius=""(?<value>\d+)""", RegexOptions.Compiled)]
     private static partial Regex NumericCornerRadius();
+    /// <summary>Every tab in the sidebar has a row in the navigation smoke table.</summary>
+    /// <remarks>
+    /// The smoke test drives each tab by its nav id and asserts its header renders — the cheapest possible
+    /// proof that a tab is not simply broken. It listed 57 of the 58 tabs. The missing one was Tweaks Hub,
+    /// which is flagged <c>inDevelopment</c>, so the single tab with no coverage at all was the one most
+    /// likely to regress.
+    /// <para>Nothing detected that. The table is a hand-maintained list of literals in a different project
+    /// from the sidebar it mirrors, so tab 59 would ship uncovered the same way. This compares the two
+    /// directly: both are source text, so it runs in the BLOCKING suite even though the test it guards runs in
+    /// the non-blocking UI job — a gap in coverage should not be reported by the job that has the gap.</para>
+    /// <para>One-directional on purpose. A nav id must have a row; a row for an id that no longer exists is a
+    /// different defect, and <c>EveryUiTextAssertion_QuotesCopyTheAppActuallyShips</c> already fails on a
+    /// header the app does not render.</para>
+    /// </remarks>
+    [Fact]
+    public void EverySidebarTab_HasASmokeRow()
+    {
+        var shell = Path.Combine(FindAppProjectDir(), "ViewModels", "MainWindowViewModel.cs");
+        var smoke = Path.Combine(FindRepoRoot(), "SysManager", "SysManager.UITests", "AllTabsSmokeUiTests.cs");
+
+        Assert.True(File.Exists(shell), $"{shell} not found — this guard would compare nothing.");
+        Assert.True(File.Exists(smoke), $"{smoke} not found — this guard would compare nothing.");
+
+        var declared = NavIdLiteral().Matches(File.ReadAllText(shell))
+            .Select(m => m.Groups["id"].Value)
+            .ToHashSet(StringComparer.Ordinal);
+        var covered = NavIdLiteral().Matches(File.ReadAllText(smoke))
+            .Select(m => m.Groups["id"].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // Vacuity floor: 58 tabs. If the literal pattern stops matching in either file, the set difference is
+        // empty and the guard passes on nothing.
+        Assert.True(declared.Count >= 50,
+            $"only {declared.Count} nav ids were read from MainWindowViewModel, out of 58 — the literal "
+            + "pattern is out of date, so a pass proves nothing.");
+        Assert.True(covered.Count >= 50,
+            $"only {covered.Count} nav ids were read from the smoke table, out of 58 — same problem.");
+
+        var uncovered = declared.Except(covered, StringComparer.Ordinal)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(uncovered.Count == 0,
+            "these tabs are reachable in the sidebar but have no row in the navigation smoke table, so nothing "
+            + "checks that they open and render their header at all. Add a row with the tab's nav id and a "
+            + "substring of its page header:\n  " + string.Join("\n  ", uncovered));
+    }
+
+    /// <summary>A <c>"nav-…"</c> identifier literal.</summary>
+    [GeneratedRegex(@"""(?<id>nav-[a-z0-9-]+)""", RegexOptions.Compiled)]
+    private static partial Regex NavIdLiteral();
 
     /// <summary>A <c>DataGrid</c> or <c>ItemsControl</c> bound to a collection.</summary>
     [GeneratedRegex(@"<(?:DataGrid|ItemsControl)\b[^>]*ItemsSource=""\{Binding", RegexOptions.Compiled)]

--- a/SysManager/SysManager.UITests/AllTabsSmokeUiTests.cs
+++ b/SysManager/SysManager.UITests/AllTabsSmokeUiTests.cs
@@ -38,6 +38,10 @@ public class AllTabsSmokeUiTests
         new object[] { "nav-restore-points", "Restore Points" },
         new object[] { "nav-task-scheduler", "Task Scheduler" },
         new object[] { "nav-boot-analyzer", "Boot Analyzer" },
+        // Tweaks Hub was the one nav id in the sidebar with no row here — 57 of 58 tabs covered, and the
+        // missing one is flagged inDevelopment, so it is the tab most likely to regress. Nothing detected the
+        // gap either; ArchitectureTests.EverySidebarTab_HasASmokeRow does now.
+        new object[] { "nav-tweaks-hub", "Tweaks Hub" },
         new object[] { "nav-system-fixes", "System Fixes" },
         // ── Gaming & Profiles ──
         new object[] { "nav-gaming-profile", "Gaming Profile" },


### PR DESCRIPTION
The navigation smoke test drives each tab by its nav id and asserts its header renders — the cheapest possible proof that a tab is not simply broken.

**It listed 57 of the 58 tabs.** The missing one was Tweaks Hub, which is flagged `inDevelopment` — so the single tab with no coverage at all was the one most likely to regress.

## Nothing detected that, and nothing would detect it for tab 59

The table is a hand-maintained list of literals, in a **different project** from the sidebar it mirrors. Drift there is invisible by construction.

`EverySidebarTab_HasASmokeRow` compares the two directly, and lives in the **blocking** unit suite even though the test it guards runs in the non-blocking UI job — a gap in coverage should not be reported by the job that has the gap. Both files are source text, so comparing them needs no desktop session.

**One-directional on purpose.** A nav id must have a row; a row for an id that no longer exists is a different defect, and `EveryUiTextAssertion_QuotesCopyTheAppActuallyShips` already fails on a header the app does not render. Mutation 6 pins that direction rather than leaving it implied.

## Two corrections to #1544

Both re-derived from source.

| The issue says | Current source says |
|---|---|
| `AutomationId` is at "only 7 sites, all in `MainWindow.xaml`", and calls that the root enabler of the dead-test finding | **37 sites across 12 files.** That layer already exists |
| Add `AutomationProperties.LabeledBy` (0 uses today) | Not taken. The app puts the visible label **in** the accessible name, which is what WCAG 2.5.3 asks for and what `EveryLabelledControl_IsAnnouncedWithTheWordsPrintedOnIt` now enforces. `LabeledBy` would be a second, parallel mechanism for the same thing |

The `HelpText` half of #1544 is real and is **next, as its own `fix:`** — it changes what a screen reader announces on the five immediately-destructive controls, so it needs a CHANGELOG entry rather than riding in a `test:` PR.

## Red/green — 6 mutations, all as claimed

| # | Mutation | Expected | Result |
|---|---|---|---|
| 1 | Remove the Tweaks Hub row | names that exact id — the real gap, reproduced | RED |
| 2 | Remove three rows | all three named, not just the first | RED, 3/3 |
| 3 | Add a 59th tab with no row | named — this is how the gap arose | RED |
| 4 | Break the **shell** read | declared-count floor fires | RED, floor |
| 5 | Break the **table** read | covered-count floor fires | RED, floor |
| 6 | Row for a tab that does not exist | **stays green** — one-directional by design | GREEN |

Two floors rather than one, because either file going unreadable makes the set difference empty and the guard would pass on nothing.

### A note on the proof

Mutation 6 first reported a false RED. Mutations 4 and 5 edit the guard's **own source**, and restoring the file is not enough — the compiled assembly still holds the broken version until it is rebuilt, and mutation 6 was running without one. Same shape as a stale-binary red: the fix is in the harness, not the guard.

## Verification

- Four projects build in Release: 0 errors, 0 warnings.
- `dotnet format --verify-no-changes`: clean.
- Guard sweep: **108 green, 1 red** — the throwaway local runner's own `Program.cs`, not in the repo.
- Leak scan over the staged diff against all 43 current patterns: 0 hits.

`test:` — no version bump, no CHANGELOG, no release.

Refs #1544
