### PR TITLE
docs: say why the app ships portable and unsigned, and add a roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ winget install laurentiu021.SysManager
 - [Features](#features) — all 58 tabs, grouped
 - [Screenshots](#screenshots)
 - [Install](#install)
+  - [Why portable, and why there is no installer](#why-portable-and-why-there-is-no-installer)
   - [Verifying the download](#verifying-the-download)
 - [Uninstalling](#uninstalling)
 - [Build from source](#build-from-source)
 - [First-time flow](#first-time-flow)
-- [Documentation](#documentation)
+- [Documentation](#documentation) — including the [roadmap](ROADMAP.md)
 - [Reporting bugs and requesting features](#reporting-bugs-and-requesting-features)
 - [Tech stack](#tech-stack)
 - [Privacy](#privacy)
@@ -1249,6 +1250,37 @@ runtime required.
 > every checksum file — and a human verifying a download takes both. Treat the badge as
 > traffic, not as an install base.
 
+### Why portable, and why there is no installer
+
+The only build is a portable `.exe`. That is a decision, not an omission, and it has a cost
+worth stating alongside the benefit.
+
+**What you get.** Nothing is written outside `%LocalAppData%\SysManager` unless you ask for
+it. There is no service, no scheduled task you did not create, no uninstaller to trust, and
+no registry footprint to clean up — delete the exe and the app is gone. You can run it from
+a USB stick on a machine you are fixing for someone else, which is a large part of what this
+tool is for.
+
+**What it costs.** A portable exe lives in a user-writable location, so another process
+running under your account could replace it on disk. That is inherent to any portable app
+and has nothing to do with SysManager's update flow. If you run SysManager elevated, run a
+build you got from the Releases page and verified. A machine-scope build under
+`Program Files`, which is not user-writable, is on the [roadmap](ROADMAP.md) alongside code
+signing — the two belong together, because an installed build people trust should be a
+signed one.
+
+**No Microsoft Store build.** The Store sandbox forbids most of what this app does: reading
+other processes' working sets, writing the hosts file, changing services and scheduled
+tasks, purging the standby list. A Store version would be a different, much smaller app
+wearing the same name.
+
+**Unsigned, for now.** Windows shows a warning on first launch and some antivirus engines
+flag an unknown publisher. Both are explained below, along with how to check the download
+yourself: [First launch](#first-launch-windows-will-warn-you) ·
+[Verifying the download](#verifying-the-download) ·
+[If your antivirus flags the download](#if-your-antivirus-flags-the-download) ·
+[Code signing](#code-signing).
+
 ### Verifying the download
 
 Each release ships a matching `SysManager-v<version>.exe.sha256`. Verify before running
@@ -1485,6 +1517,7 @@ Windows 10 / 11 x64 machine.
 
 ## Documentation
 
+- [ROADMAP.md](ROADMAP.md) — what is being worked towards, and what is deliberately not
 - [ARCHITECTURE.md](ARCHITECTURE.md) — project structure and key design decisions
 - [TESTING.md](TESTING.md) — how the test suite is organised and run
 - [CHANGELOG.md](CHANGELOG.md) — release notes

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,144 @@
+# Roadmap
+
+Direction, not dates. SysManager is one person's project with no deadlines, so this
+describes what is being worked towards and in roughly what order — not what ships when.
+Every item links to the issue where the actual discussion happens, and the issues are the
+source of truth. If something here has no issue, it is an intention rather than a plan.
+
+The open backlog is public: [all open issues](https://github.com/laurentiu021/SystemManager/issues).
+
+## Not planned, on purpose
+
+Worth stating first, because these are the questions people ask and the answers are not
+"not yet".
+
+- **No telemetry, no analytics, no crash-reporting service, no account, no cloud.** There
+  is no server side and there is not going to be one. Diagnostics stay local and are only
+  ever shared if you choose to export and send them yourself.
+- **No Microsoft Store build.** The Store sandbox forbids most of what this app does —
+  reading other processes' working sets, writing the hosts file, changing services and
+  scheduled tasks, purging the standby list. A Store version would be a different, much
+  smaller app wearing the same name.
+- **No paid tier, no upsell, no bundled offers.** MIT, free, all features.
+- **No registry "cleaning" that deletes on a guess.** A registry tool that removes entries
+  it does not understand is how utilities earned their reputation. If something lands here
+  it will be inspection-first and reversible; the request is tracked in
+  [#1726](https://github.com/laurentiu021/SystemManager/issues/1726).
+
+## Trust and distribution
+
+The largest gap between what the app is and how it is received.
+
+- **Code signing.** Windows shows a warning on first launch and some antivirus engines flag
+  an unknown publisher. The intended route is the
+  [SignPath Foundation](https://signpath.org/) programme for open-source projects, and it is
+  not simply pending: the Foundation asks for a level of public visibility — stars, external
+  write-ups, independent references — that a project this young does not have, which is a
+  fair bar for a certificate issued in their name. So this is the one roadmap item whose
+  timing is not the project's to decide, and the practical route to it is people finding the
+  app useful enough to say so. The alternatives, their cost and their lead times are being
+  written up in [#1675](https://github.com/laurentiu021/SystemManager/issues/1675). Until
+  then, [the published SHA-256 and the build attestation](README.md#verifying-the-download)
+  are what establish that a download is genuine, and the update path already refuses a
+  signature it cannot read.
+- **A machine-scope build under `Program Files`.** The portable exe lives somewhere your
+  own account can write, which means another process running as you could replace it. An
+  installed build in a location that is not user-writable removes that property. It belongs
+  with signing rather than before it, because an installed build people trust should be a
+  signed one. Background in
+  [SECURITY.md](SECURITY.md#things-to-be-aware-of), under the portable distribution model.
+- **Shorter-lived release credentials.** The winget publish step currently holds a
+  long-lived cross-repository token;
+  [#1676](https://github.com/laurentiu021/SystemManager/issues/1676) covers replacing it.
+
+## Making the app explain itself
+
+The target user is someone who wants their PC to run better and does not know what a
+working set is. Several tabs still assume otherwise.
+
+- **A first-run screen** — one page saying what this is, what is safe, and what needs
+  administrator rights ([#1635](https://github.com/laurentiu021/SystemManager/issues/1635)).
+- **Help you can reach from inside the app** — no F1, no menu, no link out to
+  documentation today ([#1640](https://github.com/laurentiu021/SystemManager/issues/1640)).
+- **One consistent voice across tabs.** Roughly twenty older tabs kept terse technical
+  headers while newer ones explain themselves in plain language
+  ([#1654](https://github.com/laurentiu021/SystemManager/issues/1654)).
+- **Nothing reaches the network before you have seen the window.** The update check runs at
+  startup ([#1653](https://github.com/laurentiu021/SystemManager/issues/1653)).
+
+## Accessibility and keyboard use
+
+Partly done and pinned by tests, partly not.
+
+- **Keyboard operability under test.** Source-level guards exist; driving real key presses
+  through the UI does not ([#1552](https://github.com/laurentiu021/SystemManager/issues/1552)).
+- **Reaching a row's buttons without walking every cell**
+  ([#1551](https://github.com/laurentiu021/SystemManager/issues/1551)).
+- **Custom themes that cannot produce unreadable text.** The custom-colour mode accepts any
+  four colours with no contrast check
+  ([#1561](https://github.com/laurentiu021/SystemManager/issues/1561)).
+
+## One design system rather than 58 views that resemble each other
+
+Spacing, radii and type sizes are still literals in the views. The token scales exist and
+are widely bypassed, so a change to one of them does not reach the screens it should.
+
+- **Typography scale** — raw `FontSize` values instead of the named text styles
+  ([#1634](https://github.com/laurentiu021/SystemManager/issues/1634)).
+- **Corner radii** — raw values instead of the `RadiusSm/Md/Lg` scale
+  ([#1633](https://github.com/laurentiu021/SystemManager/issues/1633)).
+- **The repeated status footer**, carried near-identically by most views
+  ([#1630](https://github.com/laurentiu021/SystemManager/issues/1630)).
+
+Page-layout gutters are further along: the three page-layout strategies and both
+page-ending shapes are pinned by a test rather than left to discipline.
+
+## Features people have asked for
+
+Ordered by how often they come up, not by effort.
+
+- **A treemap for Disk Analyzer** ([#1592](https://github.com/laurentiu021/SystemManager/issues/1592))
+- **Deep Cleanup reaching the three biggest Windows space hogs**
+  ([#1577](https://github.com/laurentiu021/SystemManager/issues/1577))
+- **Master output slider and default-device switching in the volume mixer**
+  ([#1588](https://github.com/laurentiu021/SystemManager/issues/1588))
+- **Startup entries showing where they live**
+  ([#1587](https://github.com/laurentiu021/SystemManager/issues/1587))
+- **Taskbar progress during long operations**
+  ([#1584](https://github.com/laurentiu021/SystemManager/issues/1584))
+- **Scheduled maintenance that does not fire on battery**
+  ([#1578](https://github.com/laurentiu021/SystemManager/issues/1578))
+- **A one-click local diagnostics bundle** — exported by you, sent by you, never
+  automatically ([#1650](https://github.com/laurentiu021/SystemManager/issues/1650))
+
+## Documentation and presentation
+
+- **A landing page** ([#1679](https://github.com/laurentiu021/SystemManager/issues/1679))
+- **Screenshots for the tabs that have none**, several of them recent features
+  ([#1664](https://github.com/laurentiu021/SystemManager/issues/1664))
+- **A README first screen that reads as an introduction rather than a wall of prose and
+  badges** ([#1677](https://github.com/laurentiu021/SystemManager/issues/1677))
+- **Discussions that are usable** — everything currently sits in Announcements and nothing
+  is pinned ([#1665](https://github.com/laurentiu021/SystemManager/issues/1665))
+
+## Under the floor
+
+Not user-visible, and the reason the rest can move at all.
+
+- **Migrating the test suite to xUnit v3**, which `Xunit.StaFact` now requires
+  ([#2028](https://github.com/laurentiu021/SystemManager/issues/2028))
+- **One PowerShell runspace per elevated session** instead of one per call
+  ([#2149](https://github.com/laurentiu021/SystemManager/issues/2149))
+- **Replacing the blocking dispatcher marshals**
+  ([#2152](https://github.com/laurentiu021/SystemManager/issues/2152))
+
+## How this list changes
+
+Anything here can be reordered by a bug report. A crash or a data-loss defect goes to the
+front; a polish item waits. If something you need is missing,
+[open an issue](https://github.com/laurentiu021/SystemManager/issues/new/choose) — the
+backlog is where this document comes from, not the other way round.
+
+---
+
+Crafted by laurentiu021 · [SysManager](https://github.com/laurentiu021/SystemManager) · MIT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -155,7 +155,10 @@ What the app can and cannot do by design:
   update flow. If you run SysManager elevated, only run a build you obtained
   from the official Releases page and verified. A machine-scope installed
   build under `Program Files` (not user-writable) is planned alongside code
-  signing once a certificate is available.
+  signing once a certificate is available — see
+  [ROADMAP.md](ROADMAP.md#trust-and-distribution) for why the two are sequenced
+  together, and the README for
+  [why the app ships portable at all](README.md#why-portable-and-why-there-is-no-installer).
 
 ## Privacy
 


### PR DESCRIPTION
The distribution decision was documented in exactly one place: a `SECURITY.md` bullet about the portable exe living somewhere user-writable. That is where a security researcher looks. The README — what a prospective user and every aggregator reads — explained *how* to install and never why there is no installer, why the Store is not an option, or that a machine-scope build is intended.

### README: "Why portable, and why there is no installer"

Under Install, stating the benefit and the cost in the same breath rather than only the benefit:

- **What you get.** Nothing written outside `%LocalAppData%\SysManager` unless you ask, no service, no scheduled task you did not create, no registry footprint. Runs from a USB stick on a machine you are fixing for someone else, which is a large part of what this tool is for.
- **What it costs.** A user-writable exe can be replaced on disk by another process running as you. Inherent to any portable app and unrelated to the update flow, so it is stated as a property rather than a bug.
- **No Store build**, answered directly: the sandbox forbids reading other processes' working sets, writing the hosts file, changing services and scheduled tasks, purging the standby list. A Store version would be a different, much smaller app wearing the same name.
- **Unsigned, for now**, with links to all four places that already explain it.

### ROADMAP.md

New, and it opens with what is **not** planned, because those are the questions people actually ask and the answers are not "not yet": no telemetry or cloud ever, no Store build, no paid tier, no registry cleaner that deletes on a guess. Then direction by theme, every item linked to its issue, with the issues named as the source of truth rather than this file.

**No dates, and no counts.** A roadmap with dates on a project that has none is fiction. The counts were left out for a concrete reason rather than a stylistic one: the token-scale issues quote 499 raw `FontSize` uses over 18 values and 177 raw corner radii, and re-measuring today gives **385 over 17, and 80**. Publishing either number would have published a wrong one, so the shape is described instead. (Those two issues want their figures re-derived — separate from this PR.)

Signing is stated the way the README already states it, not as a pending item: the SignPath Foundation asks for a level of public visibility a project this young does not have, that is a fair bar for a certificate issued in their name, and the practical route to it is people finding the app useful enough to say so. Machine-scope install is sequenced with it deliberately, because an installed build people trust should be a signed one.

`SECURITY.md`'s portable-distribution bullet now points at both, so the one place that had the whole record is no longer the only place with any of it.

### Verification

- **55 relative links and in-page anchors** across README, SECURITY and ROADMAP resolve, checked by slugifying the target headings rather than by eye. The first draft linked `SECURITY.md#threat-model`, which does not exist — the heading is `## Security model` and the paragraph lives under `### Things to be aware of`.
- **Leak scan:** 43 patterns over 10,733 bytes of added lines, 0 hits. The scanner gained a guard first: `git diff` shows nothing for an untracked file, so it was about to report a clean scan of a ROADMAP.md it had never read.
- `docs:` only — no code, no version bump, no release.

Closes #1671.
