### PR TITLE
feat: the health score could read Excellent on a PC that was out of disk space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.78.0] - 2026-09-07
+
+The health score now counts how much room is left on your Windows drive, and that will change the number you
+see. A PC with a nearly-full drive could score "Excellent" before — the worst thing a health score can do,
+because a full drive is the commonest reason a computer feels slow and it is what stops Windows installing its
+own updates.
+
+### Fixed
+- **A PC that is out of room can no longer score "Excellent", or even "Good".** As long as the drive's SMART
+  status was fine, memory was under 60% and it had been restarted recently, the score said everything was well
+  while the actual problem sat there unmentioned.
+
+### Added
+- **The score says how many GB are left, and where to get more.** "Only 4 GB free on C: — Deep Cleanup can
+  reclaim space" now appears first among the recommendations, because it is the only one of them you can act on
+  today, in this app. A worn battery and an ageing disk are real and SysManager cannot fix either.
+- **Big drives are not scolded for being big.** 400 GB free on a 4 TB disk is only 10% and nothing whatever is
+  wrong, so a comfortable amount of space in gigabytes outweighs an unimpressive percentage. It works the other
+  way too: 9 GB free on a small laptop drive is 22% and still not enough for Windows to update itself, so the
+  percentage does not get to call that healthy.
+- **Only the Windows drive counts.** A deliberately packed archive drive does not slow your PC down, and being
+  told your machine is unhealthy for a disk you filled on purpose is noise.
+- **`--health --json` reports the free-space component**, so a script can see why a score is low.
+
+### Changed
+- **Your score may read lower than before with nothing changed on your PC.** That is the new component being
+  counted, not a fault appearing. If it dropped, the recommendation on the Dashboard says why.
+
 ## [1.77.2] - 2026-09-07
 
 Cancel now works in System Logs. Filtering the log to Errors and Criticals over a long period could leave the
@@ -26,6 +54,7 @@ a stop asked for after ten seconds.
 ### Added
 - **A test that a cancelled filtered read comes back quickly.** It asks for a severity the log almost never
   contains, which is the case that used to hang: there is nothing to find, so the search ran to the end.
+
 
 ## [1.77.1] - 2026-09-07
 

--- a/README.md
+++ b/README.md
@@ -981,9 +981,13 @@ offers, "rate us" prompts:
   a summary card with freed space, warnings, and links to relevant tabs.
   Non-destructive, no admin required.
 - **Health Score** — overall system health gauge (0–100) combining disk
-  SMART, RAM usage, uptime, and battery wear. Color-coded ring (green /
-  amber / red) with up to 3 actionable recommendations. Auto-computes on
-  load and refreshes with "Scan system".
+  SMART, free space on the system drive, RAM usage, uptime, and battery
+  wear. Free space counts for a quarter of it, because a full drive is the
+  commonest reason a PC feels slow and the one thing on that list you can
+  fix today — so a machine that is out of room cannot score green, and the
+  recommendation says how many GB are left and points at Deep Cleanup.
+  Color-coded ring (green / amber / red) with up to 3 actionable
+  recommendations. Auto-computes on load and refreshes with "Scan system".
 - **System Tray** — background health monitoring (60s polling), CPU/RAM tooltip,
   Windows notifications when RAM > 90%, uptime > 14 days, or disk health degrades.
   Context menu: Show SysManager / Volume mixer / Exit.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.77.x   | :white_check_mark: |
-| < 1.77   | :x:                |
+| 1.78.x   | :white_check_mark: |
+| < 1.78   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
+++ b/SysManager/SysManager.Tests/HealthScoreServiceTests.cs
@@ -14,6 +14,24 @@ namespace SysManager.Tests;
 /// </summary>
 public class HealthScoreServiceTests
 {
+    /// <summary>The drive letter these tests treat as the system drive.</summary>
+    /// <remarks>
+    /// A literal, and deliberately not <see cref="HealthScoreService.SystemDriveLetter"/>: a test that asked
+    /// the environment which drive Windows is on would pass for the wrong reason on a machine that boots from
+    /// D:, and would stop testing the letter-matching at all.
+    /// </remarks>
+    private const string SystemDrive = "C:";
+
+    /// <summary>A comfortable, readable system drive.</summary>
+    /// <remarks>
+    /// Used by the tests about OTHER components, so that adding free space to
+    /// <see cref="HealthScoreService.UnavailableComponents"/> did not silently turn a test about the disk into
+    /// a test about two things.
+    /// </remarks>
+    private static IReadOnlyList<FixedDriveService.FixedDrive> ReadableSystemDrive(
+        double sizeGb = 500, double freeGb = 250) =>
+        [new(SystemDrive, SystemDrive, "NTFS", sizeGb, freeGb, "", "")];
+
     // ---------- construction ----------
 
     [Fact]
@@ -316,7 +334,7 @@ public class HealthScoreServiceTests
         };
         Assert.All(disks, d => Assert.Null(d.HealthPercent));   // the premise, not an assumption
 
-        var unavailable = HealthScoreService.UnavailableComponents(disks, null);
+        var unavailable = HealthScoreService.UnavailableComponents(disks, null, ReadableSystemDrive(), SystemDrive);
 
         Assert.Contains(HealthScoreService.DiskComponent, unavailable);
     }
@@ -333,7 +351,7 @@ public class HealthScoreServiceTests
             new() { FriendlyName = "Unreadable drive", HealthStatus = "" }
         };
 
-        var unavailable = HealthScoreService.UnavailableComponents(disks, null);
+        var unavailable = HealthScoreService.UnavailableComponents(disks, null, ReadableSystemDrive(), SystemDrive);
 
         Assert.DoesNotContain(HealthScoreService.DiskComponent, unavailable);
         Assert.Equal(20, HealthScoreService.ComputeDiskScore(disks));   // and the failing verdict survives
@@ -343,9 +361,261 @@ public class HealthScoreServiceTests
     public void UnavailableComponents_NoDrivesAtAll_StillMarksTheDiskUnavailable()
     {
         Assert.Contains(HealthScoreService.DiskComponent,
-            HealthScoreService.UnavailableComponents([], null));
+            HealthScoreService.UnavailableComponents([], null, ReadableSystemDrive(), SystemDrive));
         Assert.Contains(HealthScoreService.DiskComponent,
-            HealthScoreService.UnavailableComponents(null, null));
+            HealthScoreService.UnavailableComponents(null, null, ReadableSystemDrive(), SystemDrive));
+    }
+
+    // ---------- free space: the component the score used to be missing ----------
+
+    /// <summary>The verdict for a 200 GB system drive, across the range.</summary>
+    /// <remarks>
+    /// The three rules are not independently observable and that is deliberate, so this measures the COMBINED
+    /// verdict rather than pretending to test the percentage table alone. A first draft did pretend, on a
+    /// 100 GB drive, and got two rows wrong: 17% free is 17 GB, which the 20 GB floor pulls to 55 whatever the
+    /// percentage says. Each row below states the arithmetic that produces it.
+    /// </remarks>
+    [Theory]
+    [InlineData(60, 100)]   // 30% and 60 GB — both views comfortable
+    [InlineData(40, 100)]   // 20%, exactly on the top percentage band
+    [InlineData(30, 80)]    // 15% and 30 GB — both views say 80
+    [InlineData(22, 55)]    // 11%: percentage 55, absolute silent, above the 20 GB floor
+    [InlineData(20, 55)]    // 10% exactly, and exactly ON the floor rather than under it
+    [InlineData(15, 25)]    //  7.5%: percentage 25, and the 20 GB floor caps at 55 — the lower wins
+    [InlineData(10, 25)]    //  5% exactly, at the 10 GB floor rather than under it
+    [InlineData(8, 10)]     //  4%: percentage 10; the 10 GB floor caps at 25 and cannot raise it
+    public void ComputeFreeSpaceScore_ScoresTheSystemDriveAcrossTheRange(double freeGb, int expected)
+        => Assert.Equal(expected, HealthScoreService.ComputeFreeSpaceScore(
+            [new(SystemDrive, SystemDrive, "NTFS", 200, freeGb, "", "")], SystemDrive));
+
+    /// <summary>
+    /// A large disk is not unhealthy for having a small PERCENTAGE free.
+    /// </summary>
+    /// <remarks>
+    /// 400 GB free on 4 TB is 10%, which the percentage table alone calls 55 — a "needs attention" verdict on
+    /// a machine with nothing whatever wrong with it. This is the false alarm the absolute view exists to
+    /// prevent, and the reason percent alone was rejected.
+    /// </remarks>
+    [Theory]
+    [InlineData(4000, 400, 100)]   // 10% of 4 TB
+    [InlineData(2000, 60, 100)]    //  3% of 2 TB, still 60 GB of room
+    [InlineData(1000, 30, 80)]     //  3% of 1 TB, 30 GB — comfortable, not generous
+    public void ComputeFreeSpaceScore_AGenerousAbsoluteAmountOverridesALowPercentage(
+        double sizeGb, double freeGb, int expected)
+        => Assert.Equal(expected, HealthScoreService.ComputeFreeSpaceScore(
+            [new(SystemDrive, SystemDrive, "NTFS", sizeGb, freeGb, "", "")], SystemDrive));
+
+    /// <summary>
+    /// A small disk IS unhealthy for having little space, however good the percentage looks.
+    /// </summary>
+    /// <remarks>
+    /// The other direction, and the reason absolute alone was rejected too. 9 GB free on a 40 GB drive is 22%
+    /// — the top percentage band — and still not enough for Windows to install a feature update, which stages
+    /// around 20 GB. The floor is what stops the percentage calling that healthy.
+    /// </remarks>
+    [Theory]
+    [InlineData(40, 9, 25)]     // 22% free, under the 10 GB floor
+    [InlineData(64, 15, 55)]    // 23% free, under the 20 GB floor
+    [InlineData(32, 4, 25)]     // 12% free and nearly empty in absolute terms
+    public void ComputeFreeSpaceScore_AHardFloorOverridesAHealthyPercentage(
+        double sizeGb, double freeGb, int expected)
+        => Assert.Equal(expected, HealthScoreService.ComputeFreeSpaceScore(
+            [new(SystemDrive, SystemDrive, "NTFS", sizeGb, freeGb, "", "")], SystemDrive));
+
+    /// <summary>Only the system drive counts.</summary>
+    /// <remarks>
+    /// A deliberately-packed archive disk does not slow Windows down, and scoring it would report a machine as
+    /// unhealthy for a state its owner chose. The full D: here must not move the score at all.
+    /// </remarks>
+    [Fact]
+    public void ComputeFreeSpaceScore_IgnoresAFullDataDrive()
+    {
+        IReadOnlyList<FixedDriveService.FixedDrive> drives =
+        [
+            new(SystemDrive, "Windows", "NTFS", 500, 250, "", ""),
+            new("D:", "Archive", "NTFS", 4000, 1, "", "")
+        ];
+
+        Assert.Equal(100, HealthScoreService.ComputeFreeSpaceScore(drives, SystemDrive));
+    }
+
+    /// <summary>An unreadable system drive is unknown, not healthy.</summary>
+    /// <remarks>
+    /// The same rule every other component follows. <c>FixedDriveService.Enumerate</c> SKIPS a drive it cannot
+    /// read — a BitLocker-locked volume throws on <c>AvailableFreeSpace</c> — so an unreadable system drive
+    /// arrives here as an absence rather than an exception, and scoring an absence as 100 is exactly how the
+    /// disk component once reported "All SMART indicators healthy" for a machine it had never read.
+    /// </remarks>
+    [Theory]
+    [InlineData("D:")]    // enumerated drives exist, but not the system one
+    [InlineData("")]      // the system drive could not be determined
+    [InlineData(null)]
+    public void ComputeFreeSpaceScore_SystemDriveMissing_IsUnknownRatherThanHealthy(string? systemDrive)
+        => Assert.Equal(HealthScoreService.UnknownComponentScore,
+            HealthScoreService.ComputeFreeSpaceScore(ReadableSystemDrive(), systemDrive));
+
+    [Fact]
+    public void ComputeFreeSpaceScore_NoDrivesAtAll_IsUnknownRatherThanHealthy()
+    {
+        Assert.Equal(HealthScoreService.UnknownComponentScore,
+            HealthScoreService.ComputeFreeSpaceScore([], SystemDrive));
+        Assert.Equal(HealthScoreService.UnknownComponentScore,
+            HealthScoreService.ComputeFreeSpaceScore(null, SystemDrive));
+    }
+
+    /// <summary>A drive reporting zero size is not a measurement.</summary>
+    /// <remarks>
+    /// <c>SizeGB</c> is rounded to whole gigabytes, so a zero means either a drive too small to divide by or a
+    /// read that produced nothing. Dividing by it would produce infinity and the top band.
+    /// </remarks>
+    [Fact]
+    public void ComputeFreeSpaceScore_ZeroSizedDrive_IsUnknownRatherThanPerfect()
+        => Assert.Equal(HealthScoreService.UnknownComponentScore,
+            HealthScoreService.ComputeFreeSpaceScore(
+                [new(SystemDrive, SystemDrive, "NTFS", 0, 0, "", "")], SystemDrive));
+
+    /// <summary>The drive letter comparison ignores case.</summary>
+    [Fact]
+    public void ComputeFreeSpaceScore_MatchesTheDriveLetterCaseInsensitively()
+        => Assert.Equal(100, HealthScoreService.ComputeFreeSpaceScore(
+            [new("c:", "Windows", "NTFS", 500, 250, "", "")], "C:"));
+
+    /// <summary>
+    /// The system drive letter is derived, not assumed to be C:.
+    /// </summary>
+    /// <remarks>
+    /// Shaped like <c>FixedDrive.Letter</c> — a letter and a colon, no trailing separator — because the score
+    /// matches the two against each other. A trailing backslash here would silently match nothing and score
+    /// every machine "unknown".
+    /// </remarks>
+    [Fact]
+    public void SystemDriveLetter_IsALetterAndColonWithNoSeparator()
+    {
+        var letter = HealthScoreService.SystemDriveLetter();
+
+        Assert.NotNull(letter);
+        Assert.EndsWith(":", letter, StringComparison.Ordinal);
+        Assert.DoesNotContain('\\', letter);
+        Assert.DoesNotContain('/', letter);
+    }
+
+    /// <summary>
+    /// A full system drive cannot leave the overall score in a green band.
+    /// </summary>
+    /// <remarks>
+    /// The defect in one assertion. With every other component perfect, a nearly-full system drive has to pull
+    /// the total below "Excellent" (>= 90) and below "Good" (>= 80) — because before free space was a
+    /// component, this exact machine reported "Excellent".
+    /// <para>Goes through <see cref="HealthScoreService.Combine"/> rather than restating the weights, and that
+    /// distinction is the whole value of the test. An earlier version computed the total from literal weights
+    /// copied out of the service; a mutation that dropped free space back to a fifth — the very weighting this
+    /// test was written to reject — went GREEN against it, because the test was measuring its own copy.
+    /// <c>Combine</c> exists so there is one weighting and this reads it.</para>
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AFullSystemDrive_CannotScoreGreen(bool hasBattery)
+    {
+        const int perfect = 100;
+        var freeSpace = HealthScoreService.ComputeFreeSpaceScore(
+            [new(SystemDrive, SystemDrive, "NTFS", 500, 2, "", "")], SystemDrive);
+        Assert.Equal(10, freeSpace);   // the premise, not an assumption
+
+        var overall = HealthScoreService.Combine(
+            perfect, freeSpace, perfect, perfect, perfect, hasBattery);
+
+        Assert.True(overall < 90, $"a machine out of space still scored {overall}, which reads as Excellent");
+        Assert.True(overall < 80, $"a machine out of space still scored {overall}, which reads as Good");
+    }
+
+    /// <summary>Every component perfect scores exactly 100, on both arms.</summary>
+    /// <remarks>
+    /// Which is how the weights are proven to sum to one, through the code that uses them rather than through
+    /// a copy of them. Weights that do not sum to one silently rescale every score in the app, and the battery
+    /// arm redistributes so there are two sets to keep right — adding a fifth component is exactly when that
+    /// gets broken.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void EveryComponentPerfect_ScoresExactlyOneHundred(bool hasBattery)
+        => Assert.Equal(100, HealthScoreService.Combine(100, 100, 100, 100, 100, hasBattery));
+
+    /// <summary>Every component at zero scores zero, so no weight is silently negative or missing.</summary>
+    /// <remarks>
+    /// The other end of the same proof. Together with the 100 case this pins the weights to summing to exactly
+    /// one: a missing component would leave the perfect case below 100, and a duplicated one would push the
+    /// zero case above it.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void EveryComponentZero_ScoresZero(bool hasBattery)
+        => Assert.Equal(0, HealthScoreService.Combine(0, 0, 0, 0, 0, hasBattery));
+
+    /// <summary>Free space is weighted at least as heavily as any component except disk health.</summary>
+    /// <remarks>
+    /// Stated as an inequality between measured outputs rather than as a number, so it survives a re-balance
+    /// that keeps the intent. Feeding one component 0 and the rest 100 makes the drop equal to that
+    /// component's weight, which is how the ordering is read out of <c>Combine</c> without naming a single
+    /// weight here.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FreeSpace_WeighsAtLeastAsMuchAsRamUptimeAndBattery(bool hasBattery)
+    {
+        int Drop(int disk, int free, int ram, int uptime, int battery) =>
+            100 - HealthScoreService.Combine(disk, free, ram, uptime, battery, hasBattery);
+
+        var freeSpaceWeight = Drop(100, 0, 100, 100, 100);
+        var ramWeight = Drop(100, 100, 0, 100, 100);
+        var uptimeWeight = Drop(100, 100, 100, 0, 100);
+
+        Assert.True(freeSpaceWeight >= ramWeight,
+            $"free space moves the score by {freeSpaceWeight} and RAM by {ramWeight}; a full drive is the "
+            + "commonest real problem and the only one with a remedy in this app");
+        Assert.True(freeSpaceWeight >= uptimeWeight,
+            $"free space moves the score by {freeSpaceWeight} and uptime by {uptimeWeight}");
+
+        if (hasBattery)
+        {
+            var batteryWeight = Drop(100, 100, 100, 100, 0);
+            Assert.True(freeSpaceWeight >= batteryWeight,
+                $"free space moves the score by {freeSpaceWeight} and battery wear by {batteryWeight}");
+        }
+    }
+
+    /// <summary>An unreadable system drive is reported as unavailable, so a caller can say why.</summary>
+    [Fact]
+    public void UnavailableComponents_UnreadableSystemDrive_MarksFreeSpaceUnavailable()
+    {
+        Assert.Contains(HealthScoreService.FreeSpaceComponent,
+            HealthScoreService.UnavailableComponents(null, null, [], SystemDrive));
+
+        // And the negative half: a readable system drive is not reported unavailable, or the reason would be
+        // shown on every machine.
+        Assert.DoesNotContain(HealthScoreService.FreeSpaceComponent,
+            HealthScoreService.UnavailableComponents(null, null, ReadableSystemDrive(), SystemDrive));
+    }
+
+    /// <summary>A full DATA drive does not make free space unavailable, or unhealthy.</summary>
+    /// <remarks>
+    /// The rule here is "the system drive specifically", unlike the disk component's All-drives rule. A
+    /// BitLocker-locked data volume is skipped by the enumeration and changes nothing about how much room
+    /// Windows has, so reporting the component as unreadable because of it would be a false explanation.
+    /// </remarks>
+    [Fact]
+    public void UnavailableComponents_DataDriveMissing_LeavesFreeSpaceAvailable()
+    {
+        IReadOnlyList<FixedDriveService.FixedDrive> onlySystem =
+        [
+            new(SystemDrive, "Windows", "NTFS", 500, 250, "", "")
+        ];
+
+        Assert.DoesNotContain(HealthScoreService.FreeSpaceComponent,
+            HealthScoreService.UnavailableComponents(null, null, onlySystem, SystemDrive));
     }
 
     [Fact]

--- a/SysManager/SysManager/Models/HealthScoreResult.cs
+++ b/SysManager/SysManager/Models/HealthScoreResult.cs
@@ -39,6 +39,14 @@ public sealed record HealthScoreResult
 
     /// <summary>Individual component scores for breakdown display.</summary>
     public int DiskScore { get; init; } = 100;
+
+    /// <summary>How much room the system drive has left. 100 is comfortable, 10 is nearly full.</summary>
+    /// <remarks>
+    /// Added because the overall score could read "Excellent" on a machine that was out of space — SMART
+    /// healthy, RAM under 60% and a recent reboot were enough, and a full system drive is the commonest real
+    /// cause of "it got slow" as well as what breaks Windows Update and app installs.
+    /// </remarks>
+    public int FreeSpaceScore { get; init; } = 100;
     public int RamScore { get; init; } = 100;
     public int UptimeScore { get; init; } = 100;
     public int BatteryScore { get; init; } = 100;

--- a/SysManager/SysManager/Services/CliRunner.cs
+++ b/SysManager/SysManager/Services/CliRunner.cs
@@ -143,7 +143,10 @@ public sealed class CliRunner
             var svc = new HealthScoreService(new SystemInfoService(), new DiskHealthService(), new BatteryService());
             var r = await svc.ComputeAsync(ct).ConfigureAwait(false);
             return request.Json
-                ? new CliResult(CliResult.Ok, Json(new { score = r.Score, label = r.Label, disk = r.DiskScore, ram = r.RamScore, uptime = r.UptimeScore }))
+                // freeSpace is here because the score it feeds is not readable without it: a machine can
+                // report a low overall score with disk, ram and uptime all healthy, and the payload used to
+                // give a script no way to see why.
+                ? new CliResult(CliResult.Ok, Json(new { score = r.Score, label = r.Label, disk = r.DiskScore, freeSpace = r.FreeSpaceScore, ram = r.RamScore, uptime = r.UptimeScore }))
                 : new CliResult(CliResult.Ok, $"Health score: {r.Score}/100 ({r.Label})");
         }
         catch (Exception ex) when (ex is System.Management.ManagementException or InvalidOperationException)

--- a/SysManager/SysManager/Services/HealthScoreService.cs
+++ b/SysManager/SysManager/Services/HealthScoreService.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using Serilog;
 using SysManager.Models;
 
@@ -10,13 +11,23 @@ namespace SysManager.Services;
 /// <summary>
 /// Aggregates data from multiple services into a single 0–100 health score.
 /// Components weighted:
-///   - Disk health: 35%
-///   - RAM usage: 25%
-///   - Uptime: 20%
-///   - Battery wear: 20% (only on laptops; redistributed otherwise)
+///   - Disk health (SMART): 25%
+///   - Free space on the system drive: 25%
+///   - RAM usage: 20%
+///   - Uptime: 15%
+///   - Battery wear: 15% (only on laptops; redistributed otherwise, to 30/25/25/20)
 ///
 /// No admin required. Read-only queries only.
 /// </summary>
+/// <remarks>
+/// Free space was not a component until it had to be. Without it the score could read "Excellent" on a
+/// machine that was out of room — SMART healthy, RAM under 60% and a recent reboot were enough — which is the
+/// commonest real cause of "my laptop got slow" and the state that breaks Windows Update and app installs.
+/// A flagship number that is confidently wrong costs more trust than a missing feature.
+/// <para>Adding it moves every existing score: a machine that read 92 may now read less with nothing
+/// changed on it. That is the point, and the changelog says so rather than letting it look like a
+/// regression.</para>
+/// </remarks>
 public sealed class HealthScoreService
 {
     private readonly SystemInfoService _sysInfo;
@@ -65,40 +76,37 @@ public sealed class HealthScoreService
         catch (System.Runtime.InteropServices.COMException ex) { Log.Warning("HealthScore: battery WMI COM error: 0x{HResult:X8}", ex.HResult); }
         catch (InvalidOperationException ex) { Log.Warning("HealthScore: battery failed: {Error}", ex.Message); }
 
+        // Free space is read here rather than injected because FixedDriveService.Enumerate is static and
+        // needs no admin — the same shape as the other sources, and ComputeFreeSpaceScore below is pure so
+        // the bands stay testable without touching a real disk. It never throws: it skips a drive it cannot
+        // read and returns what it got.
+        IReadOnlyList<FixedDriveService.FixedDrive> drives = FixedDriveService.Enumerate();
+
         // Compute component scores
         int diskScore = ComputeDiskScore(disks);
+        int freeSpaceScore = ComputeFreeSpaceScore(drives, SystemDriveLetter());
         int ramScore = ComputeRamScore(snapshot);
         int uptimeScore = ComputeUptimeScore(snapshot);
         int batteryScore = ComputeBatteryScore(battery);
         bool hasBattery = battery?.HasBattery ?? false;
 
-        // Weighted average
-        int overall = hasBattery
-            ? (int)Math.Round(
-                diskScore * 0.35 +
-                ramScore * 0.25 +
-                uptimeScore * 0.20 +
-                batteryScore * 0.20)
-            : (int)Math.Round(
-                diskScore * 0.40 +
-                ramScore * 0.30 +
-                uptimeScore * 0.30);
-
-        overall = Math.Clamp(overall, 0, 100);
+        int overall = Combine(diskScore, freeSpaceScore, ramScore, uptimeScore, batteryScore, hasBattery);
 
         // Build recommendations
         var recommendations = BuildRecommendations(
-            diskScore, ramScore, uptimeScore, batteryScore, hasBattery, snapshot, disks, battery);
+            diskScore, freeSpaceScore, ramScore, uptimeScore, batteryScore, hasBattery,
+            snapshot, disks, battery, drives, SystemDriveLetter());
 
         // Recorded so a consumer can say "could not read this" instead of reading a verdict out of a
         // fallback number. The scores above already refuse to claim health; this is what makes the reason
         // visible.
-        var unavailable = UnavailableComponents(disks, snapshot);
+        var unavailable = UnavailableComponents(disks, snapshot, drives, SystemDriveLetter());
 
         return new HealthScoreResult
         {
             Score = overall,
             DiskScore = diskScore,
+            FreeSpaceScore = freeSpaceScore,
             RamScore = ramScore,
             UptimeScore = uptimeScore,
             BatteryScore = batteryScore,
@@ -129,10 +137,23 @@ public sealed class HealthScoreService
     /// the empty list, which is why that case is no longer spelled out.</para>
     /// </remarks>
     internal static List<string> UnavailableComponents(
-        IReadOnlyList<DiskHealthReport>? disks, SystemSnapshot? snapshot)
+        IReadOnlyList<DiskHealthReport>? disks, SystemSnapshot? snapshot,
+        IReadOnlyList<FixedDriveService.FixedDrive>? drives, string? systemDrive)
     {
         List<string> unavailable = [];
         if (disks is null || disks.All(d => d.HealthPercent is null)) unavailable.Add(DiskComponent);
+
+        // Free space is unavailable when the SYSTEM drive specifically could not be read, not when some
+        // drive could not: a BitLocker-locked data volume is skipped by the enumeration and changes nothing
+        // about how much room Windows has. The condition mirrors what ComputeFreeSpaceScore falls back on,
+        // so the score and the reason cannot disagree.
+        if (drives is null || string.IsNullOrWhiteSpace(systemDrive)
+            || !drives.Any(d => string.Equals(d.Letter, systemDrive, StringComparison.OrdinalIgnoreCase)
+                                && d.SizeGB > 0))
+        {
+            unavailable.Add(FreeSpaceComponent);
+        }
+
         if (snapshot is null)
         {
             unavailable.Add(MemoryComponent);
@@ -144,10 +165,42 @@ public sealed class HealthScoreService
 
     /// <summary>Component names used in <see cref="HealthScoreResult.UnavailableComponents"/>.</summary>
     internal const string DiskComponent = "Disk";
+    internal const string FreeSpaceComponent = "Free space";
     internal const string MemoryComponent = "Memory";
     internal const string UptimeComponent = "Uptime";
 
     // ── Component scoring ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Combines the component scores into the overall 0–100 figure.
+    /// </summary>
+    /// <remarks>
+    /// Free space carries a quarter, level with disk health, because it is the component most likely to be the
+    /// actual problem AND the only one on the list the user can fix today — with tabs this app already owns.
+    /// SMART wear and battery wear are real and have no remedy inside SysManager.
+    /// <para>A quarter is not a preference, it is the smallest weight that makes the arithmetic honest. A first
+    /// draft gave it a fifth, and <c>AFullSystemDrive_CannotScoreGreen</c> caught what that produces: with
+    /// every other component perfect, a drive at 99.6% full still totalled 82 on the battery arm, which
+    /// <see cref="HealthScoreResult.Label"/> reads as "Good". Escaping that band needs w × 90 &gt; 20, so
+    /// anything under 0.223 leaves the headline number able to call a machine that cannot install a Windows
+    /// update healthy — the exact defect free space was added to fix.</para>
+    /// <para><b>Pure and internal so the weights are testable.</b> They used to be inline here, and the tests
+    /// that cared about them re-stated them as literals — which meant changing the real weights failed
+    /// nothing. A mutation that dropped free space back to a fifth went green against those tests, and that is
+    /// why this method exists: there is now one copy of the weighting and everything reads it.</para>
+    /// <para>Every weight is a multiple of five, so the split stays legible when the battery arm
+    /// redistributes.</para>
+    /// </remarks>
+    internal static int Combine(
+        int diskScore, int freeSpaceScore, int ramScore, int uptimeScore, int batteryScore, bool hasBattery)
+    {
+        double total = hasBattery
+            ? diskScore * 0.25 + freeSpaceScore * 0.25 + ramScore * 0.20
+              + uptimeScore * 0.15 + batteryScore * 0.15
+            : diskScore * 0.30 + freeSpaceScore * 0.25 + ramScore * 0.25 + uptimeScore * 0.20;
+
+        return Math.Clamp((int)Math.Round(total), 0, 100);
+    }
 
     /// <summary>The score for a health component whose source produced nothing at all.</summary>
     /// <remarks>
@@ -184,6 +237,84 @@ public sealed class HealthScoreService
         // reaches it", which was how the contradiction survived.
         int worstScore = disks.Select(d => d.HealthPercent ?? UnknownComponentScore).Min();
         return Math.Clamp(worstScore, 0, 100);
+    }
+
+    /// <summary>
+    /// Scores how much room the SYSTEM drive has left. 100 is comfortable, 10 is nearly full.
+    /// </summary>
+    /// <remarks>
+    /// The component the score was missing, and the reason it could read "Excellent" on a machine that was
+    /// out of space — the single most common real cause of "my laptop got slow", and the state that actually
+    /// breaks Windows Update and app installs. SMART healthy, RAM under 60% and a recent reboot were enough.
+    /// <para><b>The system drive only.</b> A full data drive does not slow Windows down; a full C: does. Left
+    /// as every-drive it would report a machine as unhealthy for a deliberately-packed archive disk, which is
+    /// noise the persona cannot act on.</para>
+    /// <para><b>Percent and absolute, because each is wrong alone.</b> Percent punishes a large disk — 10% of
+    /// 4 TB is 400 GB and nothing whatever is wrong. Absolute excuses a nearly-full small one — 20 GB free is
+    /// comfortable on a 128 GB laptop and nearly empty on a 4 TB archive. So a generous ABSOLUTE amount only
+    /// ever raises the percentage verdict, and a hard floor only ever lowers it: Windows needs room to work
+    /// regardless of how big the disk is, because a feature update stages around 20 GB and the page file and
+    /// temp grow into whatever is left. Below that floor no percentage makes the machine healthy.</para>
+    /// <para>The drive letter is a parameter rather than read from the environment, so the bands are testable
+    /// without depending on which drive this machine boots from — the same reason the other scorers take
+    /// their evidence as an argument.</para>
+    /// </remarks>
+    internal static int ComputeFreeSpaceScore(IReadOnlyList<FixedDriveService.FixedDrive>? drives, string? systemDrive)
+    {
+        // Same rule as every other component: absent evidence is not a clean bill of health.
+        // FixedDriveService.Enumerate skips a drive it cannot read — a BitLocker-locked volume throws on
+        // AvailableFreeSpace — so an unreadable system drive arrives here as an absence, not an exception.
+        if (drives is null || drives.Count == 0 || string.IsNullOrWhiteSpace(systemDrive))
+            return UnknownComponentScore;
+
+        var drive = drives.FirstOrDefault(d =>
+            string.Equals(d.Letter, systemDrive, StringComparison.OrdinalIgnoreCase));
+
+        // SizeGB is rounded to whole gigabytes, so a zero here means either no such drive or one too small
+        // to divide by. Neither is a measurement.
+        if (drive is null || drive.SizeGB <= 0) return UnknownComponentScore;
+
+        var percentFree = drive.FreeGB / drive.SizeGB * 100;
+
+        var byPercent = percentFree switch
+        {
+            >= 20 => 100,
+            >= 15 => 80,
+            >= 10 => 55,
+            >= 5 => 25,
+            _ => 10
+        };
+
+        // Raises only. Below 25 GB it has no opinion and the percentage decides.
+        var byAbsolute = drive.FreeGB switch
+        {
+            >= 50 => 100,
+            >= 25 => 80,
+            _ => 0
+        };
+
+        var score = Math.Max(byPercent, byAbsolute);
+
+        // Lowers only, and it is what stops a small disk being called healthy for having a healthy
+        // percentage: 9 GB free on a 40 GB drive is 22% and still not enough for Windows to update itself.
+        if (drive.FreeGB < 20) score = Math.Min(score, 55);
+        if (drive.FreeGB < 10) score = Math.Min(score, 25);
+
+        return Math.Clamp(score, 0, 100);
+    }
+
+    /// <summary>
+    /// The drive Windows is installed on, as a letter with a colon and no separator — the shape
+    /// <see cref="FixedDriveService.FixedDrive.Letter"/> uses.
+    /// </summary>
+    /// <remarks>
+    /// Derived rather than assumed to be C:. Returns null if it cannot be determined, which
+    /// <see cref="ComputeFreeSpaceScore"/> treats as "not measured" rather than guessing a letter.
+    /// </remarks>
+    internal static string? SystemDriveLetter()
+    {
+        var root = Path.GetPathRoot(Environment.SystemDirectory);
+        return string.IsNullOrWhiteSpace(root) ? null : root.TrimEnd('\\', '/');
     }
 
     internal static int ComputeRamScore(SystemSnapshot? snapshot)
@@ -245,11 +376,29 @@ public sealed class HealthScoreService
     // ── Recommendations ────────────────────────────────────────────────
 
     private static List<HealthRecommendation> BuildRecommendations(
-        int diskScore, int ramScore, int uptimeScore, int batteryScore,
+        int diskScore, int freeSpaceScore, int ramScore, int uptimeScore, int batteryScore,
         bool hasBattery, SystemSnapshot? snapshot,
-        IReadOnlyList<DiskHealthReport>? disks, BatteryInfo? battery)
+        IReadOnlyList<DiskHealthReport>? disks, BatteryInfo? battery,
+        IReadOnlyList<FixedDriveService.FixedDrive>? drives, string? systemDrive)
     {
         List<HealthRecommendation> recs = [];
+
+        // Free space FIRST, because only three recommendations are returned and this is the one the user can
+        // act on today — with a tab this app already owns. A worn battery and a degrading disk are real, and
+        // neither has a fix inside SysManager; a full drive does.
+        if (freeSpaceScore < 80 && drives is not null)
+        {
+            var drive = drives.FirstOrDefault(d =>
+                string.Equals(d.Letter, systemDrive, StringComparison.OrdinalIgnoreCase));
+            if (drive is not null)
+            {
+                recs.Add(new HealthRecommendation
+                {
+                    Message = $"Only {drive.FreeGB:0} GB free on {drive.Letter} — Deep Cleanup can reclaim space",
+                    Severity = freeSpaceScore <= 25 ? "critical" : "warning"
+                });
+            }
+        }
 
         // Uptime
         if (uptimeScore <= 70 && snapshot is not null)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.77.2</Version>
-    <FileVersion>1.77.2.0</FileVersion>
-    <AssemblyVersion>1.77.2.0</AssemblyVersion>
+    <Version>1.78.0</Version>
+    <FileVersion>1.78.0.0</FileVersion>
+    <AssemblyVersion>1.78.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
`ComputeAsync` weighted four components — disk SMART 35%, RAM 25%, uptime 20%, battery wear 20% — and free space was not one of them. Grepping `AvailableFreeSpace|FreeGB` finds it in `FixedDriveService` and four view models, and never in `HealthScoreService`.

So a machine with a 99%-full system drive scored **"Excellent"**, as long as SMART was healthy, RAM was under 60% and it had been rebooted recently.

That is the single most common real cause of "my laptop got slow", and the state that actually stops Windows Update and app installs. A flagship number that is confidently wrong costs more trust than a missing feature would.

## The new component

`ComputeFreeSpaceScore` joins the other pure component scorers. No new data source and no admin: `FixedDriveService.Enumerate` is static, already returns `FreeGB`/`SizeGB` per fixed volume, and **skips** a drive it cannot read rather than throwing — so a BitLocker-locked volume arrives as an absence. An absence scores the same deliberate `80` the other components use for their unknowns, never 100, because "never read" is not "healthy". `UnavailableComponents` gains `"Free space"` so a caller can say which it was.

Three rules, and each is wrong without the others:

| rule | direction | why |
|---|---|---|
| percent of the system drive | the baseline | banded like the existing scorers |
| a generous **absolute** amount | raises | 400 GB free on 4 TB is 10%, which percent alone calls 55 — "needs attention" on a machine with nothing wrong |
| a hard **floor** at 20 GB / 10 GB | lowers | 9 GB free on a 40 GB drive is 22%, the *top* percentage band, and still not enough for Windows to stage a feature update |

The **system drive only**, derived from `Environment.SystemDirectory` rather than assumed to be C:. A deliberately packed archive drive does not slow Windows down, and reporting a machine unhealthy for a disk its owner filled on purpose is noise the persona cannot act on.

The recommendation goes **first**, because only three are returned and this is the only one with a remedy inside the app: *"Only 4 GB free on C: — Deep Cleanup can reclaim space"*. A worn battery and an ageing disk are real and SysManager cannot fix either.

## Two things my own tests found

**1. A fifth was not enough weight.** The first draft gave free space `0.20`, and `AFullSystemDrive_CannotScoreGreen` caught the consequence: with every other component perfect, a drive at 99.6% full still totalled **82** on the battery arm, which `Label` reads as "Good". Escaping that band needs `w × 90 > 20`, so anything under `0.223` leaves the headline number able to call a machine that cannot install a Windows update healthy — the exact defect the component was added to fix.

Weights are now `25/25/20/15/15` with a battery, `30/25/25/20` without.

**2. The weights were untestable, and the tests that thought they covered them did not.** They restated the weights as literals, so mutation R5 — dropping free space back to a fifth, the very weighting the test exists to reject — came back **GREEN**. The aggregation is now `Combine()`, pure and internal, with one copy of the weighting that both `ComputeAsync` and the tests read. R5 reds it properly, and two new tests pin the weights to summing to exactly one through the live path (every component perfect → 100, every component zero → 0) instead of through a copy.

## Red/green

| | mutation | result |
|---|---|---|
| | baseline | 24 green, 0 red |
| R1 | `ComputeFreeSpaceScore` → always 100 | **RED** 11 reds — this is the state before the change |
| R2 | drop the absolute override | **RED** 400 GB on 4 TB scores 55 |
| R3 | drop the hard floor | **RED** 9 GB on 40 GB scores 100 |
| R4 | score the emptiest drive, not the system one | **RED** a full data drive drags the score to 10 |
| R5 | weights → free space back to a fifth | **RED** *"still scored 82, which reads as Good"* |
| | restored, sha verified, rebuilt | 24 green, 0 red |

## Verification

- Four projects build **0 errors, 0 warnings**.
- The 48 `HealthScoreService` unit tests: **76 green** (theories expanded), 0 red.
- **107 of 108** guards green. The single red is `EverySourceFile_CarriesTheAuthorHeader` flagging the throwaway local runner, which is not in the repository.
- `dotnet format --verify-no-changes` clean; leak scan 43 patterns over 8 files, its two hits the Windows assistant privacy toggle in lines this change does not touch.

**No UI change.** Nothing renders the component breakdown — grepped, only `DiskScore` is consumed, for SMART classification — so the score number and the recommendation list are the only visible surfaces and both already exist. `--health --json` gains `freeSpace`, because a script could otherwise see a low score with disk, ram and uptime all healthy and no way to tell why.

README's Health Score entry and SECURITY.md's supported line are updated, and the class doc that carried the old weights now carries the new ones.

## Worth saying plainly

Every existing user's score moves. A machine that read 92 yesterday may read less today with nothing changed on it. That is the new component being counted rather than a fault appearing, the changelog says so in those words, and the Dashboard recommendation explains any drop.

Closes #1572.
