### PR TITLE
feat: the buttons you cannot undo now say so to a screen reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.77.0] - 2026-09-07
+
+Six buttons that do something you cannot take back now explain themselves out loud. Until now a screen reader
+announced only the label — "Shred All button" — and the warning about what that meant arrived afterwards, in a
+dialog you had already committed to opening. Nothing changes on screen for anyone else.
+
+### Added
+- **The app's irreversible buttons now say what they will do.** Shred All, Uninstall selected, Kill process,
+  Delete preset and Delete selected shortcuts each carry a plain sentence that a screen reader reads out when
+  you land on the button: what happens, and whether you can get it back. The red colour and the confirmation
+  dialog were the only warnings before, and neither reaches someone who cannot see the screen.
+- **"Run as administrator" now mentions that the window closes and reopens.** That is the part which is
+  startling if you cannot watch it happen. It is one shared control, so the explanation appears on all 31
+  pages that ask for administrator rights.
+- **A check that each of those buttons keeps its explanation, and that the explanation is a real sentence.**
+  An empty or one-word text would satisfy "the attribute is there" while telling nobody anything, so the check
+  counts words rather than presence.
+
+### Changed
+- **Shred All now sets its accessible name explicitly, like its siblings.** It was relying on its label being
+  read instead, which works but was the one button of its kind not saying so for itself.
+
 ## [1.76.28] - 2026-09-07
 
 Three rounded corners were slightly the wrong roundness, which is the kind of thing nobody notices one at a

--- a/README.md
+++ b/README.md
@@ -186,6 +186,19 @@ one colour disappears against at least one of those. With two, one line always c
 underneath. Measured across all 12 themes, the outline stays at 4.5:1 or better against every surface
 it is drawn on — above the 3:1 WCAG asks of a non-text indicator.
 
+### Screen readers
+The six controls that do something you cannot take back explain themselves, not just their label. Landing on
+Shred All announces the button and then "Overwrites every item in the list so it cannot be recovered, then
+deletes it. This cannot be undone, not even from the Recycle Bin." The same goes for Uninstall selected, Kill
+process, Delete preset, Delete selected shortcuts, and the Run as administrator button that appears on the 31
+pages needing elevation.
+
+Before that, the red colour and the confirmation dialog were the only warnings, and neither reaches someone
+who cannot see the screen — the dialog arrives after the button has already been pressed. The explanation is
+not a tooltip for the same reason: a tooltip needs a mouse hovering over the control, so it never reaches
+someone who tabbed to it, and it is not reliably handed to assistive software. It is kept to those six
+deliberately. An explanation on every button in the app would make it slower to navigate, not clearer.
+
 ### Context Menu Manager
 Manage Windows Explorer right-click entries — toggle them on or off without
 deleting anything (uses the standard `LegacyDisable` registry mechanism):

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.76.x   | :white_check_mark: |
-| < 1.76   | :x:                |
+| 1.77.x   | :white_check_mark: |
+| < 1.77   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1600,18 +1600,7 @@ public partial class ArchitectureTests
     [Fact]
     public void EveryImmediatelyDestructiveButton_WearsADestructiveStyle()
     {
-        // command → (view, acceptable styles). Two styles are acceptable because one destructive control per
-        // screen and one per DataGrid row are different problems: ~470 filled red buttons in a process list
-        // read as "this screen is dangerous" rather than "this button is".
-        (string Command, string View, string[] Styles)[] destructive =
-        [
-            ("DeletePresetCommand", "AudioMixerView.xaml", ["DangerButton"]),
-            ("KillProcessCommand", "ProcessManagerView.xaml", ["DangerButton", "DangerGhostButton"]),
-            ("DeleteSelectedCommand", "ShortcutCleanerView.xaml", ["DangerButton"]),
-            ("ShredAllCommand", "FileShredderView.xaml", ["DangerButton"]),
-            ("UninstallSelectedCommand", "UninstallerView.xaml", ["DangerButton"]),
-        ];
-
+        var destructive = DestructiveControls;
         var appDir = FindAppProjectDir();
         var viewsDir = Path.Combine(appDir, "Views");
         var offenders = new List<string>();
@@ -1633,7 +1622,7 @@ public partial class ArchitectureTests
             var path = Path.Combine(viewsDir, view);
             Assert.True(File.Exists(path), $"{path} not found — this guard would pass vacuously");
 
-            var xaml = Collapse(File.ReadAllText(path));
+            var xaml = XamlCode(path);
             var at = xaml.IndexOf(command, StringComparison.Ordinal);
             if (at < 0)
             {
@@ -1643,17 +1632,12 @@ public partial class ArchitectureTests
 
             checkedButtons++;
 
-            // The button's own element: back to the nearest "<Button" and forward to its close. A window
-            // around the command reference would reach into the neighbouring control's style.
-            var open = xaml.LastIndexOf("<Button", at, StringComparison.Ordinal);
-            var close = xaml.IndexOf('>', at);
-            if (open < 0 || close < 0)
+            if (ReadButtonElement(xaml, view, command, out var element) is { } problem)
             {
-                offenders.Add($"{view} — could not read the element around {command}");
+                offenders.Add(problem);
                 continue;
             }
 
-            var element = xaml[open..close];
             if (!styles.Any(style => element.Contains($"StaticResource {style}", StringComparison.Ordinal)))
                 offenders.Add($"{view} — {command} is on a button styled as neither "
                               + string.Join(" nor ", styles));
@@ -1667,6 +1651,171 @@ public partial class ArchitectureTests
             + "action, so the only warning the user gets arrives after the click:\n  "
             + string.Join("\n  ", offenders));
     }
+
+    /// <summary>
+    /// The commands that perform an immediate, unrecoverable change: the command, the view it lives in, and
+    /// the styles its button is allowed to wear.
+    /// </summary>
+    /// <remarks>
+    /// Two styles are acceptable for one row because a destructive control per screen and one per DataGrid
+    /// row are different problems: ~470 filled red buttons in a process list read as "this screen is
+    /// dangerous" rather than "this button is".
+    /// <para>Shared by <see cref="EveryImmediatelyDestructiveButton_WearsADestructiveStyle"/> and
+    /// <see cref="EveryImmediatelyDestructiveButton_ExplainsWhatItWillDo"/>. One list, because two guards
+    /// each holding a private copy of "which controls are destructive" is how one of them silently stops
+    /// covering a control the other still checks — and the count each asserts would still look right.</para>
+    /// </remarks>
+    private static (string Command, string View, string[] Styles)[] DestructiveControls =>
+    [
+        ("DeletePresetCommand", "AudioMixerView.xaml", ["DangerButton"]),
+        ("KillProcessCommand", "ProcessManagerView.xaml", ["DangerButton", "DangerGhostButton"]),
+        ("DeleteSelectedCommand", "ShortcutCleanerView.xaml", ["DangerButton"]),
+        ("ShredAllCommand", "FileShredderView.xaml", ["DangerButton"]),
+        ("UninstallSelectedCommand", "UninstallerView.xaml", ["DangerButton"]),
+    ];
+
+    /// <summary>
+    /// A view's XAML as a single line with its comments removed — the form these guards match against.
+    /// </summary>
+    /// <remarks>
+    /// Stripping comments FIRST is load-bearing, not tidiness. <c>AdminBanner.xaml</c>'s own comment explains
+    /// that "IsElevated and RelaunchAsAdminCommand are bound from the ambient DataContext", so a search for
+    /// the command name lands in that prose, finds no <c>&lt;Button</c> before it, and reports the element as
+    /// unreadable — which is how the banner check failed the first time it ran. The other three views escape
+    /// it only because none of them happens to name its command in a comment, so the trap was latent there
+    /// too. Every guard that reads a control out of a view goes through here.
+    /// </remarks>
+    private static string XamlCode(string path) =>
+        Collapse(XmlComment().Replace(File.ReadAllText(path), string.Empty));
+
+    /// <summary>
+    /// Reads the <c>&lt;Button …&gt;</c> element that binds <paramref name="command"/> out of collapsed XAML.
+    /// Returns null on success, or the offender line to report.
+    /// </summary>
+    /// <remarks>
+    /// Back to the nearest <c>&lt;Button</c> and forward to its close. A fixed window around the command
+    /// reference would reach into the neighbouring control's attributes and report them as this button's.
+    /// <para>Shared so the two guards over <see cref="DestructiveControls"/> cannot disagree about which
+    /// span they are reading. One of them passing on a different element than the other checks would be
+    /// invisible: both would report a clean run over the same list.</para>
+    /// </remarks>
+    private static string? ReadButtonElement(string collapsedXaml, string view, string command, out string element)
+    {
+        element = "";
+        var at = collapsedXaml.IndexOf(command, StringComparison.Ordinal);
+        if (at < 0) return $"{view} — nothing binds {command} any more; update this guard or the view";
+
+        var open = collapsedXaml.LastIndexOf("<Button", at, StringComparison.Ordinal);
+        var close = collapsedXaml.IndexOf('>', at);
+        if (open < 0 || close < 0) return $"{view} — could not read the element around {command}";
+
+        element = collapsedXaml[open..close];
+        return null;
+    }
+
+    /// <summary>
+    /// Every immediately destructive button says what it will do, through
+    /// <c>AutomationProperties.HelpText</c>.
+    /// </summary>
+    /// <remarks>
+    /// A red button and a confirmation dialog are both sighted affordances. To someone using Narrator, the
+    /// red is not there and the dialog arrives only after the button has been activated — so the moment to
+    /// explain the consequence is while focus is on the control, and <c>HelpText</c> is the channel UIA
+    /// provides for exactly that. It is announced after the name, so the name stays short and the
+    /// consequence goes here.
+    /// <para><b>Not <c>ToolTip</c>.</b> The app reached for it twice on these very controls
+    /// (<c>ProcessManagerView</c>'s "Kill process", <c>DiskAnalyzerView</c>'s "Show in Explorer"), and a
+    /// tooltip is mouse-hover-only — it is not reliably surfaced to a screen reader, and a keyboard user
+    /// tabbing onto the button never triggers it at all.</para>
+    /// <para><b>Deliberately narrow.</b> HelpText makes navigation more verbose, so this covers the five
+    /// controls that do something the user cannot take back, not the ~461 buttons in the app. The list is
+    /// the same one <see cref="EveryImmediatelyDestructiveButton_WearsADestructiveStyle"/> uses, so a
+    /// control added there is required to explain itself here without anyone remembering to.</para>
+    /// <para>The text is required to be prose rather than merely present: an empty or one-word HelpText
+    /// satisfies "has the attribute" while telling a user nothing, and that is the shape this would rot
+    /// into. Markup extensions are stripped before the words are counted, so a HelpText that one day
+    /// interpolates a value the way these buttons' names already do still has to carry the sentence
+    /// explaining the consequence, rather than passing on the binding alone.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryImmediatelyDestructiveButton_ExplainsWhatItWillDo()
+    {
+        var viewsDir = Path.Combine(FindAppProjectDir(), "Views");
+        var offenders = new List<string>();
+        var checkedButtons = 0;
+
+        foreach (var (command, view, _) in DestructiveControls)
+        {
+            var path = Path.Combine(viewsDir, view);
+            Assert.True(File.Exists(path), $"{path} not found — this guard would pass vacuously");
+
+            var xaml = XamlCode(path);
+            if (ReadButtonElement(xaml, view, command, out var element) is { } unreadable)
+            {
+                offenders.Add(unreadable);
+                continue;
+            }
+
+            checkedButtons++;
+
+            if (HelpTextProblem(element, $"{view} — {command}") is { } problem)
+                offenders.Add(problem);
+        }
+
+        // Vacuity floor, in two parts because one of them is not enough. Comparing against the list's own
+        // length catches an element read that stopped matching — but it moves WITH the list, so deleting a
+        // row would satisfy it while quietly dropping a control from both guards. The absolute count is what
+        // catches that. It is a measured population: raise it when a destructive control is added, and only
+        // lower it with a reason, never to make a red go away.
+        Assert.True(DestructiveControls.Length >= 5,
+            $"the shared destructive-control list is down to {DestructiveControls.Length} rows, from 5 "
+            + "measured. A control was removed from it rather than from the app, which silently narrows both "
+            + "guards over this list.");
+
+        Assert.True(checkedButtons == DestructiveControls.Length,
+            $"only {checkedButtons} of {DestructiveControls.Length} listed commands were read out of their "
+            + "views, so this guard checked less than it claims");
+
+        Assert.True(offenders.Count == 0,
+            "These controls do something the user cannot undo, and a screen reader has no way to learn that "
+            + "before activating them:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>How many words of literal text a HelpText needs before it can explain a consequence.</summary>
+    private const int MinimumHelpTextWords = 6;
+
+    /// <summary>
+    /// Checks one element's <c>AutomationProperties.HelpText</c>: present, and carrying enough literal words
+    /// to be an explanation. Returns null when it is fine, or the offender line to report.
+    /// </summary>
+    /// <remarks>
+    /// One definition of the rule, used by both the destructive buttons and the elevation banner, so the
+    /// standard cannot be stricter in one place than the other — which would be invisible, since each guard
+    /// would still report a clean run.
+    /// </remarks>
+    private static string? HelpTextProblem(string element, string what)
+    {
+        var help = HelpTextAttribute().Match(element);
+        if (!help.Success)
+            return $"{what} has no AutomationProperties.HelpText, so a screen reader announces its name and "
+                   + "nothing about what activating it does";
+
+        // Markup extensions do not count as the explanation: strip them, then count what is left.
+        var prose = BindingExpression().Replace(help.Groups["text"].Value, " ");
+        var words = prose.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return words.Length < MinimumHelpTextWords
+            ? $"{what}'s HelpText is {words.Length} words of literal text, which cannot explain a "
+              + $"consequence; at least {MinimumHelpTextWords} are expected"
+            : null;
+    }
+
+    /// <summary>An <c>AutomationProperties.HelpText</c> attribute and its value.</summary>
+    [GeneratedRegex(@"AutomationProperties\.HelpText=""(?<text>[^""]*)""", RegexOptions.Compiled)]
+    private static partial Regex HelpTextAttribute();
+
+    /// <summary>A <c>{Binding …}</c> markup extension, braces included.</summary>
+    [GeneratedRegex(@"\{[^}]*\}", RegexOptions.Compiled)]
+    private static partial Regex BindingExpression();
 
     /// <summary>
     /// Every view that lists a collection must have something to say when that collection is empty.
@@ -1980,6 +2129,18 @@ public partial class ArchitectureTests
             + "once rather than thirty times, and so the stripe's negative margin cannot drift away from the "
             + "padding it depends on:\n  " + string.Join("\n  ", handRolled));
 
+        // One control means one place to get the announcement right, so assert it IS right rather than
+        // trusting that having extracted it was enough. Its "Run as administrator" button is the elevation
+        // control on every privileged tab: without HelpText a screen-reader user is told the button's name on
+        // thirty pages and never that pressing it closes SysManager and opens it again elevated.
+        var banner = XamlCode(Path.Combine(viewsDir, "AdminBanner.xaml"));
+        var unreadable = ReadButtonElement(banner, "AdminBanner.xaml", "RelaunchAsAdminCommand", out var button);
+        Assert.True(unreadable is null, unreadable);
+
+        var bannerHelp = HelpTextProblem(button, "AdminBanner.xaml — the \"Run as administrator\" button");
+        Assert.True(bannerHelp is null,
+            bannerHelp + ". Every privileged tab renders this one control, so the gap is on all of them.");
+
         var hosts = Directory
             .EnumerateFiles(viewsDir, "*.xaml", SearchOption.TopDirectoryOnly)
             .Where(f => Path.GetFileName(f) != "AdminBanner.xaml")
@@ -1988,10 +2149,11 @@ public partial class ArchitectureTests
             .Where(n => n.Length > 0)
             .ToList();
 
-        // Vacuity floor: 30 views host the banner. A collapse means the element match broke and the
-        // view-model assertion below is checking nothing.
+        // Vacuity floor: 31 views host the banner, re-measured today — it was 30 when this was written and a
+        // host has been added since, which is exactly why the number is stated rather than remembered. A
+        // collapse means the element match broke and the view-model assertion below is checking nothing.
         Assert.True(hosts.Count >= 28,
-            $"only {hosts.Count} views were found hosting <v:AdminBanner/>, out of 30 measured — the element "
+            $"only {hosts.Count} views were found hosting <v:AdminBanner/>, out of 31 measured — the element "
             + "match is out of date, so a pass proves nothing.");
 
         var missing = new List<string>();

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.76.28</Version>
-    <FileVersion>1.76.28.0</FileVersion>
-    <AssemblyVersion>1.76.28.0</AssemblyVersion>
+    <Version>1.77.0</Version>
+    <FileVersion>1.77.0.0</FileVersion>
+    <AssemblyVersion>1.77.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AdminBanner.xaml
+++ b/SysManager/SysManager/Views/AdminBanner.xaml
@@ -32,9 +32,16 @@
                  NoTextWrapping_IsInertInsideAHorizontalStackPanel exists for that exact mistake, and two
                  views already used this DockPanel shape before the extraction. -->
             <DockPanel>
+                <!-- HelpText, not a longer Name: Narrator reads the name first and the help text after, so
+                     the consequence of pressing this belongs in the second one. "Run as administrator" says
+                     what the control is; it does not say that the window you are looking at will close and
+                     reopen, which is the part that surprises someone who cannot see it happen. Generic on
+                     purpose — this one control serves all 30 privileged tabs, and NotElevatedMessage is
+                     already where the per-tab "why" lives. -->
                 <Button Content="Run as administrator" Command="{Binding RelaunchAsAdminCommand}"
                         Style="{StaticResource AdminButton}" DockPanel.Dock="Right" Padding="14,8"
-                        AutomationProperties.Name="Run as administrator"/>
+                        AutomationProperties.Name="Run as administrator"
+                        AutomationProperties.HelpText="Closes SysManager and opens it again with administrator rights. Windows will ask you to allow it first."/>
                 <TextBlock Text="&#xE83D;" DockPanel.Dock="Left"
                            FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                            FontSize="16" Margin="0,0,10,0" VerticalAlignment="Center"

--- a/SysManager/SysManager/Views/AudioMixerView.xaml
+++ b/SysManager/SysManager/Views/AudioMixerView.xaml
@@ -40,7 +40,8 @@
                      already there; what was missing is the signal BEFORE the click. -->
                 <Button Content="Delete" Command="{Binding DeletePresetCommand}"
                         Style="{StaticResource DangerButton}" Margin="0,0,16,0"
-                        AutomationProperties.Name="Delete selected preset"/>
+                        AutomationProperties.Name="Delete selected preset"
+                        AutomationProperties.HelpText="Deletes the saved volume levels for this preset. It cannot be brought back, and the volumes you are using right now do not change."/>
 
                 <TextBox Text="{Binding NewPresetName, UpdateSourceTrigger=PropertyChanged}"
                          Width="160" Margin="0,0,8,0" VerticalContentAlignment="Center"

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -59,6 +59,8 @@
                 <Button Content="Add Folder" Command="{Binding AddFolderCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
                 <Button Content="Shred All" Command="{Binding ShredAllCommand}"
+                        AutomationProperties.Name="Shred all listed items"
+                        AutomationProperties.HelpText="Overwrites every item in the list so it cannot be recovered, then deletes it. This cannot be undone, not even from the Recycle Bin. SysManager asks you to confirm first."
                         Style="{StaticResource DangerButton}" Margin="0,0,8,0"/>
                 <Button Content="Cancel" Command="{Binding CancelCommand}"
                         Style="{StaticResource GhostButton}"

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -254,6 +254,7 @@
                                          destructive action the moment the pointer is on it. -->
                                     <Button Content="X" ToolTip="Kill process"
                                             AutomationProperties.Name="{Binding Name, StringFormat='Kill {0}'}"
+                                            AutomationProperties.HelpText="Ends this program straight away, losing anything it has not saved. SysManager asks you to confirm first."
                                             Command="{Binding DataContext.KillProcessCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                             CommandParameter="{Binding}"
                                             Style="{StaticResource DangerGhostButton}" Padding="6,2" FontSize="12"/>

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -43,6 +43,7 @@
                      tells the user which one is the dangerous one before they read the label. -->
                 <Button Content="Delete Selected" Command="{Binding DeleteSelectedCommand}"
                         AutomationProperties.Name="Delete selected shortcuts"
+                        AutomationProperties.HelpText="Deletes the ticked broken shortcuts — the ones whose target is already missing. They go to the Recycle Bin unless you turn that option off."
                         Style="{StaticResource DangerButton}" Margin="0,0,8,0"/>
                 <Button Content="Cancel" Command="{Binding CancelCommand}"
                         AutomationProperties.Name="Cancel scan"

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -74,6 +74,7 @@
                 <Button Content="Uninstall selected" Command="{Binding UninstallSelectedCommand}"
                         AutomationProperties.AutomationId="btn-uninstaller-uninstall-selected"
                         AutomationProperties.Name="Uninstall selected applications"
+                        AutomationProperties.HelpText="Removes the ticked applications from this computer. This cannot be undone — you would have to install them again. SysManager lists them and asks you to confirm first."
                         Style="{StaticResource DangerButton}" Margin="0,0,8,0"/>
                 <Button Content="Cancel" Command="{Binding CancelCommand}"
                         Style="{StaticResource GhostButton}" Margin="0,0,12,0"


### PR DESCRIPTION
Six controls in this app do something you cannot take back. To someone using Narrator, they announced only their label — "Shred All button" — and then nothing, until the confirmation dialog, which arrives *after* the button has been pressed. The red `DangerButton` style and that dialog were the only two warnings the app gave, and neither one reaches a user who cannot see the screen.

`AutomationProperties.HelpText` is the UIA channel for exactly this. It is read after the name, so the name stays short and the consequence goes in the help text. It had **zero** occurrences in the project before this change.

Not `ToolTip`, which the app reached for twice on these very controls (`ProcessManagerView`'s *Kill process*, `DiskAnalyzerView`'s *Show in Explorer*): a tooltip needs a mouse hovering, so it never fires for someone who tabbed to the button, and it is not reliably handed to assistive software.

## The copy was checked against what each control does, not what its label implies

| command | what it actually does |
|---|---|
| `ShredAllCommand` | overwrites, then deletes — irreversible, not even via the Recycle Bin |
| `UninstallSelectedCommand` | removes the ticked apps; you would have to install them again |
| `KillProcessCommand` | ends the program; unsaved work is lost |
| `DeletePresetCommand` | deletes the saved volume levels — current volumes are **not** changed |
| `DeleteSelectedCommand` | deletes ticked **broken** shortcuts — Recycle Bin unless that option is off |

The last two are why this was read line by line rather than written from the label. `DeletePreset` rewrites the presets file and leaves the live volumes alone, so "this changes your volume" would have been a lie. `ShortcutCleaner` deletes shortcuts whose target is *already missing* and defaults to the Recycle Bin, so calling it permanent would have been a worse one — a draft that said exactly that was thrown away after reading `DeleteSelectedAsync`.

The sixth control is the elevation banner, one shared control since #2134, so its help text lands on all **31** pages that ask for administrator rights at once. It says the window closes and reopens, which is the part that is startling if you cannot watch it happen, and stays generic because `NotElevatedMessage` is already where each tab's "why" lives.

`Shred All` also gains an explicit `AutomationProperties.Name`. It was relying on its `Content` being read — which works, and made it the one button of its kind not stating its own name.

## Two guards, one list, one rule

- `DestructiveControls` is hoisted out of `EveryImmediatelyDestructiveButton_WearsADestructiveStyle` so the new guard shares it. Two guards each holding a private copy of "which controls are destructive" is how one silently stops covering a control the other still checks — and both would still report a clean run.
- `ReadButtonElement` and `HelpTextProblem` are shared for the same reason. If the two guards disagreed about which span they read, or one applied a weaker rule, nothing would show it.
- The check counts **words**, not presence. An empty or one-word help text satisfies "the attribute is there" while telling nobody anything, and that is the shape this would rot into.
- **Two** vacuity floors, because one is not enough. `checkedButtons == list.Length` catches a broken element read, but it moves *with* the list — deleting a row would satisfy it while quietly narrowing both guards. The absolute `>= 5` catches that, and N5 below proves it.

## The guard failed on its first run, and that is now a mutation

`XamlCode()` strips XML comments before matching, which is load-bearing rather than tidiness. `AdminBanner.xaml`'s own comment explains that *"IsElevated and RelaunchAsAdminCommand are bound from the ambient DataContext"* — so the first search hit was that prose, no `<Button` preceded it, and the banner check reported `could not read the element around RelaunchAsAdminCommand`. The other three views escape it only because none of them happens to name its command in a comment, so the trap was latent there too. N4 reproduces it.

Also re-measured a stale floor found on the way: the banner-host count in the elevation guard said 30 and is **31** today.

## Red/green

The first three mutations edit XAML, which the guards read from disk as text, so no rebuild was needed for them. Every file restored from a SHA-verified copy and rebuilt afterwards.

| | mutation | result |
|---|---|---|
| | baseline | 3 green, 0 red |
| N1 | `FileShredder` → no HelpText | **RED** attribute missing |
| N2 | `Uninstaller` → HelpText cut to three words | **RED** on the *word count*, not presence |
| N3 | `AdminBanner` → no HelpText | **RED** — the banner's only cover |
| N4 | guard → stop stripping comments | **RED** `could not read the element` — the real failure, reproduced |
| N5 | shared list → delete a row | **RED** the absolute floor: 4 rows, from 5 |
| | restored, sha verified, rebuilt | 3 green, 0 red |

## Verification

- Four projects build **0 errors, 0 warnings**.
- **107 of 108** guards green after rebasing onto #2138. The single red is `EverySourceFile_CarriesTheAuthorHeader` flagging the throwaway local runner, which is not in the repository.
- `dotnet format --verify-no-changes` clean on the app and the test project.
- Leak scan: 43 patterns over 11 files, 1,277,086 bytes. The only two hits are the Windows assistant privacy toggle the app has always been able to switch off, in lines this change does not touch.
- Nothing changes visually, so there is no mockup and no screenshot to recapture. Hearing the announcements is a Narrator check on the secondary workstation; what can be asserted mechanically is asserted here.

## Scope

Part of #1544. The `AutomationId` half of that issue is untouched — it is a larger piece of work with a different rationale. Its `nav-tweaks-hub` half landed in #2138.
