### PR TITLE
fix: 52 tabs reported what they were doing to nobody using a screen reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.77.1] - 2026-09-07
+
+If you use a screen reader, every tab has been silent about what it was doing. Start a system repair or a
+drive scan and there was no progress, no result, and no way to know it had finished — the app said all of it
+on screen and none of it out loud. Fifty-two tabs now report themselves as they work.
+
+### Fixed
+- **Every tab's status line is now read out as it changes.** The one line that says what is happening —
+  "Scanning…", "Removed 1,204 files", "Scan complete." — reached only people who could see it. All 52 of them
+  now announce themselves politely, so they wait their turn instead of talking over what you are reading.
+- **The SFC and DISM results are announced when a repair finishes.** Those run for many minutes with the
+  window in the background, and the sentence saying how it ended was the one thing you needed and could not
+  hear.
+- **Deep Cleanup announces what it is scanning and what it cleaned.** The percentage and the folder name
+  beside them stay silent on purpose: they change several times a second, and reading those aloud would talk
+  continuously instead of telling you anything.
+
+### Added
+- **A check that every status line stays announced, and that the fast-moving numbers stay quiet.** Both halves
+  matter. A well-meant change that announced everything would look like an improvement and would make the app
+  unusable with a screen reader, so the quiet ones are named and pinned too.
+
 ## [1.77.0] - 2026-09-07
 
 Six buttons that do something you cannot take back now explain themselves out loud. Until now a screen reader
@@ -31,6 +53,7 @@ dialog you had already committed to opening. Nothing changes on screen for anyon
 ### Changed
 - **Shred All now sets its accessible name explicitly, like its siblings.** It was relying on its label being
   read instead, which works but was the one button of its kind not saying so for itself.
+
 
 ## [1.76.28] - 2026-09-07
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,17 @@ not a tooltip for the same reason: a tooltip needs a mouse hovering over the con
 someone who tabbed to it, and it is not reliably handed to assistive software. It is kept to those six
 deliberately. An explanation on every button in the app would make it slower to navigate, not clearer.
 
+Every tab also reads out what it is doing as it works. The line at the bottom of each tab — "Scanning…",
+"Removed 1,204 files", "Scan complete." — is announced on all 52 tabs that have one, as are the SFC and DISM
+results when a system repair finishes and Deep Cleanup's scan and clean summaries. Announcements are polite,
+so they wait their turn rather than cutting across whatever you are reading.
+
+What is deliberately *not* announced matters just as much. Deep Cleanup's percentage changes several times a
+second and its current folder changes per directory; the repair ETAs tick continuously. Reading those aloud
+would talk over you without telling you anything, so each tab announces the coarsest line it has and leaves
+the fast-moving numbers on screen only. Both halves of that are enforced by a test, because a change that
+announced everything would look like an improvement.
+
 ### Context Menu Manager
 Manage Windows Explorer right-click entries — toggle them on or off without
 deleting anything (uses the standard `LegacyDisable` registry mechanism):

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4858,6 +4858,187 @@ public partial class ArchitectureTests
             + $"row:\n  " + string.Join("\n  ", sameOnEveryRow));
     }
 
+    /// <summary>
+    /// Every tab's status line is a live region, and the fast-moving readouts beside them are not.
+    /// </summary>
+    /// <remarks>
+    /// 52 tabs report what a long operation is doing through one <c>TextBlock</c> bound to
+    /// <c>StatusMessage</c>, and none of them was announced: WCAG 4.1.3 asks that a status change which
+    /// never receives focus still reach assistive software, and <c>AutomationProperties.LiveSetting</c> is
+    /// the channel. Before this guard the whole project had two occurrences of it, both the same element —
+    /// the toast overlay in <c>MainWindow.xaml</c> — so a screen-reader user started a DISM repair or a drive
+    /// scan and heard nothing at all: no progress, no completion, no verdict.
+    /// <para><b>Both directions, and the negative half is the important one.</b> Over-announcing is the real
+    /// hazard here. Deep Cleanup's percentage changes several times a second and its current-folder path
+    /// changes per directory; marking those live would produce continuous speech instead of information, and
+    /// a well-meaning sweep that added the attribute everywhere would look like an improvement. So the fast
+    /// readouts are asserted to stay silent, by name.</para>
+    /// <para><b>The style pair is checked too.</b> 49 of the status lines are <c>Caption</c> and two are
+    /// <c>Subtle</c>, so the announced style exists twice — <c>StatusLine</c> and <c>SubtleStatusLine</c> —
+    /// because neither look changes here. A fix applied to one and forgotten on the other is otherwise
+    /// invisible: every view would still reference a style that exists, and this guard would still pass.</para>
+    /// <para>Parsed as XML rather than matched as text, like the progress-bar guard above: the status line in
+    /// Duplicate Finder declares its style as a nested <c>&lt;TextBlock.Style&gt;</c> element to add a tooltip
+    /// trigger, and a string scan for a <c>Style="…"</c> attribute reports that one as unstyled.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryStatusLine_IsALiveRegion_AndTheFastReadoutsAreNot()
+    {
+        // Announced status lines resolve to one of these, or carry the attribute outright.
+        string[] announcedStyles = ["{StaticResource StatusLine}", "{StaticResource SubtleStatusLine}"];
+
+        // Fast-changing readouts that sit BESIDE a coarser line which is announced instead. A live region on
+        // any of these is speech, not information. Named individually because each is a judgement, not a
+        // pattern — and every one has to be found, or the rule below covers nothing.
+        //
+        // The rule is "announce the coarsest line each tab has", which is why this list is not simply
+        // "anything that updates often". Deep Cleanup's percentage and folder path can be silent because
+        // ScanStatusLine says the same thing more slowly; the SFC and DISM ETAs can be silent because the
+        // verdict and the tab's status line cover start and finish. Duplicate Finder's status line updates
+        // five times a second and carries a file name, and is announced anyway — it is the only line that tab
+        // has, so silencing it would leave a screen-reader user with nothing at all, including no "Scan
+        // complete." Splitting a coarse line out of it, the way Deep Cleanup already does, is #2143 — and
+        // when that lands, the per-file property belongs in this list.
+        string[] mustStaySilent =
+        [
+            "ScanProgress", "LargeCurrentFolder", "SfcEtaText", "DismEtaText",
+        ];
+
+        var appDir = FindAppProjectDir();
+        var viewsDir = Path.Combine(appDir, "Views");
+        var files = Directory.EnumerateFiles(viewsDir, "*.xaml", SearchOption.TopDirectoryOnly).ToArray();
+
+        var silent = new List<string>();
+        var overAnnounced = new List<string>();
+        var statusLinesSeen = 0;
+        var fastReadoutsFound = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var path in files)
+        {
+            var root = System.Xml.Linq.XDocument.Load(path).Root;
+            if (root is null) continue;
+            var file = Path.GetFileName(path);
+
+            foreach (var block in root.DescendantsAndSelf().Where(e => e.Name.LocalName == "TextBlock"))
+            {
+                // The bound property, compared EXACTLY. A substring test looked equivalent and is not:
+                // "SfcEtaTextRenamed".Contains("SfcEtaText") is true, so renaming a binding satisfied the
+                // floor below while the guard no longer watched anything. Found by mutating exactly that.
+                var bound = BoundProperty(Attr(block, "Text"));
+                if (bound is null) continue;
+
+                if (bound.Equals("StatusMessage", StringComparison.Ordinal))
+                {
+                    statusLinesSeen++;
+                    if (!IsAnnounced(block, announcedStyles))
+                        silent.Add($"{file} — the StatusMessage line is not a live region, so nothing this "
+                                   + "tab reports while it works is announced");
+                }
+
+                if (mustStaySilent.Contains(bound, StringComparer.Ordinal))
+                {
+                    fastReadoutsFound.Add(bound);
+                    if (IsAnnounced(block, announcedStyles))
+                        overAnnounced.Add($"{file} — {bound} is a live region. It changes many times per "
+                                          + "operation, so announcing it means continuous speech; only the "
+                                          + "coarse status line and the final verdict are announced.");
+                }
+            }
+        }
+
+        // Both shared styles must exist AND both must carry the setting. Checking only one would let the
+        // pair drift apart while every view still referenced a style that resolves.
+        var appXaml = XamlCode(Path.Combine(appDir, "App.xaml"));
+        foreach (var style in (string[])["StatusLine", "SubtleStatusLine"])
+        {
+            var at = appXaml.IndexOf($"x:Key=\"{style}\"", StringComparison.Ordinal);
+            if (at < 0)
+            {
+                silent.Add($"App.xaml — the {style} style is gone, so the views referencing it will throw "
+                           + "when they open");
+                continue;
+            }
+
+            var end = appXaml.IndexOf("</Style>", at, StringComparison.Ordinal);
+            var body = end < 0 ? appXaml[at..] : appXaml[at..end];
+            if (!body.Contains("AutomationProperties.LiveSetting", StringComparison.Ordinal))
+                silent.Add($"App.xaml — {style} no longer sets AutomationProperties.LiveSetting, so every "
+                           + "view using it went quiet at once while still resolving");
+        }
+
+        // Vacuity floor: 52 status lines, one per tab that has one, measured. Raise it when a tab gains one;
+        // a drop means the Text attribute read stopped matching and the whole sweep found nothing.
+        Assert.True(statusLinesSeen >= 50,
+            $"only {statusLinesSeen} StatusMessage lines were found across {files.Length} views, out of 52 "
+            + "measured — the element read is out of date, so a pass proves nothing.");
+
+        // The negative half needs its own floor, and it is the half most likely to go quiet: an absence
+        // check over a population it never found reports success. Every name in mustStaySilent has to be
+        // located, or the list has drifted from the views and the over-announcing rule covers nothing.
+        var missingFast = mustStaySilent.Except(fastReadoutsFound, StringComparer.Ordinal).ToList();
+        Assert.True(missingFast.Count == 0,
+            "these fast-changing bindings were not found in any view, so asserting they are not live regions "
+            + "proves nothing. They were renamed or removed — update the list with the current names rather "
+            + $"than deleting the rows:\n  " + string.Join("\n  ", missingFast));
+
+        Assert.True(silent.Count == 0,
+            "a status line that is not a live region is invisible to a screen reader: the user starts a scan "
+            + "or a repair and is told nothing, including that it finished:\n  " + string.Join("\n  ", silent));
+
+        Assert.True(overAnnounced.Count == 0,
+            "these are fast-changing readouts and must NOT be live regions — announcing them talks over the "
+            + "user instead of informing them:\n  " + string.Join("\n  ", overAnnounced));
+    }
+
+    /// <summary>An attribute's value by local name, ignoring the namespace prefix.</summary>
+    private static string? Attr(System.Xml.Linq.XElement element, string localName) =>
+        element.Attributes().FirstOrDefault(a => a.Name.LocalName == localName)?.Value;
+
+    /// <summary>
+    /// The last segment of the property path a <c>{Binding …}</c> attribute value reads, or null when the
+    /// value is not a binding.
+    /// </summary>
+    /// <remarks>
+    /// Exact rather than substring, which is the whole reason this exists: a caller testing
+    /// <c>value.Contains("SfcEtaText")</c> also matches <c>SfcEtaTextRenamed</c>, so renaming a binding kept
+    /// a vacuity floor satisfied while the guard silently stopped watching anything. The LAST segment, so a
+    /// compound path like <c>DataContext.StatusMessage</c> still resolves to the property.
+    /// </remarks>
+    private static string? BoundProperty(string? attributeValue)
+    {
+        if (attributeValue is null) return null;
+
+        var at = attributeValue.IndexOf("{Binding ", StringComparison.Ordinal);
+        if (at < 0) return null;
+
+        var rest = attributeValue[(at + "{Binding ".Length)..].TrimStart();
+        var end = rest.IndexOfAny([',', '}', ' ']);
+        var path = (end < 0 ? rest : rest[..end]).Trim();
+        if (path.Length == 0) return null;
+
+        var dot = path.LastIndexOf('.');
+        return dot < 0 ? path : path[(dot + 1)..];
+    }
+
+    /// <summary>
+    /// True when this element is a live region: by the attribute, by an announced style reference, or by a
+    /// nested <c>&lt;TextBlock.Style&gt;</c> based on one.
+    /// </summary>
+    private static bool IsAnnounced(System.Xml.Linq.XElement element, string[] announcedStyles)
+    {
+        if (Attr(element, "AutomationProperties.LiveSetting") is not null) return true;
+
+        var style = Attr(element, "Style");
+        if (style is not null && announcedStyles.Contains(style, StringComparer.Ordinal)) return true;
+
+        // The nested form: <TextBlock.Style><Style BasedOn="{StaticResource StatusLine}">…
+        return element.Elements()
+            .Where(e => e.Name.LocalName.EndsWith(".Style", StringComparison.Ordinal))
+            .SelectMany(e => e.Elements().Where(s => s.Name.LocalName == "Style"))
+            .Any(s => Attr(s, "BasedOn") is { } basedOn
+                      && announcedStyles.Contains(basedOn, StringComparer.Ordinal));
+    }
+
     /// <summary>A style that suppresses the focus indicator outright.</summary>
     [GeneratedRegex(@"FocusVisualStyle""\s*Value=""\{x:Null\}""", RegexOptions.Compiled)]
     private static partial Regex NulledFocusVisual();

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -1115,6 +1115,37 @@
                 <Setter Property="FontSize" Value="12"/>
             </Style>
 
+            <!-- ============================================================ -->
+            <!-- Status lines: the same look, announced.
+
+                 52 tabs report what a long operation is doing through one TextBlock bound to
+                 StatusMessage, and a screen reader said nothing about any of them. WCAG 4.1.3 asks
+                 that a status change which never receives focus still be announced, and
+                 AutomationProperties.LiveSetting is the channel for it. Setting it in the style
+                 rather than on 52 elements means the decision is made once.
+
+                 Polite, never Assertive: a status line that ticks through "Scanning C:\…" would
+                 interrupt whatever the user is reading. Assertive is right for the toast overlay in
+                 MainWindow.xaml, which auto-dismisses and so has one chance to be heard, and that is
+                 the only place using it.
+
+                 A PAIR, because the two visual bases genuinely differ and neither look changes here:
+                 49 of the status lines are Caption, two are Subtle. Both carry the same LiveSetting,
+                 and ArchitectureTests fails if one of them stops — a fix applied to one and forgotten
+                 on the other is otherwise invisible.
+
+                 Deliberately NOT applied to the fast-moving readouts beside these lines: Deep
+                 Cleanup's percentage and current-folder path, and the SFC/DISM ETAs. Marking those
+                 live would produce continuous speech instead of information. -->
+            <!-- ============================================================ -->
+            <Style x:Key="StatusLine" TargetType="TextBlock" BasedOn="{StaticResource Caption}">
+                <Setter Property="AutomationProperties.LiveSetting" Value="Polite"/>
+            </Style>
+
+            <Style x:Key="SubtleStatusLine" TargetType="TextBlock" BasedOn="{StaticResource Subtle}">
+                <Setter Property="AutomationProperties.LiveSetting" Value="Polite"/>
+            </Style>
+
             <Style x:Key="Metric" TargetType="TextBlock">
                 <Setter Property="FontSize" Value="22"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.77.0</Version>
-    <FileVersion>1.77.0.0</FileVersion>
-    <AssemblyVersion>1.77.0.0</AssemblyVersion>
+    <Version>1.77.1</Version>
+    <FileVersion>1.77.1.0</FileVersion>
+    <AssemblyVersion>1.77.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppAlertsView.xaml
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml
@@ -133,7 +133,7 @@
             <ProgressBar AutomationProperties.Name="App alert scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -93,7 +93,7 @@
                          IsIndeterminate="{Binding IsProgressIndeterminate}"/>
             <TextBlock Grid.Column="1" Text="{Binding UpgradeEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="8,0,0,0" VerticalAlignment="Center"
                        Visibility="{Binding UpgradeEtaText, Converter={StaticResource FlexVis}}"/>
-            <TextBlock Grid.Column="2" Margin="12,0,0,0" Text="{Binding StatusMessage}" Style="{StaticResource Subtle}"/>
+            <TextBlock Grid.Column="2" Margin="12,0,0,0" Text="{Binding StatusMessage}" Style="{StaticResource SubtleStatusLine}"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/AudioMixerView.xaml
+++ b/SysManager/SysManager/Views/AudioMixerView.xaml
@@ -200,7 +200,7 @@
             <ProgressBar AutomationProperties.Name="Audio device refresh progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/BandwidthMonitorView.xaml
+++ b/SysManager/SysManager/Views/BandwidthMonitorView.xaml
@@ -203,7 +203,7 @@
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding ModeDescription}" Style="{StaticResource Caption}" DockPanel.Dock="Right"
                        HorizontalAlignment="Right" TextTrimming="CharacterEllipsis" MaxWidth="420"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" TextWrapping="Wrap"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/BatteryHealthView.xaml
+++ b/SysManager/SysManager/Views/BatteryHealthView.xaml
@@ -180,7 +180,7 @@
             <ProgressBar AutomationProperties.Name="Refresh progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml
@@ -133,7 +133,7 @@
                     AutomationProperties.Name="Cancel reading boot history"
                     Style="{StaticResource GhostButton}" Margin="0,0,12,0" Padding="10,2"
                     Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/BrowserCleanerView.xaml
+++ b/SysManager/SysManager/Views/BrowserCleanerView.xaml
@@ -102,7 +102,7 @@
             <ProgressBar AutomationProperties.Name="Browser cleanup progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -280,7 +280,7 @@
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding InstallEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,0,8,0" VerticalAlignment="Center"
                        Visibility="{Binding InstallEtaText, Converter={StaticResource FlexVis}}" DockPanel.Dock="Left"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -102,7 +102,13 @@
                         <TextBlock Text="SFC result:" DockPanel.Dock="Left" FontWeight="SemiBold"
                                    Foreground="{DynamicResource TextSecondary}"
                                    VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <!-- Announced: an SFC repair runs for many minutes with the window in the
+                             background, and this is the sentence that says how it ended. The "SFC /scannow
+                             is running" label above is static text, so a live region could not announce it
+                             even if it carried one — what changes there is visibility, not content. Start
+                             and progress are covered by the status line at the bottom of the tab. -->
                         <TextBlock Text="{Binding SfcVerdict}" TextWrapping="Wrap" VerticalAlignment="Center"
+                                   AutomationProperties.LiveSetting="Polite"
                                    Foreground="{Binding SfcVerdictColorHex, Converter={StaticResource HexBrush}}"/>
                     </DockPanel>
                 </Border>
@@ -124,6 +130,7 @@
                                    Foreground="{DynamicResource TextSecondary}"
                                    VerticalAlignment="Center" Margin="0,0,8,0"/>
                         <TextBlock Text="{Binding DismVerdict}" TextWrapping="Wrap" VerticalAlignment="Center"
+                                   AutomationProperties.LiveSetting="Polite"
                                    Foreground="{Binding DismVerdictColorHex, Converter={StaticResource HexBrush}}"/>
                     </DockPanel>
                 </Border>
@@ -140,7 +147,7 @@
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Value="{Binding Progress}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/CliInterfaceView.xaml
+++ b/SysManager/SysManager/Views/CliInterfaceView.xaml
@@ -74,7 +74,7 @@
         </Border>
 
         <!-- Status -->
-        <TextBlock Grid.Row="4" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+        <TextBlock Grid.Row="4" Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"
                    Margin="0,12,0,0" TextWrapping="Wrap"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -300,7 +300,7 @@
             <ProgressBar AutomationProperties.Name="Context menu scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/CpuAffinityView.xaml
+++ b/SysManager/SysManager/Views/CpuAffinityView.xaml
@@ -116,7 +116,7 @@
                 <ProgressBar AutomationProperties.Name="Process list progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                              IsIndeterminate="{Binding IsProgressIndeterminate}"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
+                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" TextWrapping="Wrap"/>
             </DockPanel>
             <Button Grid.Column="1" Content="Restore" Command="{Binding RestoreCommand}"
                     Style="{StaticResource SecondaryButton}" Margin="0,0,8,0" Padding="14,8"

--- a/SysManager/SysManager/Views/DarkModeView.xaml
+++ b/SysManager/SysManager/Views/DarkModeView.xaml
@@ -76,7 +76,7 @@
         <Border Grid.Row="4"/>
 
         <!-- Status -->
-        <TextBlock Grid.Row="5" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+        <TextBlock Grid.Row="5" Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"
                    Margin="0,12,0,0" TextWrapping="Wrap"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -608,7 +608,7 @@
             </Grid>
 
             <!-- ═══ ROW 9: Status bar ═══ -->
-            <TextBlock Grid.Row="9" Text="{Binding StatusMessage}" Style="{StaticResource Caption}" Margin="0,4,0,0"/>
+            <TextBlock Grid.Row="9" Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" Margin="0,4,0,0"/>
         </Grid>
     </ScrollViewer>
 </UserControl>

--- a/SysManager/SysManager/Views/DebloaterView.xaml
+++ b/SysManager/SysManager/Views/DebloaterView.xaml
@@ -130,7 +130,7 @@
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Value="{Binding Progress}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -56,7 +56,11 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Column="0" Text="{Binding ScanStatusLine}" Foreground="{DynamicResource Accent}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <!-- Announced: this is the coarse "what is happening" line. The percentage
+                                     beside it deliberately is not — a live region on a number that changes
+                                     every tick produces continuous speech instead of information. -->
+                                <TextBlock Grid.Column="0" Text="{Binding ScanStatusLine}" Foreground="{DynamicResource Accent}" FontWeight="SemiBold" VerticalAlignment="Center"
+                                           AutomationProperties.LiveSetting="Polite"/>
                                 <TextBlock Grid.Column="1" Text="{Binding ScanProgress, StringFormat={}{0}%}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="12,0,0,0"/>
                             </Grid>
                             <ProgressBar AutomationProperties.Name="Scan progress" Height="6" Minimum="0" Maximum="100" Value="{Binding ScanProgress}" Margin="0,6,0,0"/>
@@ -128,7 +132,8 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Column="0" Text="{Binding CleanStatusLine}" Foreground="{DynamicResource Success}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="0" Text="{Binding CleanStatusLine}" Foreground="{DynamicResource Success}" FontWeight="SemiBold" VerticalAlignment="Center"
+                                           AutomationProperties.LiveSetting="Polite"/>
                                 <TextBlock Grid.Column="1" Text="{Binding CleanProgress, StringFormat={}{0}%}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center" Margin="12,0,0,0"/>
                             </Grid>
                             <ProgressBar AutomationProperties.Name="Cleanup progress" Height="6" Minimum="0" Maximum="100" Value="{Binding CleanProgress}" Margin="0,6,0,0"/>

--- a/SysManager/SysManager/Views/DefenderView.xaml
+++ b/SysManager/SysManager/Views/DefenderView.xaml
@@ -137,7 +137,7 @@
             <ProgressBar AutomationProperties.Name="Defender operation progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -189,7 +189,7 @@
             <ProgressBar AutomationProperties.Name="Scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/DisplayProfileView.xaml
+++ b/SysManager/SysManager/Views/DisplayProfileView.xaml
@@ -113,7 +113,7 @@
                 <ProgressBar AutomationProperties.Name="Display mode progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                              IsIndeterminate="{Binding IsProgressIndeterminate}"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
+                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" TextWrapping="Wrap"/>
             </DockPanel>
             <Button Grid.Column="1" Content="Apply mode" Command="{Binding ApplyCommand}"
                     Style="{StaticResource PrimaryButton}" Padding="16,8"

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -67,7 +67,7 @@
                 <TextBlock Text="{Binding SelectedPreset.Description}" Style="{StaticResource Subtle}"
                            Margin="0,0,0,4"
                            Visibility="{Binding SelectedPreset, Converter={StaticResource FlexVis}}"/>
-                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Subtle}" Margin="0,4,0,0"
+                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource SubtleStatusLine}" Margin="0,4,0,0"
                            Visibility="{Binding StatusMessage, Converter={StaticResource FlexVis}}"/>
             </StackPanel>
         </Border>

--- a/SysManager/SysManager/Views/DriversView.xaml
+++ b/SysManager/SysManager/Views/DriversView.xaml
@@ -124,7 +124,7 @@
                 <ProgressBar AutomationProperties.Name="Driver scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                              IsIndeterminate="{Binding IsProgressIndeterminate}"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
             </DockPanel>
         </Grid>
     </ScrollViewer>

--- a/SysManager/SysManager/Views/DuplicateFileView.xaml
+++ b/SysManager/SysManager/Views/DuplicateFileView.xaml
@@ -190,7 +190,10 @@
                        TextTrimming="CharacterEllipsis"
                        ToolTip="{Binding CurrentFile}">
                 <TextBlock.Style>
-                    <Style TargetType="TextBlock" BasedOn="{StaticResource Caption}">
+                    <!-- BasedOn StatusLine, not Caption: this is the one status line in the app declared as
+                         an inline style rather than a style reference, because it adds a tooltip trigger.
+                         It still has to be announced like the other 51. -->
+                    <Style TargetType="TextBlock" BasedOn="{StaticResource StatusLine}">
                         <!-- No tooltip outside a scan: an empty one renders as a stray blank box. -->
                         <Setter Property="ToolTipService.IsEnabled" Value="False"/>
                         <Style.Triggers>

--- a/SysManager/SysManager/Views/EdgeOneDriveView.xaml
+++ b/SysManager/SysManager/Views/EdgeOneDriveView.xaml
@@ -97,7 +97,7 @@
             <ProgressBar AutomationProperties.Name="Edge and OneDrive operation progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -231,7 +231,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/FileLockView.xaml
+++ b/SysManager/SysManager/Views/FileLockView.xaml
@@ -90,7 +90,7 @@
                 <ProgressBar AutomationProperties.Name="File lock scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                              IsIndeterminate="{Binding IsProgressIndeterminate}"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
+                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" TextWrapping="Wrap"/>
             </DockPanel>
             <Button Grid.Column="1" Content="End process" Command="{Binding KillSelectedCommand}"
                     Style="{StaticResource DangerButton}" Padding="14,8"

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -128,7 +128,7 @@
                     <Run Text="{Binding Items.Count, Mode=OneWay}"/>
                     <Run Text=" item(s) queued"/>
                 </TextBlock>
-                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"
                            Margin="16,0,0,0" Opacity="0.8" TextWrapping="Wrap"
                            VerticalAlignment="Center"/>
             </DockPanel>

--- a/SysManager/SysManager/Views/GamingProfileView.xaml
+++ b/SysManager/SysManager/Views/GamingProfileView.xaml
@@ -115,7 +115,7 @@
                              IsIndeterminate="{Binding IsProgressIndeterminate}"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
                 <TextBlock DockPanel.Dock="Left" VerticalAlignment="Center"
-                           Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
+                           Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" TextWrapping="Wrap"/>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                     <Button Content="Start game mode" Command="{Binding StartCommand}" Style="{StaticResource PrimaryButton}"
                             Margin="0,0,8,0" Padding="16,8" AutomationProperties.Name="Start game mode"/>

--- a/SysManager/SysManager/Views/LegacyPanelsView.xaml
+++ b/SysManager/SysManager/Views/LegacyPanelsView.xaml
@@ -73,7 +73,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="2" Margin="0,8,0,0">
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" VerticalAlignment="Center"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" VerticalAlignment="Center"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -482,7 +482,7 @@
             <ProgressBar AutomationProperties.Name="Log loading progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/NotificationBlockerView.xaml
+++ b/SysManager/SysManager/Views/NotificationBlockerView.xaml
@@ -139,7 +139,7 @@
             <ProgressBar AutomationProperties.Name="Notification setting progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/PerformanceView.xaml
+++ b/SysManager/SysManager/Views/PerformanceView.xaml
@@ -313,7 +313,7 @@
             <ProgressBar AutomationProperties.Name="Performance tweak progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/PingView.xaml
+++ b/SysManager/SysManager/Views/PingView.xaml
@@ -221,7 +221,7 @@
         </Border>
 
         <!-- Status -->
-        <TextBlock Grid.Row="4" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+        <TextBlock Grid.Row="4" Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"
                    Margin="28,12,28,24" TextWrapping="Wrap"/>
 
     </Grid>

--- a/SysManager/SysManager/Views/PrivacyMonitorView.xaml
+++ b/SysManager/SysManager/Views/PrivacyMonitorView.xaml
@@ -66,7 +66,7 @@
 
         <!-- Status bar -->
         <DockPanel Grid.Row="3" Margin="0,8,0,0">
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" VerticalAlignment="Center"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" VerticalAlignment="Center"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -112,7 +112,7 @@
             <ProgressBar AutomationProperties.Name="Privacy setting progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -278,7 +278,7 @@
             <ProgressBar AutomationProperties.Name="Process list progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/ProfileView.xaml
+++ b/SysManager/SysManager/Views/ProfileView.xaml
@@ -79,7 +79,7 @@
             <ProgressBar AutomationProperties.Name="Profile import and export progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/ResourceHistoryView.xaml
+++ b/SysManager/SysManager/Views/ResourceHistoryView.xaml
@@ -120,7 +120,7 @@
             <ProgressBar AutomationProperties.Name="Resource history loading progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="True"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" TextWrapping="Wrap"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/RestorePointsView.xaml
+++ b/SysManager/SysManager/Views/RestorePointsView.xaml
@@ -97,7 +97,7 @@
             <ProgressBar AutomationProperties.Name="Restore point progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
+++ b/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
@@ -117,7 +117,7 @@
             <ProgressBar AutomationProperties.Name="Scheduled maintenance progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="True"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" TextWrapping="Wrap"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -287,7 +287,7 @@
             <ProgressBar AutomationProperties.Name="Service list progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/SettingsWatchdogView.xaml
+++ b/SysManager/SysManager/Views/SettingsWatchdogView.xaml
@@ -161,7 +161,7 @@
         </Border>
 
         <!-- Status -->
-        <TextBlock Grid.Row="7" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+        <TextBlock Grid.Row="7" Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"
                    Margin="28,12,28,24" TextWrapping="Wrap"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/StandbyMemoryView.xaml
+++ b/SysManager/SysManager/Views/StandbyMemoryView.xaml
@@ -104,7 +104,7 @@
                 <ProgressBar AutomationProperties.Name="Standby memory progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                              IsIndeterminate="{Binding IsProgressIndeterminate}"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
+                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" TextWrapping="Wrap"/>
             </DockPanel>
             <Button Grid.Column="1" Content="Purge standby list" Command="{Binding PurgeCommand}"
                     Style="{StaticResource PrimaryButton}" Padding="16,8" IsEnabled="{Binding IsElevated}"

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -246,7 +246,7 @@
             <ProgressBar AutomationProperties.Name="Startup item scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/SystemFixesView.xaml
+++ b/SysManager/SysManager/Views/SystemFixesView.xaml
@@ -98,7 +98,7 @@
                     AutomationProperties.Name="Cancel current repair"
                     Style="{StaticResource GhostButton}" Margin="0,0,12,0" Padding="10,2"
                     Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -381,7 +381,7 @@
                     <ProgressBar AutomationProperties.Name="System health check progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                                  IsIndeterminate="{Binding IsProgressIndeterminate}"
                                  Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+                    <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
                 </DockPanel>
             </StackPanel>
         </ScrollViewer>

--- a/SysManager/SysManager/Views/SystemReportView.xaml
+++ b/SysManager/SysManager/Views/SystemReportView.xaml
@@ -82,7 +82,7 @@
             <ProgressBar AutomationProperties.Name="Report generation progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/TaskSchedulerView.xaml
+++ b/SysManager/SysManager/Views/TaskSchedulerView.xaml
@@ -167,7 +167,7 @@
                         AutomationProperties.Name="Cancel the task scan"
                         Style="{StaticResource GhostButton}" Margin="0,0,12,0" Padding="10,2"
                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
+                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" TextWrapping="Wrap"/>
             </DockPanel>
             <Button Grid.Column="1" Content="Enable / Disable" Command="{Binding ToggleEnabledCommand}"
                     Style="{StaticResource PrimaryButton}" Padding="16,8"

--- a/SysManager/SysManager/Views/TimerResolutionView.xaml
+++ b/SysManager/SysManager/Views/TimerResolutionView.xaml
@@ -95,7 +95,7 @@
         </WrapPanel>
 
         <!-- Status -->
-        <TextBlock Grid.Row="5" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+        <TextBlock Grid.Row="5" Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"
                    VerticalAlignment="Bottom" Margin="0,8,0,0" TextWrapping="Wrap"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/TracerouteView.xaml
+++ b/SysManager/SysManager/Views/TracerouteView.xaml
@@ -112,7 +112,7 @@
         </Grid>
 
         <!-- Status -->
-        <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" Style="{StaticResource Caption}"
+        <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"
                    Margin="28,12,28,24" TextWrapping="Wrap"/>
 
     </Grid>

--- a/SysManager/SysManager/Views/TweaksHubView.xaml
+++ b/SysManager/SysManager/Views/TweaksHubView.xaml
@@ -111,7 +111,7 @@
                              VerticalAlignment="Center" Margin="0,0,12,0" IsIndeterminate="True"
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
                 <TextBlock DockPanel.Dock="Left" VerticalAlignment="Center"
-                           Text="{Binding StatusMessage}" Style="{StaticResource Caption}" TextWrapping="Wrap"/>
+                           Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" TextWrapping="Wrap"/>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                     <!-- Content is bound via an inner TextBlock: StringFormat on a ContentControl's
                          Content (an int) isn't applied without ContentStringFormat on the template, so

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -280,7 +280,7 @@
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
             <TextBlock Text="{Binding UninstallEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="0,0,8,0" VerticalAlignment="Center"
                        Visibility="{Binding UninstallEtaText, Converter={StaticResource FlexVis}}" DockPanel.Dock="Left"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -253,7 +253,7 @@
             <ProgressBar AutomationProperties.Name="Windows feature progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -366,7 +366,7 @@
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Value="{Binding Progress}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource Caption}"/>
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
         </DockPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
Every tab with a long-running operation says what it is doing through one `TextBlock` bound to `StatusMessage`. None of them was a live region, so a screen-reader user started a DISM repair or a drive scan and heard **nothing** — no start, no progress, no completion, no verdict. WCAG 4.1.3 asks that a status change which never receives focus still reach assistive software.

Before this, the whole project had two occurrences of `AutomationProperties.LiveSetting` and they were the same element: the toast overlay in `MainWindow.xaml`. The API was already understood and used correctly there; it simply had not reached the per-tab status lines.

## Announced through a shared style, not 52 copies of an attribute

| style | based on | applies to |
|---|---|---|
| `StatusLine` | `Caption` | 50 status lines |
| `SubtleStatusLine` | `Subtle` | 2 status lines |

A **pair**, because the two visual bases genuinely differ and no look changes here: 49 of the lines carried `Caption` as an attribute, two carried `Subtle`, and Duplicate Finder's declares its style as a nested `<TextBlock.Style>` based on `Caption` because it adds a tooltip trigger — that one now bases on `StatusLine`.

`Polite`, never `Assertive`. A line that ticks through "Scanning C:\…" must not interrupt whatever the user is reading. `Assertive` stays where it belongs: on the toast that auto-dismisses and so has one chance to be heard.

Four more lines are announced individually because they are not `StatusMessage` bindings — Deep Cleanup's `ScanStatusLine` and `CleanStatusLine`, and Quick Cleanup's `SfcVerdict` and `DismVerdict`.

## The negative half is the one that matters

The rule is **announce the coarsest line each tab has**. Deep Cleanup's percentage changes several times a second and its folder path changes per directory; the SFC and DISM ETAs tick continuously. Marking those live would produce speech instead of information — and a well-meaning sweep that added the attribute everywhere would look like an improvement while making the app unusable with a screen reader. They are asserted to stay silent, by name.

## Two corrections to #1545's own description

Both from reading the code rather than the issue:

- It asks for the "SFC /scannow is running in background" and "DISM is running" labels to be announced. Those are **static text**. A live region reports content changes, and what changes there is visibility, not content — a `LiveSetting` on them would announce nothing. The bound **verdicts** are the announceable thing, and start/progress are already covered by the tab's own status line.
- It lists `CurrentFile` among the fast readouts to leave silent. It is bound to `ToolTip`, not `Text`, so it was never a live-region candidate — a tooltip is not one. The guard's vacuity floor caught that the moment it was written, which is what the floor is for.

## Duplicate Finder is a documented exception

Its status line is throttled to 200 ms and carries a file name, so it changes five times a second. It is also the **only** line that tab has: silencing it would leave a screen-reader user with nothing at all, including no "Scan complete." It is announced anyway, and #2143 is filed to split a coarse line out of it the way Deep Cleanup already does.

## The guard, and the hole its own mutation found

`EveryStatusLine_IsALiveRegion_AndTheFastReadoutsAreNot` pins both halves. Parsed as XML rather than matched as text, following the progress-bar guard above it, because a string scan for `Style="…"` reports Duplicate Finder's nested style as unstyled. It also checks that **both** shared styles still carry the setting — a fix applied to one and forgotten on the other is otherwise invisible, since every view would still reference a style that resolves.

The binding comparison is **exact**, and that is not a detail. It started as `text.Contains("SfcEtaText")`, which also matches `"SfcEtaTextRenamed"` — so renaming a binding kept the vacuity floor satisfied while the guard silently stopped watching anything. Mutation P5 was written to test that floor, came back **GREEN**, and that is how the hole was found. `BoundProperty()` now reads the last segment of the binding path and compares it exactly.

## Red/green

All six mutations are XAML, which the guard loads from disk at run time, so none needed a rebuild. Every file restored from a SHA-verified copy.

| | mutation | result |
|---|---|---|
| | baseline | 1 green, 0 red |
| P1 | one view → `StatusLine` back to `Caption` | **RED** that tab is silent again |
| P2 | `App.xaml` → `StatusLine` loses its setter | **RED** 50 views go quiet while still resolving |
| P3 | `App.xaml` → `SubtleStatusLine` loses its setter | **RED** proves the *pair* is checked, not half of it |
| P4 | Deep Cleanup → announce the percentage | **RED** the negative half |
| P5 | CleanupView → rename `SfcEtaText` | **RED** the fast-readout floor (green before the exact-match fix) |
| P6 | Duplicate Finder → nested style back to `Caption` | **RED** the shape a string scan cannot see |
| | restored, sha verified | 1 green, 0 red |

## Verification

- Four projects build **0 errors, 0 warnings**.
- **108 of 109** guards green after rebasing onto #2142. The single red is `EverySourceFile_CarriesTheAuthorHeader` flagging the throwaway local runner, which is not in the repository.
- `dotnet format --verify-no-changes` clean on the app and the test project.
- Leak scan: 43 patterns over 58 files, 1,991,512 bytes. The only two hits are the Windows assistant privacy toggle the app has always been able to switch off, in lines this change does not touch.
- Nothing changes visually. Hearing the announcements is a Narrator pass on the secondary workstation; what can be asserted mechanically is asserted here.

README's "Screen readers" section, added by #2142, gains the status-line half: what is announced, and what deliberately is not.

Closes #1545.
