### PR TITLE
fix: Cancel could not stop a severity-filtered System Logs read for minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.77.2] - 2026-09-07
+
+Cancel now works in System Logs. Filtering the log to Errors and Criticals over a long period could leave the
+tab stuck for minutes with Cancel doing nothing at all — four and a half minutes on one slower machine, against
+a stop asked for after ten seconds.
+
+### Fixed
+- **Pressing Cancel while System Logs is reading now stops it.** The filtering was being done by Windows
+  itself, inside a single call SysManager had no way to interrupt: it searched the whole period for a matching
+  event before handing anything back, and until it did, Cancel and Refresh could do nothing. SysManager now
+  reads the events and applies the severity filter itself, so it can stop between one event and the next. An
+  unfiltered read — what the tab does by default — behaves exactly as before.
+
+### Added
+- **A test that a cancelled filtered read comes back quickly.** It asks for a severity the log almost never
+  contains, which is the case that used to hang: there is nothing to find, so the search ran to the end.
+
 ## [1.77.1] - 2026-09-07
 
 If you use a screen reader, every tab has been silent about what it was doing. Start a system repair or a
@@ -31,6 +48,7 @@ on screen and none of it out loud. Fifty-two tabs now report themselves as they 
 - **A check that every status line stays announced, and that the fast-moving numbers stay quiet.** Both halves
   matter. A well-meant change that announced everything would look like an improvement and would make the app
   unusable with a screen reader, so the quiet ones are named and pinned too.
+
 
 ## [1.77.0] - 2026-09-07
 

--- a/SysManager/SysManager.IntegrationTests/EventLogServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/EventLogServiceTests.cs
@@ -114,6 +114,59 @@ public class EventLogServiceTests
     }
 
     /// <summary>
+    /// Cancelling a SEVERITY-FILTERED read stops it, which is the case that used to hang.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Read_Cancellation_StopsFast"/> above covers an unfiltered read and always passed. The
+    /// filtered one did not: the severity filter used to be a <c>Level</c> clause in the XPath, which the
+    /// Event Log service evaluates itself, so a single <c>ReadEvent()</c> walked records internally until it
+    /// found a match and returned only then. That native call cannot be interrupted by a token, so on a
+    /// machine with few Error or Critical events in the window the read blocked for minutes with Cancel doing
+    /// nothing — measured at 4 m 43 s against a 10-second budget on a CI runner.
+    /// <para>The window is wide, the cap unreachable, and the severity deliberately SCARCE, because the
+    /// defect only appears when the filter cannot be satisfied quickly. Filtering on Error would pass either
+    /// way on a machine with plenty of errors — the cap fills in milliseconds and nothing ever blocks — which
+    /// would make this green against the very code it exists to catch. Verbose (Level 5) is essentially
+    /// absent from the System log, so an OS-evaluated query for it has to walk the whole window.</para>
+    /// <para><b>It still only fails where the scan is slow, and that is worth being exact about.</b> Restoring
+    /// the old <c>Level</c> clause and running this on a developer machine leaves it GREEN: a System log of
+    /// 28,997 records answers the same unsatisfiable query in 333 ms, comfortably inside the budget. The 4 m
+    /// 43 s came from a CI runner, so that is where this test can go red, and the integration job is where it
+    /// runs. A test that can only fail on some machines is a weak test; it is kept because the alternative is
+    /// no regression test at all for a defect that was measured, and because a machine fast enough to pass it
+    /// is a machine where the bug does not bite.</para>
+    /// <para>Asserts the elapsed time rather than a count: the point is that control comes back, not what was
+    /// collected. Five seconds is the same budget its unfiltered sibling uses.</para>
+    /// </remarks>
+    [Fact]
+    public async Task Read_Cancellation_WithASeverityFilter_StopsFast()
+    {
+        var svc = new EventLogService();
+        var opt = new EventLogQueryOptions
+        {
+            LogName = "System",
+            Since = DateTime.Now.AddYears(-10),
+            MaxResults = 100000,
+            Severities = new() { EventSeverity.Verbose }
+        };
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(150);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var count = 0;
+        try
+        {
+            await foreach (var _ in svc.ReadAsync(opt, cts.Token)) count++;
+        }
+        catch (OperationCanceledException) { /* the expected end of a cancelled read */ }
+        sw.Stop();
+
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
+            $"a cancelled severity-filtered read took {sw.Elapsed} after {count} entries; the filter is "
+            + "being evaluated somewhere the token cannot reach");
+    }
+
+    /// <summary>
     /// Every entry that comes back carries an explanation and a recommendation.
     /// </summary>
     /// <remarks>

--- a/SysManager/SysManager.IntegrationTests/QaAuditTests.cs
+++ b/SysManager/SysManager.IntegrationTests/QaAuditTests.cs
@@ -321,6 +321,21 @@ public class QaAuditTests
         Assert.DoesNotContain("'Evil'Provider'", xpath);
     }
 
+    /// <summary>
+    /// The clauses the OS can bound cheaply combine; severity is not one of them.
+    /// </summary>
+    /// <remarks>
+    /// This asserted <c>Level=2</c> until the severity filter moved into managed code. A <c>Level</c> clause
+    /// is evaluated by the Event Log service itself, so one <c>ReadEvent()</c> walked records internally until
+    /// it found a match and returned only then — a blocking native call no <c>CancellationToken</c> can
+    /// interrupt, measured at 4 m 43 s against a 10-second token. The filter now runs in
+    /// <c>EventLogService.Matches</c>, where the loop can be cancelled between records.
+    /// <para>Asserting the clause is ABSENT rather than deleting the row: the only thing stopping it being
+    /// reinstated later as an obvious-looking optimisation is a test that fails when it comes back. Three
+    /// sibling assertions in <c>SysManager.Tests</c> were migrated the same way; this copy was missed because
+    /// it reaches <c>BuildXPath</c> by reflection from a different project, so grepping the method name in the
+    /// unit tests did not find it — the integration job did.</para>
+    /// </remarks>
     [Fact]
     public void EventLogService_BuildXPath_CombinesAllFilters()
     {
@@ -335,10 +350,11 @@ public class QaAuditTests
             "BuildXPath", BindingFlags.NonPublic | BindingFlags.Static)!;
         var xpath = (string)m.Invoke(null, new object[] { opt })!;
 
-        Assert.Contains("Level=2", xpath);
         Assert.Contains("TimeCreated", xpath);
         Assert.Contains("Provider[@Name='X']", xpath);
         Assert.Contains("EventID=42", xpath);
+        Assert.Contains(" and ", xpath);
+        Assert.DoesNotContain("Level", xpath);
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/EventLogServiceTests.cs
+++ b/SysManager/SysManager.Tests/EventLogServiceTests.cs
@@ -30,29 +30,12 @@ public class EventLogServiceTests
         Assert.Equal("*", result);
     }
 
-    [Fact]
-    public void BuildXPath_WithSeverity_IncludesLevel()
-    {
-        var opt = new EventLogQueryOptions
-        {
-            Severities = [EventSeverity.Error]
-        };
-        var result = InvokeBuildXPath(opt);
-        Assert.Contains("Level=2", result);
-    }
-
-    [Fact]
-    public void BuildXPath_MultipleSeverities_IncludesOr()
-    {
-        var opt = new EventLogQueryOptions
-        {
-            Severities = new List<EventSeverity> { EventSeverity.Error, EventSeverity.Warning }
-        };
-        var result = InvokeBuildXPath(opt);
-        Assert.Contains("Level=2", result);
-        Assert.Contains("Level=3", result);
-        Assert.Contains(" or ", result);
-    }
+    // BuildXPath_WithSeverity_IncludesLevel and BuildXPath_MultipleSeverities_IncludesOr used to sit here,
+    // asserting the query carried a Level clause. That clause is gone — it made a single ReadEvent() block
+    // uninterruptibly while the OS searched for a match — so both assertions are now inverted, and
+    // BuildXPath_NeverFiltersSeverityInTheQuery below asserts the absence in their place. What they were
+    // really about, that one or several requested severities are honoured, is covered by the Matches tests
+    // against the code that now does the filtering.
 
     [Fact]
     public void BuildXPath_WithSince_IncludesTimeCreated()
@@ -123,9 +106,11 @@ public class EventLogServiceTests
         };
         var result = InvokeBuildXPath(opt);
         Assert.Contains(" and ", result);
-        Assert.Contains("Level=1", result);
         Assert.Contains("Provider[@Name='disk']", result);
         Assert.Contains("EventID=11", result);
+        // Severities is set above and contributes nothing, which is the point: the clauses the OS can bound
+        // cheaply still combine, and severity is not one of them.
+        Assert.DoesNotContain("Level", result, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -176,60 +161,111 @@ public class EventLogServiceTests
     public void MapLevel_UnknownValue_ReturnsInfo()
         => Assert.Equal(EventSeverity.Info, InvokeMapLevel((byte)99));
 
-    // ---------- SeverityToLevels (the live inverse of MapLevel) ----------
+    // ---------- Matches: the severity filter, now applied in managed code ----------
 
+    /// <summary>
+    /// A requested severity admits every raw Level that <c>MapLevel</c> folds into it.
+    /// </summary>
+    /// <remarks>
+    /// This is the invariant <c>SeverityToLevels</c> used to carry. That method existed only to build the
+    /// query's <c>Level</c> clause, and the clause is gone: it made a single <c>ReadEvent()</c> block
+    /// uninterruptibly for minutes while the OS searched for a match, which is the cancellation defect this
+    /// change fixes. The method went with it rather than staying alive on the strength of its own test.
+    /// <para>Info is the case that matters and the reason its predecessor was once wrong. <c>MapLevel</c>
+    /// folds Level 0 (LogAlways) into Info, so an Info filter must admit BOTH 0 and 4 or every LogAlways
+    /// event silently disappears from an Info-filtered view. A dead twin once encoded <c>Info => 4</c> and a
+    /// reflection test certified it.</para>
+    /// </remarks>
     [Theory]
-    [InlineData(EventSeverity.Critical, new[] { 1 })]
-    [InlineData(EventSeverity.Error, new[] { 2 })]
-    [InlineData(EventSeverity.Warning, new[] { 3 })]
-    [InlineData(EventSeverity.Verbose, new[] { 5 })]
-    // Info is the case that matters and the reason the old test was wrong. MapLevel folds Level 0
-    // (LogAlways) into Info, so the XPath must ask for BOTH 0 and 4 or every LogAlways event silently
-    // disappears from an Info-filtered view. A dead twin of this method encoded `Info => 4` and a reflection
-    // test certified it; both are gone.
-    [InlineData(EventSeverity.Info, new[] { 0, 4 })]
-    public void SeverityToLevels_IsTheExactInverseOfMapLevel(EventSeverity severity, int[] expected)
-        => Assert.Equal(expected, EventLogService.SeverityToLevels(severity));
+    [InlineData(EventSeverity.Critical, (byte)1)]
+    [InlineData(EventSeverity.Error, (byte)2)]
+    [InlineData(EventSeverity.Warning, (byte)3)]
+    [InlineData(EventSeverity.Verbose, (byte)5)]
+    [InlineData(EventSeverity.Info, (byte)4)]
+    [InlineData(EventSeverity.Info, (byte)0)]
+    public void Matches_AdmitsEveryLevelThatMapsIntoTheRequestedSeverity(EventSeverity severity, byte level)
+        => Assert.True(EventLogService.Matches([severity], level));
 
-
-    // ---------- P2 #32 regression: Info filter must include Level 0 (LogAlways) ----------
+    /// <summary>A severity that was not asked for is rejected, including the LogAlways edge.</summary>
+    /// <remarks>
+    /// The negative half of the pair above. Without it, a filter that admitted everything would satisfy
+    /// every row of that theory — <c>Level 0</c> against a Critical-only filter is the specific case the old
+    /// <c>BuildXPath_CriticalOnly_DoesNotIncludeLevel0</c> guarded.
+    /// </remarks>
+    [Theory]
+    [InlineData(EventSeverity.Critical, (byte)0)]
+    [InlineData(EventSeverity.Critical, (byte)2)]
+    [InlineData(EventSeverity.Error, (byte)3)]
+    [InlineData(EventSeverity.Info, (byte)1)]
+    public void Matches_RejectsALevelThatWasNotAskedFor(EventSeverity severity, byte level)
+        => Assert.False(EventLogService.Matches([severity], level));
 
     [Fact]
-    public void BuildXPath_InfoSeverity_IncludesLevel0AndLevel4()
+    public void Matches_MultipleSeverities_AdmitsEachOfThem()
     {
-        var opt = new EventLogQueryOptions
-        {
-            Severities = [EventSeverity.Info]
-        };
-        var result = InvokeBuildXPath(opt);
-        Assert.Contains("Level=0", result);
-        Assert.Contains("Level=4", result);
-        Assert.Contains(" or ", result);
+        List<EventSeverity> both = [EventSeverity.Info, EventSeverity.Error];
+
+        Assert.True(EventLogService.Matches(both, 0));
+        Assert.True(EventLogService.Matches(both, 4));
+        Assert.True(EventLogService.Matches(both, 2));
+        Assert.False(EventLogService.Matches(both, 3));
     }
 
-    [Fact]
-    public void BuildXPath_InfoAndError_IncludesLevel0_Level4_Level2()
+    /// <summary>No filter admits everything, including a record with no Level at all.</summary>
+    /// <remarks>
+    /// The Logs tab's default is an unfiltered read, so this is the path most users take. A null Level folds
+    /// to Info the same way Level 0 does, and must not be dropped by an absent filter.
+    /// </remarks>
+    [Theory]
+    [InlineData((byte)1)]
+    [InlineData((byte)5)]
+    [InlineData(null)]
+    public void Matches_NoFilter_AdmitsEverything(byte? level)
     {
-        var opt = new EventLogQueryOptions
-        {
-            Severities = [EventSeverity.Info, EventSeverity.Error]
-        };
-        var result = InvokeBuildXPath(opt);
-        Assert.Contains("Level=0", result);
-        Assert.Contains("Level=4", result);
-        Assert.Contains("Level=2", result);
+        Assert.True(EventLogService.Matches(null, level));
+        Assert.True(EventLogService.Matches([], level));
     }
 
+    /// <summary>
+    /// The query carries no <c>Level</c> clause, whatever severities were asked for.
+    /// </summary>
+    /// <remarks>
+    /// The clause is what made one <c>ReadEvent()</c> block for 4 m 43 s against a 10-second token on a CI
+    /// runner: the Event Log service evaluates the query itself and returns only once it finds a match, and
+    /// that native call cannot be cancelled. Asserting its ABSENCE is the only thing that stops it being
+    /// reinstated later as an obvious-looking optimisation — the filter would still work, and only the
+    /// cancellation would quietly break again.
+    /// </remarks>
     [Fact]
-    public void BuildXPath_CriticalOnly_DoesNotIncludeLevel0()
+    public void BuildXPath_NeverFiltersSeverityInTheQuery()
     {
         var opt = new EventLogQueryOptions
         {
-            Severities = [EventSeverity.Critical]
+            Severities = [EventSeverity.Info, EventSeverity.Error, EventSeverity.Critical]
         };
+
         var result = InvokeBuildXPath(opt);
-        Assert.Contains("Level=1", result);
-        Assert.DoesNotContain("Level=0", result);
+
+        Assert.DoesNotContain("Level", result, StringComparison.Ordinal);
+        // Still "*" here, because severity was the only filter asked for — proving the clause was dropped
+        // rather than merely renamed.
+        Assert.Equal("*", result);
+    }
+
+    /// <summary>The other clauses are untouched by that removal.</summary>
+    [Fact]
+    public void BuildXPath_StillFiltersTheThingsTheOsCanBoundCheaply()
+    {
+        var opt = new EventLogQueryOptions
+        {
+            Severities = [EventSeverity.Error],
+            Since = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc)
+        };
+
+        var result = InvokeBuildXPath(opt);
+
+        Assert.Contains("TimeCreated", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("Level", result, StringComparison.Ordinal);
     }
 
     // ---------- EventLogQueryOptions defaults ----------

--- a/SysManager/SysManager/Services/EventLogService.cs
+++ b/SysManager/SysManager/Services/EventLogService.cs
@@ -141,11 +141,22 @@ public sealed partial class EventLogService
             if (rec is null) yield break;
 
             FriendlyEventEntry? entry = null;
-            try { entry = Project(rec, opt.LogName); }
+            try
+            {
+                // Severity is filtered HERE rather than in the query — see BuildXPath for why, because it
+                // is the fix for a cancellation defect rather than a preference. Before Project on purpose:
+                // Project formats the record's message, which is the expensive part, and a filtered read
+                // discards most of what it reads.
+                if (Matches(opt.Severities, rec.Level))
+                    entry = Project(rec, opt.LogName);
+            }
             catch (EventLogException) { /* skip malformed record */ }
             catch (InvalidOperationException) { /* skip malformed record */ }
             finally { rec.Dispose(); }
 
+            // Null here means one of three things — filtered out, malformed, or unreadable — and all three
+            // are "move on to the next record". Deliberately does NOT increment emitted, so MaxResults
+            // still counts what the caller receives.
             if (entry is null) continue;
             EventExplainer.Enrich(entry);
 
@@ -250,6 +261,18 @@ public sealed partial class EventLogService
         return (i < 0 ? s : s[..i]).Trim();
     }
 
+    /// <summary>
+    /// True when a record's raw <c>Level</c> satisfies the requested severities. An absent or empty filter
+    /// accepts everything.
+    /// </summary>
+    /// <remarks>
+    /// Uses the same <see cref="MapLevel"/> the projection uses, so a record cannot be admitted here and
+    /// then labelled with a different severity in the list. Internal so the mapping is testable without a
+    /// real <c>EventRecord</c>, which cannot be constructed.
+    /// </remarks>
+    internal static bool Matches(List<EventSeverity>? severities, byte? level) =>
+        severities is not { Count: > 0 } || severities.Contains(MapLevel(level));
+
     private static EventSeverity MapLevel(byte? level) => level switch
     {
         1 => EventSeverity.Critical,
@@ -268,12 +291,20 @@ public sealed partial class EventLogService
     {
         List<string> clauses = [];
 
-        if (opt.Severities is { Count: > 0 })
-        {
-            var levels = opt.Severities.SelectMany(SeverityToLevels).Distinct().ToList();
-            clauses.Add("(" + string.Join(" or ", levels.Select(l => $"Level={l}")) + ")");
-        }
-
+        // Severity is deliberately NOT a clause here, and putting it back would reintroduce a defect rather
+        // than an optimisation. The Event Log service evaluates this query itself: a single ReadEvent() walks
+        // records internally until one satisfies it, and returns only then. That call is a blocking native
+        // call and no CancellationToken can interrupt it, so with a Level clause over a window that contains
+        // few matches, one read blocked for 4 m 43 s on a CI runner against a 10-second token — Cancel did
+        // nothing, the tab stayed busy, and Refresh stayed disabled because it is gated on not-busy.
+        //
+        // Without it, each ReadEvent() returns the next record in the window immediately and the loop's own
+        // ct.IsCancellationRequested check between records becomes the cancellation point. See Matches(),
+        // which applies the filter in managed code using the same MapLevel the projection uses.
+        //
+        // The trade is examining more records, not doing more total work: the OS was already walking them,
+        // and it did so uninterruptibly. An unfiltered read — the Logs tab's default — is byte-for-byte
+        // unchanged, because every record it reads is emitted either way.
         if (opt.Since.HasValue)
         {
             // InvariantCulture is REQUIRED: the ':' in the format string is replaced by the
@@ -304,19 +335,4 @@ public sealed partial class EventLogService
         return "*[System[" + string.Join(" and ", clauses) + "]]";
     }
 
-    /// <summary>
-    /// Maps a severity back to ALL event levels that <see cref="MapLevel"/> folds into it.
-    /// Used by <see cref="BuildXPath"/> so the XPath Level clause is the exact inverse of
-    /// the read-side classification. In particular, Level 0 (LogAlways) is classified as
-    /// Info by MapLevel, so Info must query BOTH Level=0 and Level=4.
-    /// </summary>
-    internal static IEnumerable<int> SeverityToLevels(EventSeverity s) => s switch
-    {
-        EventSeverity.Critical => [1],
-        EventSeverity.Error => [2],
-        EventSeverity.Warning => [3],
-        EventSeverity.Info => [0, 4],
-        EventSeverity.Verbose => [5],
-        _ => [0, 4]
-    };
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.77.1</Version>
-    <FileVersion>1.77.1.0</FileVersion>
-    <AssemblyVersion>1.77.1.0</AssemblyVersion>
+    <Version>1.77.2</Version>
+    <FileVersion>1.77.2.0</FileVersion>
+    <AssemblyVersion>1.77.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
The severity filter was a `Level` clause in the XPath the Event Log service evaluates itself. That means a single `EventLogReader.ReadEvent()` walks records internally until one satisfies the query and returns only then — and it is a blocking native call no `CancellationToken` can interrupt.

On a window containing few matches, one read blocked for **4 m 43 s against a 10-second token** on a CI runner. For that whole time Cancel did nothing, the tab stayed busy, and Refresh stayed disabled because it is gated on not-busy.

The loop around it was already right: it checks the token between records and does not swallow the cancellation. The gap was entirely inside one record read, where the token cannot reach.

## The filter moves into managed code

`BuildXPath` keeps `Since`, `Provider` and `EventID` — bounds the OS can apply cheaply — and drops `Level`. Each `ReadEvent()` now returns the next record in the window immediately, which makes the loop's existing `ct.IsCancellationRequested` check the cancellation point.

Three things about the trade, because it reads like a pessimisation and is not:

- An **unfiltered** read is unchanged. Every record it reads is emitted either way, and that is the Logs tab's default.
- A filtered read examines more records but does not do more **total work**. The OS was already walking them; it just did so uninterruptibly and without telling anyone.
- `Matches()` is consulted **before** `Project()`, because `Project` formats the record's message — the expensive part — and a filtered read discards most of what it reads. Reading `rec.Level` is cheap.

`Matches()` uses the same `MapLevel` the projection uses, so a record cannot be admitted by the filter and then labelled with a different severity in the list.

## `SeverityToLevels` is deleted, and its invariant is not

It existed only to build that clause. With the clause gone it was production code kept alive by its own test.

What it guarded is kept: `MapLevel` folds Level 0 (LogAlways) into Info, so an Info filter must admit **both** 0 and 4 — now asserted against `Matches`, the code that actually does the filtering. Three `BuildXPath` tests that asserted the `Level` clause are migrated the same way rather than deleted, and a new one asserts the clause is **absent**, because the only thing stopping it being reinstated later as an obvious-looking optimisation is a test that fails when it comes back.

## The regression test, and why it filters on Verbose

`Read_Cancellation_WithASeverityFilter_StopsFast` asks for Verbose, which the System log essentially never contains. The defect only appears when the filter **cannot** be satisfied quickly: filtering on Error would fill its cap in milliseconds and pass against the very code it exists to catch.

## Red/green

| | mutation | result |
|---|---|---|
| | baseline | unit 11 green 0 red · integration 2 green 0 red |
| Q1 | restore the `Level` clause | **RED** the absence guard fires |
| Q2 | `Matches` → always true | **RED** 4 unit reds + `Read_SeverityFilter` |
| Q3 | `MapLevel` → unknown/0 folds to Verbose | **RED** the LogAlways row, exactly as its ancestor guarded |
| Q4 | `Enumerate` → drop the `Matches` guard | **RED** `Unexpected severity Info on entry 1` |
| | restored, sha verified, rebuilt | unit 11 green 0 red · integration 2 green 0 red |

**Q1 needs a caveat rather than a claim.** It reds the XPath absence guard, but it does **not** red the cancellation test on this workstation — and that is measured, not assumed. A System log of 28,997 records answers the same unsatisfiable `Level=5` query in **333 ms**, so the blocking read finishes inside the test's budget. The 4 m 43 s came from a CI runner, so the integration job is where that test can go red.

The first attempt at Q1 was also wrong in a way worth recording: it mapped severity to Level by enum ordinal, producing `Level=4 or Level=3` for Info+Error — a query matching plenty of events, and therefore proving nothing. The faithful mapping is the one the deleted `SeverityToLevels` carried.

## Verification

- Four projects build **0 errors, 0 warnings**.
- **107 of 108** guards green. The single red is `EverySourceFile_CarriesTheAuthorHeader` flagging the throwaway local runner, which is not in the repository.
- The 29 `EventLogService` unit tests: **43 green** (theories expanded), 0 red.
- The 7 integration reads: green, in **0.5 s** against a 0.47 s baseline measured before the change — so no local regression from client-side filtering.
- `dotnet format --verify-no-changes` clean; leak scan 43 patterns over 5 files, its one hit the Windows assistant privacy toggle in a historical changelog line.

The observable proof lands after merge: `Read_SeverityFilter_ReturnsOnlyRequested` took 4 m 43 s in the integration job and should now be comparable to its unfiltered siblings.

Closes #2140.
