### PR TITLE
fix: two tabs ended closer to the window edge than the other sixteen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.78.3] - 2026-09-08
+
+On File Shredder and Shortcut Cleaner the line at the bottom of the page sat closer to the window edge than
+the same line does on every other tab. A few pixels, but it is the kind of unevenness you notice without
+being able to say what is wrong.
+
+### Fixed
+- **The bottom line on File Shredder and Shortcut Cleaner now sits where it does on the other sixteen tabs.**
+  Both were 4px tight above and 8px tight below, which read as the page ending a little abruptly.
+
+### Added
+- **A check that a page cannot end flush against the bottom of the window.** The app's shell adds no padding
+  of its own, so the last section's bottom margin is the only gap there is. Two page shapes end a tab
+  legitimately and the check knows both, so a new tab is told which one it should match rather than being
+  guessed at.
+
 ## [1.78.2] - 2026-09-08
 
 Running SysManager as administrator left a hidden `powershell.exe` behind every time a feature used one. They

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1813,6 +1813,12 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"AutomationProperties\.HelpText=""(?<text>[^""]*)""", RegexOptions.Compiled)]
     private static partial Regex HelpTextAttribute();
 
+    /// <summary>
+    /// A <c>Margin</c> carrying the 28px horizontal page gutter, whatever its vertical values.
+    /// </summary>
+    [GeneratedRegex(@"Margin=""28,(?<top>\d+),28,(?<bottom>\d+)""", RegexOptions.Compiled)]
+    private static partial Regex SideGutter();
+
     /// <summary>A <c>{Binding …}</c> markup extension, braces included.</summary>
     [GeneratedRegex(@"\{[^}]*\}", RegexOptions.Compiled)]
     private static partial Regex BindingExpression();
@@ -2179,6 +2185,86 @@ public partial class ArchitectureTests
             "AdminBanner binds IsElevated and RelaunchAsAdminCommand from its host's DataContext, so a host "
             + "missing either gets a banner stuck in one state or a dead button. Add the member, or do not "
             + "host the banner:\n  " + string.Join("\n  ", missing));
+    }
+
+    /// <summary>
+    /// A per-section view's LAST horizontal-28 gutter must carry a documented bottom gutter, so no tab ends
+    /// with its content jammed against the bottom of the window.
+    /// </summary>
+    /// <remarks>
+    /// The per-section layout strategy gives each section its own 28px side gutter, and the bottom of the last
+    /// one is the only thing standing between the content and the window edge — the shell wraps a view in a
+    /// bare <c>&lt;Border Background="{DynamicResource Surface0}"&gt;</c> with no padding of its own, so a
+    /// zero there really is flush.
+    /// <para><b>Two values, because two shapes legitimately end a page.</b> A view with a bottom status row
+    /// ends on <c>28,12,28,24</c>: the row is its own section and owns the gap. A view whose last section is
+    /// the content card itself has no such row, so the card carries the gap and ends on
+    /// <c>28,16,28,28</c> — the documented content-card top of 16 with a bottom of its own instead of the 0
+    /// a card gets when something follows it. Three views are that second shape (DnsHosts, NetworkRepair,
+    /// SpeedTest) and the remaining fifteen are the first.</para>
+    /// <para><b>Measured.</b> Two views ended on <c>28,8,28,16</c> — FileShredder and ShortcutCleaner, both a
+    /// row commented <c>&lt;!-- Footer --&gt;</c>, i.e. exactly the shape the documented value covers, 4px
+    /// tight at the top and 8px at the bottom. Both fixed to <c>28,12,28,24</c>; 18 of 18 pass now.</para>
+    /// <para><b>Comment-stripped, which changes the population.</b> <c>AdminBanner.xaml</c>'s doc comment
+    /// contains a usage snippet reading <c>Margin="28,12,28,0"</c> and the control has no real gutter of its
+    /// own, so over raw text it counts as a 59th gutter-carrying file on the strength of an example. It is not
+    /// an offender either way — the header check excludes it, since nothing in it says
+    /// <c>28,24,28,0</c> — but a floor measured against prose is a floor that moves when a comment is
+    /// reworded. Reading through <see cref="XamlCode"/> is what makes 58 mean 58 files of markup.</para>
+    /// <para>Part (a) of #1616. The original report also named Ping and Traceroute as flush to the edge;
+    /// re-derived from current source both now end on the documented footer, so that half was already fixed
+    /// and this guard is what stops it recurring.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryPerSectionView_EndsOnADocumentedBottomGutter()
+    {
+        // The documented last-gutter for each of the two shapes that can end a per-section page.
+        var documented = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [@"Margin=""28,12,28,24"""] = "a bottom status row, which owns the gap itself",
+            [@"Margin=""28,16,28,28"""] = "a final content card, which carries the gap in place of a status row",
+        };
+
+        var viewsDir = Path.Combine(FindAppProjectDir(), "Views");
+        var perSection = new List<string>();
+        var offenders = new List<string>();
+        var gutterViews = 0;
+
+        foreach (var file in Directory.GetFiles(viewsDir, "*.xaml"))
+        {
+            var xaml = XamlCode(file);
+            var gutters = SideGutter().Matches(xaml);
+            if (gutters.Count == 0) continue;
+            gutterViews++;
+
+            // The per-section header. Its absence means Strategy 1 (one root gutter) or the scrolling
+            // variant, neither of which stacks sections, so neither has a last section to end.
+            if (!xaml.Contains(@"Margin=""28,24,28,0""", StringComparison.Ordinal)) continue;
+
+            var name = Path.GetFileName(file);
+            perSection.Add(name);
+
+            var last = gutters[^1].Value;
+            if (!documented.ContainsKey(last))
+                offenders.Add($"{name} ends on {last}");
+        }
+
+        // Vacuity floors, both measured today: 58 views carry a 28 gutter and 18 of them are per-section.
+        // A collapse in either means the Margin or header match stopped matching real markup, and a pass
+        // would then prove nothing about any view.
+        Assert.True(gutterViews >= 50,
+            $"only {gutterViews} views were found with a 28 side gutter, out of 58 measured — the Margin "
+            + "pattern is out of date, so this guard is reading almost nothing.");
+        Assert.True(perSection.Count >= 15,
+            $"only {perSection.Count} per-section views were found, out of 18 measured — the header match is "
+            + "out of date.");
+
+        Assert.True(offenders.Count == 0,
+            "A per-section view's last 28-gutter is the only bottom gutter the page has: the shell adds no "
+            + "padding, so an undersized one reads as content crowding the window edge and a zero is flush "
+            + "against it. End on one of:\n  "
+            + string.Join("\n  ", documented.Select(d => $"{d.Key} — {d.Value}"))
+            + "\nOffenders:\n  " + string.Join("\n  ", offenders));
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.78.2</Version>
-    <FileVersion>1.78.2.0</FileVersion>
-    <AssemblyVersion>1.78.2.0</AssemblyVersion>
+    <Version>1.78.3</Version>
+    <FileVersion>1.78.3.0</FileVersion>
+    <AssemblyVersion>1.78.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -118,7 +118,7 @@
                       Visibility="{Binding Items.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
 
         <!-- Footer -->
-        <Border Grid.Row="3" Margin="28,8,28,16" Padding="8">
+        <Border Grid.Row="3" Margin="28,12,28,24" Padding="8">
             <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives its children infinite
                  width, so TextWrapping never engages and a long message — such as one naming
                  several files that could not be queued — is clipped off the right edge. -->

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -116,7 +116,7 @@
                       Visibility="{Binding BrokenShortcuts.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
 
         <!-- Footer -->
-        <Border Grid.Row="4" Margin="28,8,28,16" Padding="8">
+        <Border Grid.Row="4" Margin="28,12,28,24" Padding="8">
             <TextBlock Style="{StaticResource Subtle}">
                 <Run Text="{Binding BrokenCount, Mode=OneWay}"/>
                 <Run Text=" broken · "/>


### PR DESCRIPTION
File Shredder and Shortcut Cleaner both end on a row commented `<!-- Footer -->` at `Margin="28,8,28,16"`, where the other views of that shape use `28,12,28,24`. 4px tight above the row and 8px below it.

That bottom value is the entire gap between the page and the window edge. The shell wraps a view in a bare `<Border Background="{DynamicResource Surface0}">` with no padding of its own, so nothing downstream makes up the difference.

### What was measured

All 58 views carrying a 28px side gutter, read comment-stripped. 18 are per-section — they open with the documented `28,24,28,0` header — and after this change 15 end on `28,12,28,24` and 3 on `28,16,28,28`. Nothing ends flush.

Two end-shapes are legitimate and the new guard accepts both:

| last 28-gutter | the shape it belongs to |
|---|---|
| `28,12,28,24` | a bottom status row. It is its own section and owns the gap. |
| `28,16,28,28` | a final content card, where there is no status row to own it. The documented content-card top of 16 with a bottom of its own instead of the 0 a card gets when something follows it. DnsHosts, NetworkRepair, SpeedTest. |

Naming the second shape is the point. Without it the contract has an answer for fifteen views and silence for three, which is how a fourth variant arrives.

### The guard

`EveryPerSectionView_EndsOnADocumentedBottomGutter`, in the blocking suite. It reads through `XamlCode`, which strips comments: `AdminBanner.xaml`'s doc comment contains a usage snippet reading `Margin="28,12,28,0"` and the control has no real gutter of its own, so over raw text it counts as a 59th gutter-carrying file on the strength of an example. Not an offender either way — the header check excludes it — but a floor measured against prose moves when a comment is reworded.

### Red/green, five mutations

| | | |
|---|---|---|
| baseline | | GREEN |
| M1 | FileShredder footer back to `28,8,28,16` | RED, names FileShredderView |
| M2 | ShortcutCleaner footer back to `28,8,28,16` | RED, names ShortcutCleanerView |
| M3 | DnsHosts final card to `28,16,28,0`, flush | RED, names DnsHostsView — the defect #1616 leads with |
| M4 | `SideGutter` regex matches nothing | RED on the vacuity floor, not a vacuous pass |
| M5 | drop the per-section header check | RED naming all 40 Strategy-1 and scrolling views, so the filter is what scopes the population |
| restored, sha verified, rebuilt | | GREEN |

Two flaws in the proof runner were fixed on the way, both of which had already produced a wrong result. M5 written as `if (false) continue;` makes the next statement unreachable, CS0162 is an error here, and the build failure was reported as BROKEN — which says nothing about the guard. And a restore hit a transient `PermissionError` right after a build and left M4's mutation sitting in the tree, the one outcome a proof must never produce; writes now retry.

### Re-derived, not taken from the issue

#1616's headline finding is that Ping and Traceroute are flush to the window edge. They are not, and have not been for some time — both end on the documented footer today. The issue's part (a) was down to these two 4-8px mismatches, and this guard is what keeps the flush case from coming back.

### Verification

- Four projects build, 0 errors 0 warnings
- 109 green, 1 red over every guard in `ArchitectureTests`; the red is the throwaway local runner's own file, which is not in this repository
- `dotnet format --verify-no-changes` clean
- Leak scan: 43 patterns over 6,505 bytes of added lines, 0 hits

Deferred to the workstation that runs the application: how the two corrected footers look against a sibling tab. The values are copied from fifteen views that already use them, so this is a look rather than a question.

Part (a) of #1616. Part (b), writing the third page-layout variant and this two-shape footer rule into the UI conventions, is not a change to this repository and stays open there.
