### PR TITLE
fix: opening a PowerShell runspace had no time limit, so a wedged host froze the tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.78.1] - 2026-09-07
+
+A tab that uses Windows PowerShell can no longer sit "working…" forever. If the PowerShell host on your PC
+cannot start — wedged, blocked by policy, or simply out of room to run another one — SysManager now gives up
+after a minute and tells you, instead of waiting for something that is never going to answer.
+
+### Fixed
+- **A stuck PowerShell host no longer freezes the tab that needed it.** Windows Update, System Health and
+  System Fixes all start a PowerShell session when you run them as administrator. Starting one had no time
+  limit, so if it never finished starting, the tab stayed busy — and because Cancel and Refresh are only
+  enabled when a tab is *not* busy, there was nothing left to press. It now fails the same way it already did
+  when PowerShell is missing entirely, which is a message rather than a spinner.
+
+### Added
+- **A test that a PowerShell session which never starts is abandoned rather than waited on.** It uses a
+  stand-in that deliberately never finishes, so the check is instant and cannot become flaky.
+
 ## [1.78.0] - 2026-09-07
 
 The health score now counts how much room is left on your Windows drive, and that will change the number you

--- a/SysManager/SysManager.Tests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.Tests/PowerShellRunnerTests.cs
@@ -224,6 +224,87 @@ public class PowerShellRunnerTests
         Assert.Equal(["process instance", "process"], order);
     }
 
+    /// <summary>
+    /// An open that never completes fails, rather than waiting forever.
+    /// </summary>
+    /// <remarks>
+    /// <c>Runspace.Open()</c> takes neither a token nor a timeout, so nothing inside it can be asked to stop.
+    /// Before this, a host that could not complete a handshake produced no exception and no return — a hang
+    /// dump from the integration job showed 275 threads parked in <c>RemoteRunspace.Open</c> (#2149). The
+    /// surrounding code is carefully fail-closed and maps transport, Win32 and file-not-found failures onto a
+    /// "PowerShell host unavailable" state, but that mapping only fires on a THROW; a wait that never signals
+    /// slips past all of it, and the user gets a tab that stays busy with Cancel gated on not-busy.
+    /// <para>Deterministic, and no sleeping: the stub returns a task that is never completed, and the timeout
+    /// is injected at 50 ms. Against the unbounded code this test does not fail — it never finishes, which is
+    /// the defect stated as precisely as a test can state it.</para>
+    /// <para><see cref="RuntimeException"/> on purpose, matching its neighbours: callers already map that type
+    /// onto their unavailable/failed states, so a timeout arrives as "PowerShell is not available" rather than
+    /// as an unhandled fault of a novel type.</para>
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_OpenThatNeverCompletes_TimesOutInsteadOfHanging()
+    {
+        var runspace = RunspaceFactory.CreateRunspace(InitialSessionState.Create());
+        var neverCompletes = new TaskCompletionSource();
+        var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            openRunspace: _ => neverCompletes.Task,
+            createRunspace: () => (runspace, null, null),
+            openRunspaceTimeout: TimeSpan.FromMilliseconds(50));
+
+        var ex = await Assert.ThrowsAsync<RuntimeException>(
+            () => runner.RunAsync("'never-runs'"));
+
+        Assert.Contains("did not become ready", ex.Message, StringComparison.Ordinal);
+        Assert.IsType<TimeoutException>(ex.InnerException);
+    }
+
+    /// <summary>
+    /// The timeout applies whether or not the session is elevated.
+    /// </summary>
+    /// <remarks>
+    /// The exception MAPPING beside it is gated on <c>_isElevated</c>, because only the elevated path uses an
+    /// out-of-process host whose failures need translating. The timeout is not, and this asserts that: the
+    /// out-of-process path is where a hang has been observed, but an unbounded wait is the wrong behaviour on
+    /// either path, and gating it would leave the in-process one with no answer at all.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task RunAsync_OpenTimeout_AppliesRegardlessOfElevation(bool isElevated)
+    {
+        var runspace = RunspaceFactory.CreateRunspace(InitialSessionState.Create());
+        var neverCompletes = new TaskCompletionSource();
+        var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            isElevated: () => isElevated,
+            trustedPowerShellModulePath:
+                @"C:\Program Files\WindowsPowerShell\Modules;" +
+                @"C:\Windows\System32\WindowsPowerShell\v1.0\Modules",
+            openRunspace: _ => neverCompletes.Task,
+            createRunspace: () => (runspace, null, null),
+            openRunspaceTimeout: TimeSpan.FromMilliseconds(50));
+
+        var ex = await Assert.ThrowsAsync<RuntimeException>(
+            () => runner.RunAsync("'never-runs'"));
+
+        Assert.IsType<TimeoutException>(ex.InnerException);
+    }
+
+    /// <summary>The shipped timeout is generous enough not to fire on a slow cold start.</summary>
+    /// <remarks>
+    /// The value is the whole risk in this change: too tight and it breaks a working feature on a slow machine,
+    /// which is worse than the hang it replaces. Asserted as a floor rather than an exact number so it can be
+    /// raised without editing a test, and never lowered past the point where a cold <c>powershell.exe</c> start
+    /// plus a handshake could plausibly still be in progress.
+    /// </remarks>
+    [Fact]
+    public void DefaultOpenRunspaceTimeout_IsGenerousEnoughForAColdStart()
+        => Assert.True(PowerShellRunner.DefaultOpenRunspaceTimeout >= TimeSpan.FromSeconds(30),
+            $"the open timeout is {PowerShellRunner.DefaultOpenRunspaceTimeout.TotalSeconds:0}s; a cold "
+            + "powershell.exe start and handshake on a slow machine can take longer than that, and a timeout "
+            + "that fires on a working host is worse than the hang it replaces");
+
     [Fact]
     public void DisposeRunspaceResources_DisposesInDependencyOrder()
     {

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -29,6 +29,7 @@ public sealed class PowerShellRunner : IPowerShellRunner
     private readonly Func<System.Diagnostics.Process, CancellationToken, Task> _waitForProcessExit;
     private readonly Action<System.Diagnostics.Process> _terminateProcessTree;
     private readonly Func<Runspace, Task> _openRunspace;
+    private readonly TimeSpan _openRunspaceTimeout;
     private readonly Func<(Runspace Runspace, IDisposable? ProcessInstance, IDisposable? Process)> _createRunspace;
     private readonly bool _isElevated;
     private readonly string _trustedPowerShellModulePath;
@@ -45,7 +46,8 @@ public sealed class PowerShellRunner : IPowerShellRunner
         Func<bool>? isElevated = null,
         string? trustedPowerShellModulePath = null,
         Func<Runspace, Task>? openRunspace = null,
-        Func<(Runspace Runspace, IDisposable? ProcessInstance, IDisposable? Process)>? createRunspace = null)
+        Func<(Runspace Runspace, IDisposable? ProcessInstance, IDisposable? Process)>? createRunspace = null,
+        TimeSpan? openRunspaceTimeout = null)
     {
         _scheduleProcessStart = scheduleProcessStart
             ?? throw new ArgumentNullException(nameof(scheduleProcessStart));
@@ -55,6 +57,7 @@ public sealed class PowerShellRunner : IPowerShellRunner
             ?? (static process => process.Kill(entireProcessTree: true));
         _openRunspace = openRunspace
             ?? (static runspace => Task.Run(() => runspace.Open()));
+        _openRunspaceTimeout = openRunspaceTimeout ?? DefaultOpenRunspaceTimeout;
 
         var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
         _isElevated = (isElevated ?? Helpers.AdminHelper.IsElevated)();
@@ -573,11 +576,43 @@ public sealed class PowerShellRunner : IPowerShellRunner
         }
     }
 
+    /// <summary>
+    /// How long to wait for a runspace to become ready before giving up on it.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately generous rather than tight. Opening the elevated runspace starts a <c>powershell.exe</c>
+    /// 5.1 child and completes a handshake with it, and a cold start on a slow or busy machine is legitimately
+    /// slow — a timeout that fired on that would turn a working feature into a broken one, which is worse than
+    /// the defect it fixes. What it has to beat is not "slow", it is "never".
+    /// <para>A hang dump from the integration job showed <b>275 threads</b> parked in
+    /// <c>RemoteRunspace.Open</c> on a host saturated with leaked runspaces (#2149), and <c>Open()</c> takes no
+    /// timeout of its own. Sixty seconds turns a permanently busy tab into an error the existing
+    /// unavailable-host handling already knows how to show.</para>
+    /// </remarks>
+    internal static readonly TimeSpan DefaultOpenRunspaceTimeout = TimeSpan.FromSeconds(60);
+
     private async Task OpenRunspaceAsync(Runspace runspace)
     {
         try
         {
-            await _openRunspace(runspace).ConfigureAwait(false);
+            // WaitAsync rather than a token passed inward: Open() offers neither cancellation nor a timeout
+            // of its own, so there is nothing to hand it. This bounds the WAIT, not the work — the open may
+            // still be in flight when we give up, and the caller's `using` disposes the runspace either way.
+            await _openRunspace(runspace).WaitAsync(_openRunspaceTimeout).ConfigureAwait(false);
+        }
+        catch (TimeoutException ex)
+        {
+            // NOT gated on _isElevated, unlike the mapping below. The out-of-process path is elevated-only, so
+            // that is where a hang has actually been observed — but an unbounded wait is the wrong behaviour
+            // either way, and gating this would leave the in-process path with no answer at all.
+            //
+            // Thrown as RuntimeException like its neighbour, because callers already map that onto their
+            // established unavailable/failed states. A timeout that surfaced as a novel exception type would
+            // reach them as an unhandled fault instead of as "PowerShell is not available".
+            throw new RuntimeException(
+                $"Windows PowerShell did not become ready within {_openRunspaceTimeout.TotalSeconds:0} "
+                + "seconds and the request was abandoned.",
+                ex);
         }
         catch (Exception ex) when (_isElevated && IsPowerShellHostUnavailable(ex))
         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.78.0</Version>
-    <FileVersion>1.78.0.0</FileVersion>
-    <AssemblyVersion>1.78.0.0</AssemblyVersion>
+    <Version>1.78.1</Version>
+    <FileVersion>1.78.1.0</FileVersion>
+    <AssemblyVersion>1.78.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
`Runspace.Open()` takes neither a cancellation token nor a timeout, so nothing inside it can be asked to stop. `OpenRunspaceAsync` awaited it bare.

That makes the surrounding code's careful fail-closed design unreachable in one specific case. It maps `PSRemotingTransportException`, `PSInvalidOperationException`, `Win32Exception`, `FileNotFoundException` and `UnauthorizedAccessException` onto a "PowerShell host unavailable" state — and every one of those fires on a **throw**. A host that cannot complete a handshake throws nothing. It returns nothing. The await never resumes.

For the user that is a tab stuck on "working..." with no way out, because Cancel and Refresh are both gated on not-busy.

**Not hypothetical.** A hang dump from the integration job added in #2131, on its first executions, showed **275 threads** parked in:

```
System.Management.Automation.RemoteRunspace.Open
System.Management.Automation.Runspaces.AsyncResult.EndInvoke
System.Threading.WaitHandle.WaitMultiple
```

on a host saturated by ~276 leaked out-of-process runspaces. That leak is #2149(a) and is untouched here. This is **(b)**, and it is the half worth doing first because it caps the damage from the leak rather than depending on the leak being fixed.

## The change

The wait is bounded with `WaitAsync` rather than by passing a token inward, because there is no token to pass. That bounds the **wait**, not the work: the open may still be in flight when we give up, and the caller's `using` disposes the runspace either way.

**Sixty seconds, and the value is the whole risk in this change.** Opening the elevated runspace starts a `powershell.exe` 5.1 child and completes a handshake with it, and a cold start on a slow or busy machine is legitimately slow. A timeout that fired on that would turn a working feature into a broken one, which is worse than the defect. What it has to beat is not "slow", it is "never". `DefaultOpenRunspaceTimeout_IsGenerousEnoughForAColdStart` asserts it as a **floor**, so it can be raised without editing a test and cannot be quietly lowered.

The timeout arm is deliberately **not** gated on `_isElevated`, unlike the mapping beside it. Only the elevated path uses an out-of-process host whose failures need translating, and that is where the hang was observed — but an unbounded wait is wrong on either path, and gating it would leave the in-process path with no answer at all. Asserted both ways.

Thrown as `RuntimeException` like its neighbour, because callers already map that type onto their established unavailable/failed states. A timeout surfacing as a novel exception type would reach them as an unhandled fault instead of as "PowerShell is not available".

## Red/green

S1 is the one that matters, and its red is a **hang** — the defect stated as precisely as a test can state it.

| | mutation | result |
|---|---|---|
| | baseline | 5 green, 0 red |
| S1 | remove the `WaitAsync` bound | **RED (HUNG)** never returned in 60s |
| S2 | gate the timeout arm on `_isElevated` | **RED** on the unelevated row: a bare `TimeoutException` reaches the caller instead of `RuntimeException` |
| S3 | lower the shipped timeout to 5 seconds | **RED** on the floor |
| | restored, sha verified, rebuilt | 5 green, 0 red |

Deterministic and instant: the stub returns a task that is never completed and the timeout is injected at 50 ms, so there is no sleeping and nothing to go flaky. Against the unbounded code the test does not fail — it never finishes.

## Verification

- Four projects build **0 errors, 0 warnings**.
- The 28 `PowerShellRunner` tests: **43 green** (theories expanded).
- **107 of 108** guards green. The single red is `EverySourceFile_CarriesTheAuthorHeader` flagging the throwaway local runner, which is not in the repository.
- `dotnet format --verify-no-changes` clean; leak scan 43 patterns over 4 files, its one hit the Windows assistant privacy toggle in a historical changelog line.

Part of #2149. The runspace leak (a) is deliberately left for its own change: it is a lifecycle change in a privileged path and wants its own review.
