### PR TITLE
fix: the elevated runspace's powershell.exe outlived it, and every leftover held threads open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.78.2] - 2026-09-08
+
+Running SysManager as administrator left a hidden `powershell.exe` behind every time a feature used one. They
+were invisible, they never went away on their own, and each one held a few threads open inside SysManager. A
+long session with a lot of Windows Update or disk-health checks accumulated them.
+
+### Fixed
+- **The helper SysManager starts for administrator tasks is now actually stopped when the task ends.** It was
+  being let go of rather than closed — the difference being that letting go of something does not end it. Each
+  leftover kept its output pipes open, which kept threads inside SysManager waiting on them for nothing. In a
+  test run that used PowerShell hundreds of times, this left roughly 276 of them alive at once and over a
+  thousand stuck threads, until the run could no longer make progress.
+
+### Added
+- **A test that starts a real background process and proves the cleanup stops it.** Written the awkward way on
+  purpose: the first two versions passed against code that did no cleanup at all, once because the stand-in
+  process was dying for an unrelated reason and once because the test never went through the real code path.
+
 ## [1.78.1] - 2026-09-07
 
 A tab that uses Windows PowerShell can no longer sit "working…" forever. If the PowerShell host on your PC

--- a/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
@@ -11,6 +11,74 @@ namespace SysManager.IntegrationTests;
 [Collection("Network")]
 public class PowerShellRunnerTests
 {
+    /// <summary>
+    /// A run's teardown STOPS the child process the runspace was built with, rather than only dropping its
+    /// handle.
+    /// </summary>
+    /// <remarks>
+    /// #2149(a), end to end through <c>RunAsync</c>. Disposing a <see cref="System.Diagnostics.Process"/>
+    /// releases the HANDLE and does not stop the process. When <c>powershell.exe</c> outlived its runspace, its
+    /// stdout and stderr pipes stayed open and the remoting transport's reader threads stayed blocked in
+    /// <c>ReadFile</c> forever — a hang dump from the integration job showed 1,112 such threads, about four per
+    /// runspace, so roughly 276 children still alive in a single test host.
+    /// <para><b>Through RunAsync, not by invoking the release directly.</b> An earlier version called the
+    /// private method by reflection, which proved what the method does and nothing about whether the production
+    /// path uses it — a mutation that handed teardown a bare <c>Dispose</c> instead left it green. Injecting the
+    /// child through the <c>createRunspace</c> seam and letting <c>RunAsync</c> tear it down is what closes
+    /// that: it covers the wiring and the behaviour in one assertion.</para>
+    /// <para>An in-process runspace is used, so the run itself needs no elevation; the child injected beside it
+    /// stands in for the <c>powershell.exe</c> the elevated path would have started.</para>
+    /// <para><b>Nothing is redirected, and that is load-bearing.</b> The first stand-in was <c>cmd /c pause</c>
+    /// with redirected stdin, and it made the test undiscriminating: disposing the <c>Process</c> closes its
+    /// redirected handles, <c>pause</c> saw EOF, and the child exited on its own — so a mutation that removed
+    /// the termination entirely still left this GREEN. With no redirected handles, disposing the object cannot
+    /// touch the process and only an actual kill ends it. A loopback ping is the delay: ~59 seconds against a
+    /// 10-second wait, almost no CPU, and no traffic leaves the machine. It also runs as <c>cmd</c> → <c>ping</c>,
+    /// so the tree kill is exercised rather than a single process.</para>
+    /// <para>Observed through a SECOND handle to the same process: teardown disposes the one it is given, and
+    /// querying that afterwards throws "No process is associated with this object", which says nothing about
+    /// whether the process died. The independent handle lets <c>WaitForExitAsync</c> be awaited rather than
+    /// polled, so there is no sleeping and nothing to go flaky.</para>
+    /// </remarks>
+    [Fact]
+    public async Task RunspaceTeardown_StopsTheChildTheRunspaceWasBuiltWith()
+    {
+        var child = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(
+            "cmd.exe", "/c ping -n 60 127.0.0.1 > nul")
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true
+        })!;
+
+        using var observer = System.Diagnostics.Process.GetProcessById(child.Id);
+
+        try
+        {
+            Assert.False(observer.HasExited);   // the premise, not an assumption
+
+            var runspace = System.Management.Automation.Runspaces.RunspaceFactory.CreateRunspace(
+                System.Management.Automation.Runspaces.InitialSessionState.CreateDefault2());
+            var runner = new PowerShellRunner(
+                action => Task.Run(action),
+                createRunspace: () => (runspace, null, child));
+
+            var result = await runner.RunAsync("2 + 2");
+            Assert.Equal(4, (int)result[0].BaseObject);   // the run really happened, so teardown really ran
+
+            using var bounded = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await observer.WaitForExitAsync(bounded.Token);
+
+            Assert.True(observer.HasExited,
+                "the child process outlived the run; its pipes stay open and the remoting transport's "
+                + "reader threads stay blocked on them forever");
+        }
+        finally
+        {
+            try { if (!observer.HasExited) observer.Kill(entireProcessTree: true); }
+            catch (InvalidOperationException) { /* already gone, which is the expected outcome */ }
+        }
+    }
+
     [Fact]
     public async Task RunAsync_SimpleExpression_ReturnsResult()
     {

--- a/SysManager/SysManager.Tests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.Tests/PowerShellRunnerTests.cs
@@ -305,6 +305,42 @@ public class PowerShellRunnerTests
             + "powershell.exe start and handshake on a slow machine can take longer than that, and a timeout "
             + "that fires on a working host is worse than the hang it replaces");
 
+    /// <summary>
+    /// The release action runs after the runspace and the process instance, not before them.
+    /// </summary>
+    /// <remarks>
+    /// Ordering only. An earlier version of this test claimed to prove the WIRING — that the production path
+    /// hands teardown <c>ReleaseProcess</c> rather than a bare <c>Dispose</c> — and it did not: it called
+    /// <c>DisposeRunspaceResources</c> directly with its own lambda, so mutating what <c>RunspaceResources</c>
+    /// passes left it green. It was asserting that the method honours its own argument, which is trivially
+    /// true. Renamed to what it actually covers.
+    /// <para>The wiring is proven end to end by
+    /// <c>PowerShellRunnerTests.RunspaceTeardown_StopsTheChildTheRunspaceWasBuiltWith</c> in
+    /// <c>SysManager.IntegrationTests</c>, which injects a real live child and asserts <c>RunAsync</c>'s
+    /// teardown killed it. That needs a real process, because the decision is
+    /// <c>is Process &amp;&amp; !HasExited</c> and no double satisfies it.</para>
+    /// </remarks>
+    [Fact]
+    public void DisposeRunspaceResources_ReleasesTheChildLast()
+    {
+        var order = new List<string>();
+        var runspace = new RecordingDisposable("runspace", order);
+        var processInstance = new RecordingDisposable("process instance", order);
+        var process = new RecordingDisposable("process", order);
+
+        PowerShellRunner.DisposeRunspaceResources(
+            runspace,
+            processInstance,
+            process,
+            releaseProcess: p =>
+            {
+                order.Add("released");
+                p?.Dispose();
+            });
+
+        Assert.Equal(["runspace", "process instance", "released", "process"], order);
+    }
+
     [Fact]
     public void DisposeRunspaceResources_DisposesInDependencyOrder()
     {

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -5,6 +5,7 @@
 using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
+using Serilog;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -558,8 +559,10 @@ public sealed class PowerShellRunner : IPowerShellRunner
         }
         finally
         {
+            // The runspace was never created, so the child started above has nothing to serve. Stop it rather
+            // than only dropping the handle — an orphan here keeps its pipes open exactly like a leaked one.
             if (runspace is null)
-                DisposeRunspaceResources(null, processInstance, process);
+                DisposeRunspaceResources(null, processInstance, process, ReleaseProcess);
         }
     }
 
@@ -568,7 +571,7 @@ public sealed class PowerShellRunner : IPowerShellRunner
         try
         {
             var (runspace, processInstance, process) = _createRunspace();
-            return new RunspaceResources(runspace, processInstance, process);
+            return new RunspaceResources(runspace, processInstance, process, ReleaseProcess);
         }
         catch (Exception ex) when (_isElevated && IsPowerShellHostUnavailable(ex))
         {
@@ -640,10 +643,29 @@ public sealed class PowerShellRunner : IPowerShellRunner
             "Windows PowerShell 5.1 is unavailable or blocked by system policy.",
             innerException);
 
+    /// <summary>
+    /// Tears down a runspace and the child process behind it, in dependency order.
+    /// </summary>
+    /// <param name="releaseProcess">
+    /// How to release the child. Defaults to disposing the handle, which is all this used to do; the elevated
+    /// path passes <see cref="ReleaseProcess"/>, which also stops a child that is still running.
+    /// </param>
+    /// <remarks>
+    /// Disposing a <see cref="System.Diagnostics.Process"/> releases the HANDLE and does not stop the process.
+    /// That is the whole of the leak in #2149: when <c>powershell.exe</c> outlived the runspace, its stdout and
+    /// stderr pipes stayed open, and the remoting transport's reader threads stayed blocked in <c>ReadFile</c>
+    /// forever. A hang dump from the integration job showed 1,112 such threads — about four per runspace, so
+    /// roughly 276 children still alive in one process.
+    /// <para>Closing the runspace before disposing it is deliberately NOT done here. It is the obvious next
+    /// idea and it carries a real risk: 275 of those runspaces were parked inside <c>Open()</c>, and
+    /// <c>Close()</c> on a runspace that never finished opening can block on the same handshake. Stopping the
+    /// child is what actually frees the threads, and it cannot block on the runspace's state.</para>
+    /// </remarks>
     internal static void DisposeRunspaceResources(
         IDisposable? runspace,
         IDisposable? processInstance,
-        IDisposable? process)
+        IDisposable? process,
+        Action<IDisposable?>? releaseProcess = null)
     {
         try
         {
@@ -657,8 +679,44 @@ public sealed class PowerShellRunner : IPowerShellRunner
             }
             finally
             {
-                process?.Dispose();
+                (releaseProcess ?? (static p => p?.Dispose()))(process);
             }
+        }
+    }
+
+    /// <summary>
+    /// Stops the child process behind an out-of-process runspace if it is still running, then disposes the
+    /// handle. Never throws: teardown runs in a <c>finally</c>.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors <see cref="TryTerminateForCancellationAsync"/>'s handling of the same races — the process can
+    /// exit between the <c>HasExited</c> check and the kill, and a tree termination can fail outright — because
+    /// they are the same races, not because the shape is tidy. The difference is that this one has nothing to
+    /// report to: a failure to stop the child leaks what was already leaking, and throwing out of a
+    /// <c>finally</c> would replace that with losing the runspace's disposal too.
+    /// </remarks>
+    private void ReleaseProcess(IDisposable? process)
+    {
+        try
+        {
+            if (process is System.Diagnostics.Process child && !child.HasExited)
+                _terminateProcessTree(child);
+        }
+        catch (InvalidOperationException)
+        {
+            // Already gone, or the handle no longer refers to a live process. Either way there is nothing
+            // left to stop.
+        }
+        catch (Exception ex) when (
+            ex is System.ComponentModel.Win32Exception or
+            AggregateException or
+            NotSupportedException)
+        {
+            Log.Debug(ex, "PowerShell: could not stop the runspace's child process during teardown");
+        }
+        finally
+        {
+            process?.Dispose();
         }
     }
 
@@ -666,21 +724,24 @@ public sealed class PowerShellRunner : IPowerShellRunner
     {
         private readonly IDisposable? _processInstance;
         private readonly IDisposable? _process;
+        private readonly Action<IDisposable?> _releaseProcess;
 
         public RunspaceResources(
             Runspace runspace,
             IDisposable? processInstance,
-            IDisposable? process)
+            IDisposable? process,
+            Action<IDisposable?> releaseProcess)
         {
             Runspace = runspace ?? throw new ArgumentNullException(nameof(runspace));
             _processInstance = processInstance;
             _process = process;
+            _releaseProcess = releaseProcess ?? throw new ArgumentNullException(nameof(releaseProcess));
         }
 
         public Runspace Runspace { get; }
 
         public void Dispose()
-            => DisposeRunspaceResources(Runspace, _processInstance, _process);
+            => DisposeRunspaceResources(Runspace, _processInstance, _process, _releaseProcess);
     }
 
     internal static void ApplyTrustedPowerShellModulePath(

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.78.1</Version>
-    <FileVersion>1.78.1.0</FileVersion>
-    <AssemblyVersion>1.78.1.0</AssemblyVersion>
+    <Version>1.78.2</Version>
+    <FileVersion>1.78.2.0</FileVersion>
+    <AssemblyVersion>1.78.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Disposing a `System.Diagnostics.Process` releases the **handle**. It does not stop the process. Teardown did only that:

```csharp
finally { try { processInstance?.Dispose(); } finally { process?.Dispose(); } }
```

So when the `powershell.exe` 5.1 child behind an out-of-process runspace did not exit on its own, it stayed — and its stdout and stderr pipes stayed open with it, which kept the remoting transport's reader threads blocked in `ReadFile` forever.

## Measured, not inferred

A hang dump from the integration job showed **1,447 managed threads** in one test host, of which **1,112 were PowerShell remoting transport threads**:

| count | frame |
|---:|---|
| 560 | `ClientSessionTransportManagerBase.ProcessMessageProc` |
| 276 | `OutOfProcessClientSessionTransportManager.ProcessOutputData` |
| 276 | `OutOfProcessClientSessionTransportManager.ProcessErrorData` |
| 275 | `RemoteRunspace.Open` — a host too saturated to complete another handshake |

About four threads per runspace, so roughly **276 children still alive**. #2150 bounded that `Open()` wait; this removes the saturation that caused it.

**Elevated only**, which is why it never showed up locally: `CreateRunspace` takes the out-of-process branch only when `_isElevated`, and a CI runner is elevated while a developer session is not.

## The change

`ReleaseProcess` stops a child that is still running, then disposes the handle. It mirrors `TryTerminateForCancellationAsync`'s handling of the same races — the process can exit between the `HasExited` check and the kill, a tree termination can fail outright — because they are the same races. The difference is that this one has nothing to report to: it runs in a `finally`, so a failure to stop the child leaks what was already leaking, while throwing would additionally lose the runspace's disposal.

**Closing the runspace before disposing it is deliberately not done.** It is the obvious next idea and it carries a real risk: 275 of those runspaces were parked inside `Open()`, and `Close()` on a runspace that never finished opening can block on the same handshake. Stopping the child is what frees the threads, and it cannot block on the runspace's state.

**Reusing one runspace per session** instead of creating one per invocation is the structural fix and is **not here**. It is a lifecycle change in a privileged path and wants its own review; #2149 stays open for it. This makes each invocation clean up after itself, which is what turns 276 leaks into none.

## Red/green

| | mutation | result |
|---|---|---|
| | baseline | unit 2 green · integration 1 green |
| T1 | `ReleaseProcess` → dispose only, do not stop | **RED** the child outlives the run; the bounded wait is cancelled |
| T2 | hand teardown a bare `Dispose` instead | **RED** same, via the production wiring |
| T3 | drop the `HasExited` guard | GREEN, deliberately — the guard narrows a race and is not the thing under test |
| | restored, sha verified, rebuilt | unit 2 green · integration 1 green |

## The test took three attempts, and two of them were false greens

Worth recording, because each attempt found a real flaw in the previous one:

1. **It invoked the private release by reflection.** That proved what the method does and nothing about whether the production path uses it — T2 left it green. It now goes through `RunAsync` with the child injected via the `createRunspace` seam, so wiring and behaviour are one assertion.
2. **The stand-in was `cmd /c pause` with redirected stdin.** Disposing the `Process` closes its redirected handles, `pause` saw EOF, and the child exited on its own — so T1, which removes the termination entirely, *still* left it green. Nothing is redirected now: disposing the object cannot touch the process, and only a kill ends it.
3. **The proof runner itself reported GREEN when the harness produced no summary at all.** T1 had killed it, via an orphaned child writing to a closed pipe. It now treats a missing summary as BROKEN rather than as an absence of reds.

Observed through a **second, independent handle** to the same process, because teardown disposes the one it is given and querying that afterwards throws *"No process is associated with this object"* — which says nothing about whether the process died. The independent handle lets `WaitForExitAsync` be awaited rather than polled, so there is no sleeping and nothing to go flaky.

`DisposeRunspaceResources_ReleasesTheChildThroughTheSuppliedAction` is renamed to `..._ReleasesTheChildLast`, which is what it actually covers. It asserts ordering, not wiring, and the old name claimed otherwise.

## Verification

- Four projects build **0 errors, 0 warnings**.
- The `PowerShellRunner` unit tests: **44 green**.
- **107 of 108** guards green. The single red is `EverySourceFile_CarriesTheAuthorHeader` flagging the throwaway local runner, which is not in the repository.
- `dotnet format --verify-no-changes` clean; leak scan 43 patterns over 5 files, its one hit the Windows assistant privacy toggle in a historical changelog line.

The observable confirmation lands after merge: the integration job's thread count should stop climbing, and #2141's one never-completing test should complete.

Part of #2149; the per-session reuse half stays open there.
