### PR TITLE
fix: ten dispatcher marshals waited for a UI thread that may never run them

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -617,6 +617,16 @@ Key utility classes that don't fit neatly into Services or ViewModels (not an ex
   prevent because nothing holds those files open yet.
 - `RecycleBinHelper` — empties the Recycle Bin via the shell API; shared by Deep
   Cleanup and the One-Click Tune-Up so the interop has one source of truth.
+- `UiThread` — the one way background work updates the UI. Runs the action inline
+  when already on the UI thread and posts it otherwise, so the caller never waits
+  for the dispatcher. It replaced ten hand-written synchronous marshals, each
+  guarded on whether an `Application` existed — which is not the question, because
+  an `Application` can exist while nothing pumps its dispatcher and a blocking
+  `Invoke` then waits on a queue no one drains. The two callers that need the
+  update to have landed before their next statement await
+  `Dispatcher.InvokeAsync` instead: an un-resumed continuation costs nothing, a
+  blocked thread costs a thread. A fitness function asserts nothing marshals
+  synchronously, including via a short local holding the dispatcher.
 - `MarkdownTextBlock` — lightweight Markdown-to-WPF inline renderer.
 - Value converters: `EqualityConverter`, `IntGreaterThanZeroConverter`,
   `ValueConverters` (boolean/visibility/inverse helpers).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
-## [1.78.3] - 2026-09-08
+## [1.78.4] - 2026-09-08
+
+Ten places in SysManager updated the screen by handing the work to the window and then standing still until
+the window had done it. Nothing you would have noticed, because the window is normally listening — but it is
+the shape of freeze that only happens when something else has gone wrong, which is the worst time for a
+second problem. They now hand the work over and carry on.
+
+### Fixed
+- **Background work no longer waits on the window to catch up.** Ten spots did, including the notification
+  popup, which is reached at the end of most scans. A scan that has finished has nothing to gain from waiting
+  for its "done" message to appear, and if the window were ever waiting on that scan, both would have waited
+  forever. Two of the ten legitimately need the screen updated before they continue, and those now wait in a
+  way that cannot freeze anything.
+
+### Added
+- **A check that stops the pattern coming back.** It recognises the roundabout way of writing it too — the
+  form this codebase actually used, where the window is stored under a short name first — because the version
+  that only caught the obvious spelling let a test case straight through.
 
 On File Shredder and Shortcut Cleaner the line at the bottom of the page sat closer to the window edge than
 the same line does on every other tab. A few pixels, but it is the kind of unevenness you notice without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ second problem. They now hand the work over and carry on.
   form this codebase actually used, where the window is stored under a short name first — because the version
   that only caught the obvious spelling let a test case straight through.
 
+## [1.78.3] - 2026-09-08
+
 On File Shredder and Shortcut Cleaner the line at the bottom of the page sat closer to the window edge than
 the same line does on every other tab. A few pixels, but it is the kind of unevenness you notice without
 being able to say what is wrong.

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -8506,6 +8506,129 @@ public partial class ArchitectureTests
     private static partial Regex BlockingWaitInDispose();
 
     /// <summary>
+    /// Nothing marshals to the dispatcher with the synchronous <c>Invoke</c>. Post it, or await
+    /// <c>InvokeAsync</c> when the next statement reads what the action wrote.
+    /// </summary>
+    /// <remarks>
+    /// Ten sites across six files did, each behind <c>if (Application.Current?.Dispatcher is { } d)</c> —
+    /// a guard that asks whether an <see cref="System.Windows.Application"/> EXISTS, which is not the
+    /// question. An <c>Application</c> can exist while nothing pumps its dispatcher, and a synchronous
+    /// <c>Invoke</c> then waits on a queue no one drains, forever. A hang dump from the integration suite
+    /// showed ten threads parked exactly there and seven more waiting on a <c>DispatcherOperation</c>
+    /// (#2152). In the app the UI thread does pump, so these normally returned — which is what made it a
+    /// latent deadlock rather than a visible bug.
+    /// <para><b>Two receiver shapes, because catching only one catches nothing.</b> The obvious form names
+    /// the dispatcher at the call (<c>Application.Current.Dispatcher.Invoke(…)</c>). The form this
+    /// codebase actually used binds it to a short local first — <c>is { } d</c>, then <c>d.Invoke(…)</c> —
+    /// and a pattern keyed on the word "Dispatcher" walks straight past it. So dispatcher-bearing locals
+    /// are collected per file and their names checked too. The mutation that binds a differently-named
+    /// local is the one that proves this half is load-bearing.</para>
+    /// <para><b>Comments stripped first.</b> <c>Helpers/UiThread.cs</c> documents the pattern it replaced
+    /// by quoting it, and the remarks you are reading do the same. A guard that reads its own prose as
+    /// code goes red on a clean tree.</para>
+    /// <para><b>Both floors are measured, not guessed.</b> 351 source files and 29 asynchronous marshals
+    /// today. The second floor is the one that matters: if the receiver patterns silently stop matching
+    /// real code, "no offenders" is indistinguishable from "nothing was read", and only a population
+    /// count separates them.</para>
+    /// </remarks>
+    [Fact]
+    public void NothingMarshalsToTheDispatcherSynchronously()
+    {
+        var appDir = FindAppProjectDir();
+        var files = Directory
+            .EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                                    StringComparison.Ordinal))
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+                                    StringComparison.Ordinal))
+            .ToList();
+
+        var offenders = new List<string>();
+        var asyncMarshals = 0;
+
+        foreach (var file in files)
+        {
+            // Comments stripped BEFORE matching, per the remarks above.
+            var code = string.Join('\n', File.ReadAllLines(file)
+                .Select(line => CommentTail().Replace(line, string.Empty)));
+            var name = Path.GetFileName(file);
+
+            asyncMarshals += AsyncMarshal().Matches(code).Count;
+
+            foreach (var hit in NamedDispatcherInvoke().Matches(code).Cast<Match>())
+                offenders.Add($"{name} — {hit.Value.Trim()}");
+
+            // The short-local form: bind the dispatcher to a name, then call Invoke on the name.
+            foreach (var local in DispatcherLocal().Matches(code).Cast<Match>()
+                         .Select(m => m.Groups["name"].Value)
+                         .Where(n => n.Length > 0)
+                         .Distinct(StringComparer.Ordinal))
+            {
+                // `[?!]?` and not `\??`: the null-forgiving `ui!.Invoke(…)` is the same blocking call, and
+                // a pattern that only allows `?` walks past it. The mutation that writes it that way is
+                // what found this — the first version of this guard passed on it.
+                var alias = new Regex($@"(?<![A-Za-z0-9_]){Regex.Escape(local)}\s*[?!]?\s*\.\s*Invoke\s*\(",
+                                      RegexOptions.CultureInvariant);
+                if (alias.IsMatch(code))
+                    offenders.Add($"{name} — {local}.Invoke(…), where {local} holds a Dispatcher");
+            }
+        }
+
+        Assert.True(files.Count >= 300,
+            $"only {files.Count} source files enumerated, out of 351 measured — this guard is reading the "
+            + "wrong folder.");
+        Assert.True(asyncMarshals >= 25,
+            $"only {asyncMarshals} asynchronous dispatcher marshals found, out of 29 measured. The receiver "
+            + "patterns have stopped matching real code, so a clean result here proves nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "A synchronous Dispatcher.Invoke blocks the calling thread until the UI thread runs the "
+            + "action. If nothing is pumping that dispatcher the wait never ends, and if the UI thread is "
+            + "itself waiting on this work, both sides wait forever. Post it with UiThread.Post, or "
+            + "`await dispatcher.InvokeAsync(…)` when the next statement reads what the action wrote — an "
+            + "un-resumed continuation costs nothing, a blocked thread costs a thread:\n  "
+            + string.Join("\n  ", offenders));
+
+        // Positive controls: every receiver shape that appeared in this codebase has to be recognised, and
+        // the asynchronous forms have to be left alone.
+        Assert.Matches(NamedDispatcherInvoke(), "Application.Current?.Dispatcher.Invoke(Update);");
+        Assert.Matches(NamedDispatcherInvoke(), "App.Current?.Dispatcher.Invoke(() => { });");
+        Assert.Matches(NamedDispatcherInvoke(), "dispatcher.Invoke(Update);");
+        Assert.Matches(NamedDispatcherInvoke(), "Dispatcher?.Invoke(Update);");
+        Assert.Matches(NamedDispatcherInvoke(), "Dispatcher!.Invoke(Update);");
+        Assert.DoesNotMatch(NamedDispatcherInvoke(), "dispatcher.InvokeAsync(Update);");
+        Assert.DoesNotMatch(NamedDispatcherInvoke(), "Dispatcher.BeginInvoke(action);");
+        Assert.DoesNotMatch(NamedDispatcherInvoke(), "ToastRequested?.Invoke(title, detail);");
+        Assert.Equal("d", DispatcherLocal().Match("if (Application.Current?.Dispatcher is { } d)")
+                                           .Groups["name"].Value);
+        Assert.Equal("ui", DispatcherLocal().Match("var ui = Application.Current.Dispatcher;")
+                                            .Groups["name"].Value);
+    }
+
+    /// <summary>
+    /// A synchronous <c>Invoke</c> on a receiver expression that names the dispatcher. <c>InvokeAsync</c>
+    /// and <c>BeginInvoke</c> are excluded by requiring the call to be <c>Invoke</c> exactly.
+    /// </summary>
+    [GeneratedRegex(@"(?<![A-Za-z0-9_])(?:[A-Za-z_][A-Za-z0-9_.?!]*\.)?[Dd]ispatcher\s*[?!]?\s*\.\s*Invoke\s*\(",
+                    RegexOptions.CultureInvariant)]
+    private static partial Regex NamedDispatcherInvoke();
+
+    /// <summary>
+    /// A local or field that holds a dispatcher: the <c>is { } name</c> pattern form, a
+    /// <c>var name = …Dispatcher</c> assignment, or a <c>Dispatcher name</c> declaration.
+    /// </summary>
+    [GeneratedRegex(@"[Dd]ispatcher\s+is\s*\{\s*\}\s*(?<name>[A-Za-z_][A-Za-z0-9_]*)"
+                    + @"|var\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*[^;]*[Dd]ispatcher"
+                    + @"|(?<![A-Za-z0-9_])Dispatcher\??\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*[;=,)]",
+                    RegexOptions.CultureInvariant)]
+    private static partial Regex DispatcherLocal();
+
+    /// <summary>An asynchronous marshal: the forms this codebase is supposed to use.</summary>
+    [GeneratedRegex(@"InvokeAsync\s*\(|BeginInvoke\s*\(|UiThread\.Post\s*\(",
+                    RegexOptions.CultureInvariant)]
+    private static partial Regex AsyncMarshal();
+
+    /// <summary>
     /// A documentation comment that describes parameters, a return value or a thrown exception must also
     /// carry a <c>&lt;summary&gt;</c>. Those tags describe the pieces and never say what the member is
     /// for, which is the half a reader needs first.

--- a/SysManager/SysManager/Helpers/UiThread.cs
+++ b/SysManager/SysManager/Helpers/UiThread.cs
@@ -1,0 +1,56 @@
+// SysManager · UiThread — posts work to the UI thread without waiting for it
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows;
+using System.Windows.Threading;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Runs an action on the UI thread. Already there, it runs inline; otherwise it is posted and the
+/// caller continues without waiting.
+/// </summary>
+/// <remarks>
+/// The pattern this replaces appeared ten times across six files, each written as
+/// <c>if (Application.Current?.Dispatcher is { } d) d.Invoke(Update); else Update();</c>. That guard
+/// asks whether an <see cref="Application"/> exists, which is not the question that matters — an
+/// <c>Application</c> can exist while nothing is pumping its dispatcher, and a synchronous
+/// <c>Invoke</c> then waits for a queue no one is draining. A hang dump from the integration suite
+/// showed ten threads parked exactly there (#2152).
+/// <para><b>Why posting is the right default.</b> A background thread that has finished its work and
+/// wants the UI updated has nothing to gain by waiting for the UI thread to have run the update. The
+/// project already agreed: <c>BeginInvoke</c> is used in 19 places against these ten, and
+/// <c>BulkInstallerViewModel.LoadIconsAsync</c> carries a comment saying so — eighteen lines above a
+/// blocking <c>Invoke</c> in the next method.</para>
+/// <para><b>When NOT to use this.</b> If the next statement reads what the action wrote, posting
+/// changes the answer. Those callers await <c>Dispatcher.InvokeAsync</c> directly instead, which keeps
+/// the ordering without parking a thread: an un-resumed continuation costs nothing, a blocked thread
+/// costs a thread. <c>StartupViewModel.ScanAsync</c> and <c>ServicesViewModel.RefreshAsync</c> are
+/// both that case.</para>
+/// <para><b>Where exceptions land.</b> With <c>Invoke</c>, an exception thrown by the action surfaced
+/// on the calling thread, where a surrounding <c>catch</c> could see it. Posted, it surfaces on the
+/// dispatcher thread. Every call site converted to this helper passes an action that only assigns
+/// properties or raises an event, so nothing was relying on catching it — the two sites whose actions
+/// run inside a meaningful <c>try</c> await instead, precisely so their <c>catch</c> still works.</para>
+/// </remarks>
+internal static class UiThread
+{
+    /// <summary>Posts <paramref name="action"/> to the application's UI thread.</summary>
+    internal static void Post(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
+        => Post(Application.Current?.Dispatcher, action, priority);
+
+    /// <summary>
+    /// Posts <paramref name="action"/> to <paramref name="dispatcher"/>. A null dispatcher means
+    /// there is no UI thread to marshal to — headless tests and the designer — so the action runs
+    /// on the caller's thread, which is what those callers want.
+    /// </summary>
+    internal static void Post(Dispatcher? dispatcher, Action action,
+                              DispatcherPriority priority = DispatcherPriority.Normal)
+    {
+        if (dispatcher is null || dispatcher.CheckAccess())
+            action();
+        else
+            _ = dispatcher.InvokeAsync(action, priority);
+    }
+}

--- a/SysManager/SysManager/Services/ToastService.cs
+++ b/SysManager/SysManager/Services/ToastService.cs
@@ -4,6 +4,7 @@
 
 using System.Windows;
 using System.Windows.Threading;
+using SysManager.Helpers;
 
 namespace SysManager.Services;
 
@@ -17,11 +18,22 @@ public sealed class ToastService
 
     private DispatcherTimer? _autoDismiss;
 
+    /// <remarks>
+    /// Posted rather than marshalled synchronously. This is reached from 39 call sites, most of them
+    /// the last line of an async scan on a background thread, and a caller has nothing to gain by
+    /// waiting for a notification to have been raised. It was the most widely reached of the ten
+    /// blocking marshals in #2152.
+    /// <para>The no-window early return is kept deliberately rather than folded into
+    /// <see cref="UiThread.Post"/>. Post runs inline when there is no dispatcher, which is right for a
+    /// property assignment and wrong here: there is nothing to show a toast in, and running the body
+    /// would construct a <see cref="DispatcherTimer"/> on a thread whose dispatcher never pumps. No
+    /// window means no toast, which is what this did before.</para>
+    /// </remarks>
     public void Show(string title, string detail, int autoHideMs = 5000)
     {
-        if (Application.Current?.Dispatcher is not { } dispatcher) return;
+        if (Application.Current?.Dispatcher is null) return;
 
-        dispatcher.Invoke(() =>
+        UiThread.Post(() =>
         {
             _autoDismiss?.Stop();
             ToastRequested?.Invoke(title, detail);

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.78.3</Version>
-    <FileVersion>1.78.3.0</FileVersion>
-    <AssemblyVersion>1.78.3.0</AssemblyVersion>
+    <Version>1.78.4</Version>
+    <FileVersion>1.78.4.0</FileVersion>
+    <AssemblyVersion>1.78.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BulkInstallerViewModel.cs
@@ -155,7 +155,9 @@ public sealed partial class BulkInstallerViewModel : ViewModelBase
 
             var installedIds = ParseInstalledIds(string.Join("\n", lines));
 
-            App.Current?.Dispatcher.Invoke(() =>
+            // Posted, for the reason the comment in LoadIconsAsync above already gives: nothing here
+            // reads the flags back, so waiting on UI availability buys nothing (#2152).
+            UiThread.Post(() =>
             {
                 foreach (var app in Apps)
                 {

--- a/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
@@ -90,19 +90,13 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
         try
         {
             string dns = await _dnsService.GetCurrentDnsAsync(_cts.Token).ConfigureAwait(false);
-            if (Application.Current?.Dispatcher is { } dispatcher)
-                dispatcher.Invoke(() => CurrentDns = dns);
-            else
-                CurrentDns = dns;
+            UiThread.Post(() => CurrentDns = dns);
         }
         catch (OperationCanceledException) { }
         catch (Exception ex)
         {
             Log.Warning(ex, "Failed to read current DNS");
-            if (Application.Current?.Dispatcher is { } d)
-                d.Invoke(() => CurrentDns = "Unable to detect");
-            else
-                CurrentDns = "Unable to detect";
+            UiThread.Post(() => CurrentDns = "Unable to detect");
         }
     }
 
@@ -446,34 +440,15 @@ public sealed partial class DnsHostsViewModel : ViewModelBase
         UpdateCanRestorePreviousDns();
     }
 
-    private void UpdateCanRestorePreviousDns()
-    {
-        void Update() => CanRestorePreviousDns = _dnsUndo is not null;
+    // The three setters below are called from both threads and marshal a single property assignment.
+    // They post rather than wait: no caller reads the value back, and successive posts run in the
+    // order they were queued, so a status line still ends on the last message set (#2152).
+    private void UpdateCanRestorePreviousDns() =>
+        UiThread.Post(() => CanRestorePreviousDns = _dnsUndo is not null);
 
-        if (Application.Current?.Dispatcher is { } dispatcher)
-            dispatcher.Invoke(Update);
-        else
-            Update();
-    }
+    private void SetStatusMessage(string value) => UiThread.Post(() => StatusMessage = value);
 
-    private void SetStatusMessage(string value)
-    {
-        void Update() => StatusMessage = value;
-
-        if (Application.Current?.Dispatcher is { } dispatcher)
-            dispatcher.Invoke(Update);
-        else
-            Update();
-    }
-    private void SetDnsApplying(bool value)
-    {
-        void Update() => IsDnsApplying = value;
-
-        if (Application.Current?.Dispatcher is { } dispatcher)
-            dispatcher.Invoke(Update);
-        else
-            Update();
-    }
+    private void SetDnsApplying(bool value) => UiThread.Post(() => IsDnsApplying = value);
 
     // ── Hosts Commands ───────────────────────────────────────────────────
 

--- a/SysManager/SysManager/ViewModels/GamingProfileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/GamingProfileViewModel.cs
@@ -220,14 +220,11 @@ public sealed partial class GamingProfileViewModel : ViewModelBase
     {
         // The bound game exited and the service auto-reverted. Reflect it in the UI (marshalled
         // to the UI thread — the event fires from a Process.Exited callback on a pool thread).
-        var dispatcher = System.Windows.Application.Current?.Dispatcher;
-        void Update()
+        UiThread.Post(() =>
         {
             IsSessionActive = _service.IsActive;
             StatusMessage = "The game exited — game mode ended and original settings were restored.";
-        }
-        if (dispatcher is null || dispatcher.CheckAccess()) Update();
-        else dispatcher.Invoke(Update);
+        });
     }
 
     /// <summary>Builds an honest, plain-language summary of an apply batch (pure, testable).</summary>

--- a/SysManager/SysManager/ViewModels/NetworkSharedState.cs
+++ b/SysManager/SysManager/ViewModels/NetworkSharedState.cs
@@ -579,11 +579,14 @@ public sealed partial class NetworkSharedState : ObservableObject, IDisposable
         foreach (var b in Buffers.Values) TrimBuffer(b);
     }
 
-    internal void InvokeOnUi(Action action)
-    {
-        if (Dispatcher is null || Dispatcher.CheckAccess()) action();
-        else Dispatcher.BeginInvoke(DispatcherPriority.Background, action);
-    }
+    /// <remarks>
+    /// This was the shape <see cref="Helpers.UiThread"/> was extracted from, so it now calls it rather
+    /// than keeping a second copy that could drift. <see cref="DispatcherPriority.Background"/> is kept
+    /// and passed explicitly: chart and buffer updates should yield to input rather than compete with
+    /// it, which is the opposite of what a status line wants, so it stays a per-caller decision.
+    /// </remarks>
+    internal void InvokeOnUi(Action action) =>
+        Helpers.UiThread.Post(Dispatcher, action, DispatcherPriority.Background);
 
     // ── Chart theming ──
 

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -108,8 +108,11 @@ public sealed partial class ServicesViewModel : ViewModelBase
             RehydratePreviousStartTypes();
             // Ensure collection updates happen on the UI thread to prevent
             // cross-thread exceptions when navigating during concurrent scans (#154).
+            // Awaited rather than posted: the finally below clears IsBusy, and posting would stop the
+            // spinner before the list it is waiting for had appeared. Awaiting a DispatcherOperation
+            // keeps that order without parking this thread the way Invoke did (#2152).
             if (Application.Current?.Dispatcher is { } d && !d.CheckAccess())
-                d.Invoke(ApplyFilterCore);
+                await d.InvokeAsync(ApplyFilterCore);
             else
                 ApplyFilterCore();
         }

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -94,21 +94,21 @@ public sealed partial class StartupViewModel : ViewModelBase
                 item.Icon = IconExtractorService.GetIcon(exePath ?? item.Command);
             }
 
-            if (System.Windows.Application.Current?.Dispatcher is { } dispatcher)
-            {
-                dispatcher.Invoke(() =>
-                {
-                    _allEntries.Clear();
-                    _allEntries.AddRange(sorted);
-                    ApplyFilter();
-                });
-            }
-            else
+            void Publish()
             {
                 _allEntries.Clear();
                 _allEntries.AddRange(sorted);
                 ApplyFilter();
             }
+
+            // Awaited rather than posted, because the next line reads _allEntries.Count. Awaiting a
+            // DispatcherOperation keeps that ordering without parking this thread the way the previous
+            // synchronous Invoke did: if nothing ever pumps the dispatcher, an un-resumed continuation
+            // costs nothing while a blocked thread costs a thread (#2152).
+            if (System.Windows.Application.Current?.Dispatcher is { } dispatcher)
+                await dispatcher.InvokeAsync(Publish);
+            else
+                Publish();
 
             StatusMessage = $"Found {_allEntries.Count} startup items.";
             ToastService.Instance.Show("Scan complete", $"{_allEntries.Count} startup items found");


### PR DESCRIPTION
Ten sites marshalled to the WPF dispatcher with the synchronous `Invoke`, each written this way:

```csharp
if (Application.Current?.Dispatcher is { } d) d.Invoke(Update); else Update();
```

That guard asks whether an `Application` **exists**, which is not the question. An `Application` can exist while nothing is pumping its dispatcher, and a synchronous `Invoke` then waits on a queue no one will drain, forever. The `else` covers "no Application" — the case the authors had in mind. The case that hangs has no branch at all.

Measured, not inferred: once #2151 removed 1,403 leaked threads of noise from the integration suite's hang dump, ten threads were parked in `Dispatcher.Invoke` and seven more waiting on a `DispatcherOperation`, under `StartupViewModel.ScanAsync` and `ServicesViewModel.RefreshAsync`. `StaHelper.Run` creates the `Application` on an STA thread and lets it exit, so from the first UI test onward `Application.Current` is set and its dispatcher belongs to a thread that no longer exists.

In the app the UI thread does pump, so these normally returned. That is what made it a latent deadlock rather than a visible bug: a blocking marshal looks harmless until something upstream waits on the work doing it.

### `Helpers/UiThread.Post`, which is not a new invention

`NetworkSharedState.InvokeOnUi` was already exactly this shape. The helper is that extracted, and `InvokeOnUi` now calls it rather than keeping a second copy that could drift. It keeps passing `DispatcherPriority.Background` explicitly, because a chart buffer should yield to input and a status line should not — that stays a per-caller decision.

**Eight sites post. Two await `Dispatcher.InvokeAsync`,** because the next statement reads what the action wrote:

- `StartupViewModel` reads `_allEntries.Count` on the following line.
- `ServicesViewModel`'s `finally` clears `IsBusy`, so posting would stop the spinner before the list it is waiting for appeared.

Awaiting keeps the ordering without parking a thread: an un-resumed continuation costs nothing, a blocked thread costs a thread.

**`ToastService.Show` keeps its no-window early return** rather than folding it into `Post`. `Post` runs inline when there is no dispatcher, which is right for a property assignment and wrong here — there is nothing to show a toast in, and running the body would construct a `DispatcherTimer` on a thread whose dispatcher never pumps. No window means no toast, which is what it did before.

**Where exceptions land does change.** With `Invoke`, an exception from the action surfaced on the calling thread where a surrounding `catch` could see it; posted, it surfaces on the dispatcher thread. Every converted action only assigns properties or raises an event, so nothing was relying on catching it — and the two whose actions run inside a meaningful `try` are precisely the two that await, so their `catch` still works.

### Red/green, seven mutations

| | | |
|---|---|---|
| baseline | | GREEN |
| M1 | ToastService back to a blocking `Invoke` | RED, names ToastService.cs |
| M2 | StartupViewModel back to a blocking `Invoke` | RED, names StartupViewModel.cs |
| M3 | the same, behind a differently-named local | RED via the alias half |
| M4 | `NamedDispatcherInvoke` matches nothing | RED via its positive control |
| M4b | it stops allowing a null-forgiving receiver | RED via its positive control |
| M5 | `AsyncMarshal` matches nothing | RED on the population floor |
| M6 | `DispatcherLocal` stops capturing the name | RED via its positive control |
| restored, sha verified, rebuilt | | GREEN |

**M3 found a real defect in the first version of the guard**, which is the whole reason to write that mutation. It injected `ui!.Invoke(…)` — the null-forgiving form — and the alias pattern allowed only `?`. It passed. Both patterns now accept `[?!]` and both carry a positive control for it, so M4b fails if that is ever narrowed again.

Note which mechanism protects what: the **population floor** protects `AsyncMarshal`, and the **positive controls** protect the two receiver patterns, because a regex that matches nothing produces no offenders and the floor cannot see it. Both are exercised above rather than assumed.

### What this does not claim

It does **not** close #2141. The last prediction of that kind, in #2151, was wrong — the leak turned out to be hiding the hang rather than causing it. What is established is that these ten calls block forever in a host with no pump, and that threads were demonstrably parked in them. Whether the never-completing test is downstream of one is what this PR's own integration run answers, and I will report that measurement here either way.

### Verification

- Four projects build, 0 errors 0 warnings
- 110 green, 1 red over every guard in `ArchitectureTests`; the red is the throwaway local runner's own file, which is not in this repository
- `dotnet format --verify-no-changes` clean on both projects, after it caught the new file being written with LF endings
- Leak scan: 43 patterns over 17,023 bytes of added lines, 0 hits
- ARCHITECTURE.md gains `UiThread` in the utilities list, with why the old guard was the wrong question

Part of #2152.
