### PR TITLE
fix: the standby purge was named after a different feature, and the picker showed the enum

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -560,7 +560,8 @@ Key services:
   two reads let a setting move in between and appear settled while it had changed.
 - `CliRunner` — the headless command-line entry point (dispatched from `App.OnStartup`
   before the single-instance mutex, attaching to the parent console). Exposes only
-  read-only/safe verbs (`--health`, `--cleanup`, `--trim-ram`, `--version/--help/--list`)
+  read-only/safe verbs (`--health`, `--cleanup`, `--purge-standby` — with `--trim-ram`
+  retained as an alias for schedules registered under the old name — `--version/--help/--list`)
   with `--json`/`--silent` modifiers and conventional exit codes (0/1/2). `Parse` and
   `ExecuteAsync` are pure/return-value-based, so the whole CLI is unit-tested without
   launching the process; `IsCliInvocation` is strict so the elevation/update-applier args

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.78.5] - 2026-09-08
+
+Scheduled Maintenance offered you "TrimRam" in its dropdown and then asked you to confirm "Purge standby
+memory" — two names, one step apart, for the same thing. Worse, "Trim RAM" is the name of a *different*
+button in Performance Mode that does a different job, so scheduling it looked like scheduling that.
+
+### Changed
+- **The Scheduled Maintenance dropdown now reads "Clean temporary files" and "Purge standby memory"**,
+  which is what the confirmation has always said. It was showing internal names.
+- **The command line calls it `--purge-standby`**, because that is what it does. `--trim-ram` still works,
+  so any schedule you already set keeps running — but the two memory features now have two names. Purging
+  the standby list needs administrator rights; Performance Mode's Trim RAM does not, and the old shared
+  name hid that difference.
+
+### Added
+- **Checks that a picker cannot show internal names again**, and that an action's command line is one the
+  app actually recognises — the failure being a nightly task that runs, reports success, and does nothing.
+
 ## [1.78.4] - 2026-09-08
 
 Ten places in SysManager updated the screen by handing the work to the window and then standing still until

--- a/README.md
+++ b/README.md
@@ -1052,8 +1052,10 @@ offers, "rate us" prompts:
   SysManager accepts command-line flags and runs headless (no window), writing its
   output to the launching console
 - Commands: `--health` (read-only health score), `--cleanup` (temp-file cleanup,
-  never follows junctions), `--trim-ram` (purge the standby list), plus `--version`,
-  `--help`, and `--list`
+  never follows junctions), `--purge-standby` (purge the standby list), plus `--version`,
+  `--help`, and `--list`. `--trim-ram` still works as an alias for `--purge-standby`,
+  so an existing scheduled task keeps running; new scripts should use the current name,
+  which says which of the two memory operations it is
 - `--json` emits machine-readable output; `--silent` suppresses chatter for
   scripting; conventional **exit codes** (0 success · 1 error · 2 usage) let a script
   branch on the result

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2268,6 +2268,78 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// A picker bound to a list of enum values renders a label, not the enum's <c>ToString()</c>.
+    /// </summary>
+    /// <remarks>
+    /// The Scheduled Maintenance action picker did not. It bound <c>ItemsSource="{Binding Actions}"</c>,
+    /// a list of <c>MaintenanceAction</c> values, with no <c>ItemTemplate</c> and no
+    /// <c>DisplayMemberPath</c> — so WPF fell back to <c>ToString()</c> and the dropdown offered
+    /// "Cleanup" and "TrimRam". The model had a perfectly good <c>ActionLabel</c> the whole time; it was
+    /// used by the confirmation dialog, the activity log and the status line, and not by the one control
+    /// where the user chooses. So the user picked "TrimRam" and was then asked to confirm "Purge standby
+    /// memory" (#1524).
+    /// <para>That is the unreachable-surface shape: a property implemented, tested, and bound by nothing.
+    /// The compiler cannot see it and a view-model test cannot either — only the XAML can.</para>
+    /// <para><b>Scoped to enum-backed pickers by name.</b> Checking every ComboBox would flag the ones
+    /// bound to objects with a sensible <c>ToString()</c> or an explicit <c>DisplayMemberPath</c>, which
+    /// are correct. The list here is the enum-valued ones, each with the resource key that must appear
+    /// inside it — so adding a third enum picker means adding a row, which is the point.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryEnumBackedPicker_ShowsALabelRatherThanTheEnumName()
+    {
+        // view -> (the ItemsSource binding that carries enum values, the converter key it must render with)
+        var pickers = new[]
+        {
+            ("ScheduledMaintenanceView.xaml", "{Binding Actions}", "MaintenanceActionText"),
+        };
+
+        var viewsDir = Path.Combine(FindAppProjectDir(), "Views");
+        var app = XamlCode(Path.Combine(FindAppProjectDir(), "App.xaml"));
+        var offenders = new List<string>();
+
+        foreach (var (view, itemsSource, converterKey) in pickers)
+        {
+            var xaml = XamlCode(Path.Combine(viewsDir, view));
+
+            var at = xaml.IndexOf($@"ItemsSource=""{itemsSource}""", StringComparison.Ordinal);
+            if (at < 0)
+            {
+                offenders.Add($"{view} — nothing binds ItemsSource=\"{itemsSource}\" any more; "
+                            + "update this guard or the view");
+                continue;
+            }
+
+            // The element, from its opening angle bracket to its close — not a fixed window, which would
+            // reach into the next control and report its ItemTemplate as this one's.
+            var open = xaml.LastIndexOf('<', at);
+            var close = xaml.IndexOf("</ComboBox>", at, StringComparison.Ordinal);
+            if (open < 0 || close < 0)
+            {
+                offenders.Add($"{view} — the picker has no closing </ComboBox>, so it cannot carry an "
+                            + "ItemTemplate: it renders each enum value's ToString()");
+                continue;
+            }
+
+            var element = xaml[open..close];
+            if (!element.Contains(converterKey, StringComparison.Ordinal))
+                offenders.Add($"{view} — the picker does not render through {converterKey}, so the "
+                            + "dropdown shows raw enum names");
+
+            // A StaticResource inside a DataTemplate resolves at RUNTIME, so deleting the converter from
+            // App.xaml still compiles and still passes the check above. Assert the definition exists.
+            if (!app.Contains($@"x:Key=""{converterKey}""", StringComparison.Ordinal))
+                offenders.Add($"App.xaml no longer defines {converterKey}, which {view} resolves at "
+                            + "runtime — the picker will throw when it is opened");
+        }
+
+        Assert.True(offenders.Count == 0,
+            "An enum-backed picker with no ItemTemplate shows the developer's name for each value. The "
+            + "label belongs in the model and reaches the screen through a converter, so the picker and "
+            + "the confirmation dialog cannot disagree:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
     /// Anything clickable by mouse that is not a <c>Button</c> must also be operable by keyboard — focusable,
     /// a tab stop, and activated by BOTH Enter and Space.
     /// </summary>

--- a/SysManager/SysManager.Tests/CliRunnerTests.cs
+++ b/SysManager/SysManager.Tests/CliRunnerTests.cs
@@ -24,9 +24,30 @@ public class CliRunnerTests
     [InlineData("--list", CliCommand.List)]
     [InlineData("--health", CliCommand.Health)]
     [InlineData("--cleanup", CliCommand.Cleanup)]
-    [InlineData("--trim-ram", CliCommand.TrimRam)]
+    [InlineData("--purge-standby", CliCommand.PurgeStandby)]
     public void Parse_RecognizesVerbs(string arg, CliCommand expected)
         => Assert.Equal(expected, CliRunner.Parse([arg]).Command);
+
+    /// <summary>
+    /// <c>--trim-ram</c> still resolves to the standby purge. This is a compatibility promise, not a
+    /// duplicate of the row above.
+    /// </summary>
+    /// <remarks>
+    /// The verb was renamed to <c>--purge-standby</c> because <c>--trim-ram</c> named Performance Mode's
+    /// operation while doing Standby List Cleaner's (#1524). The old spelling has to keep working: a
+    /// maintenance schedule registered before the rename has <c>"--trim-ram --silent"</c> baked into a
+    /// Windows scheduled task's argument string on the user's machine, and an unrecognised flag routes to
+    /// <c>Unknown</c> — so dropping the alias would leave that task running <c>--help</c> nightly and
+    /// reporting success while doing nothing.
+    /// <para>Asserted here rather than as another <c>[InlineData]</c> row so that deleting the alias
+    /// fails a test whose name says what broke, instead of one that reads like a parser typo.</para>
+    /// </remarks>
+    [Fact]
+    public void Parse_StillAcceptsTheFormerTrimRamSpelling()
+    {
+        Assert.Equal(CliCommand.PurgeStandby, CliRunner.Parse(["--trim-ram"]).Command);
+        Assert.Equal(CliCommand.PurgeStandby, CliRunner.Parse(["--TRIM-RAM"]).Command);
+    }
 
     [Fact]
     public void Parse_IsCaseInsensitive()

--- a/SysManager/SysManager.Tests/MaintenanceScheduleTests.cs
+++ b/SysManager/SysManager.Tests/MaintenanceScheduleTests.cs
@@ -13,7 +13,7 @@ public class MaintenanceScheduleTests
 
     [Theory]
     [InlineData(MaintenanceAction.Cleanup, "--cleanup --silent")]
-    [InlineData(MaintenanceAction.TrimRam, "--trim-ram --silent")]
+    [InlineData(MaintenanceAction.PurgeStandby, "--purge-standby --silent")]
     public void CliArguments_MapToWhitelistedVerbs(MaintenanceAction action, string expected)
     {
         var s = new MaintenanceSchedule(action, MaintenanceFrequency.Daily, 3, 0);
@@ -44,7 +44,7 @@ public class MaintenanceScheduleTests
     [Fact]
     public void Summary_Weekly_NamesDay()
     {
-        var s = new MaintenanceSchedule(MaintenanceAction.TrimRam, MaintenanceFrequency.Weekly, 22, 30, DayOfWeek.Friday);
+        var s = new MaintenanceSchedule(MaintenanceAction.PurgeStandby, MaintenanceFrequency.Weekly, 22, 30, DayOfWeek.Friday);
         Assert.Equal("Every Friday at 22:30", s.Summary);
     }
 
@@ -52,7 +52,7 @@ public class MaintenanceScheduleTests
     public void ActionLabel_IsHumanReadable()
     {
         Assert.Equal("Clean temporary files", new MaintenanceSchedule(MaintenanceAction.Cleanup, MaintenanceFrequency.Daily, 0, 0).ActionLabel);
-        Assert.Equal("Purge standby memory", new MaintenanceSchedule(MaintenanceAction.TrimRam, MaintenanceFrequency.Daily, 0, 0).ActionLabel);
+        Assert.Equal("Purge standby memory", new MaintenanceSchedule(MaintenanceAction.PurgeStandby, MaintenanceFrequency.Daily, 0, 0).ActionLabel);
     }
 
     // ── DescribeResultCode: last-run status in plain language ─────────────
@@ -79,5 +79,49 @@ public class MaintenanceScheduleTests
     {
         Assert.Equal(@"\SysManager\", MaintenanceSchedulerService.TaskFolder);
         Assert.Equal("Scheduled Maintenance", MaintenanceSchedulerService.TaskName);
+    }
+
+    // ── Every action is honestly named, end to end ────────────────────────
+
+    /// <summary>
+    /// Every declared <see cref="MaintenanceAction"/> has a plain-language label and a CLI argument
+    /// string the parser actually recognises.
+    /// </summary>
+    /// <remarks>
+    /// Enumerates the enum rather than listing values, so adding a third action fails here until it has
+    /// both — which is the failure mode this is for. The existing rows are asserted individually above;
+    /// this asserts the SET is complete, and those are different questions.
+    /// <para><b>Why the round trip through the parser.</b> The defect behind #1524 was exactly a
+    /// disagreement between the name and the behaviour: <c>MaintenanceAction.TrimRam</c> emitted
+    /// <c>--trim-ram</c>, which <c>CliRunner</c> ran as a standby purge — Standby List Cleaner's
+    /// operation under Performance Mode's name, with a different elevation requirement. Asserting the
+    /// emitted verb resolves to a real command is what catches an action whose arguments fall through to
+    /// <c>--help</c>, which is what an unrecognised flag does: the scheduled task would run nightly,
+    /// exit 0, and do nothing.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryMaintenanceAction_HasALabelAndAVerbTheParserKnows()
+    {
+        var actions = Enum.GetValues<MaintenanceAction>();
+        Assert.True(actions.Length >= 2, $"only {actions.Length} actions found — reading the wrong enum");
+
+        foreach (var action in actions)
+        {
+            var label = MaintenanceSchedule.LabelFor(action);
+            Assert.False(string.IsNullOrWhiteSpace(label), $"{action} has no label");
+            Assert.NotEqual("Unknown", label);
+            // Exact inequality, not "does not contain": a label may legitimately share a word with the
+            // enum name. What must not happen is the label BEING the enum name, which is what the action
+            // picker was effectively showing before it got an ItemTemplate.
+            Assert.NotEqual(action.ToString(), label);
+
+            var schedule = new MaintenanceSchedule(action, MaintenanceFrequency.Daily, 3, 0);
+            var verb = schedule.CliArguments.Split(' ')[0];
+            var parsed = CliRunner.Parse([verb]).Command;
+
+            Assert.NotEqual(CliCommand.Unknown, parsed);
+            Assert.NotEqual(CliCommand.None, parsed);
+            Assert.NotEqual(CliCommand.Help, parsed);
+        }
     }
 }

--- a/SysManager/SysManager.Tests/MaintenanceSchedulerServiceTests.cs
+++ b/SysManager/SysManager.Tests/MaintenanceSchedulerServiceTests.cs
@@ -67,10 +67,10 @@ public class MaintenanceSchedulerServiceTests
     public async Task RegisterAsync_DailySchedule_SetsDailyTrue()
     {
         var (svc, ps) = NewService(StateRow("Ready"));
-        var schedule = new MaintenanceSchedule(MaintenanceAction.TrimRam, MaintenanceFrequency.Daily, 9, 0);
+        var schedule = new MaintenanceSchedule(MaintenanceAction.PurgeStandby, MaintenanceFrequency.Daily, 9, 0);
         await svc.RegisterAsync(schedule, exePath: @"C:\x.exe");
         await ps.Received(1).RunAsync(Arg.Any<string>(),
-            Arg.Is<IDictionary<string, object?>?>(p => (bool)p!["Daily"]! && (string)p["Args"]! == "--trim-ram --silent"),
+            Arg.Is<IDictionary<string, object?>?>(p => (bool)p!["Daily"]! && (string)p["Args"]! == "--purge-standby --silent"),
             Arg.Any<CancellationToken>());
     }
 

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -33,6 +33,7 @@
             <h:ProcessSafetyToTooltipConverter x:Key="ProcSafetyTip"/>
             <h:IntGreaterThanZeroConverter x:Key="GreaterThanZero"/>
             <h:EqualityConverter x:Key="IsEqual"/>
+            <h:MaintenanceActionToTextConverter x:Key="MaintenanceActionText"/>
 
             <sys:Boolean xmlns:sys="clr-namespace:System;assembly=mscorlib" x:Key="TrueValue">True</sys:Boolean>
             <sys:Boolean xmlns:sys="clr-namespace:System;assembly=mscorlib" x:Key="FalseValue">False</sys:Boolean>

--- a/SysManager/SysManager/Helpers/ValueConverters.cs
+++ b/SysManager/SysManager/Helpers/ValueConverters.cs
@@ -251,6 +251,25 @@ public sealed class SafetyLevelToTextConverter : IValueConverter
         => throw new NotSupportedException();
 }
 
+/// <summary>
+/// Maps a <see cref="MaintenanceAction"/> to the plain-language label the user should see.
+/// </summary>
+/// <remarks>
+/// The Scheduled Maintenance action picker binds a list of enum values, so without this it rendered
+/// each one's <c>ToString()</c> — the dropdown offered "Cleanup" and "TrimRam" while the confirmation
+/// dialog that followed said "Purge standby memory" (#1524). Delegates to
+/// <see cref="MaintenanceSchedule.LabelFor"/> so the picker and the dialog cannot disagree; the label
+/// text itself lives in the model, once.
+/// </remarks>
+public sealed class MaintenanceActionToTextConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is MaintenanceAction action ? MaintenanceSchedule.LabelFor(action) : "Unknown";
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
 // ── Process provenance (Process Manager) ─────────────────────────────────────────────────────
 // Deliberately SEPARATE from the SafetyLevel* converters above. Those switch on the
 // Models.SafetyLevel enum (Safe/Caution/Critical) used by Services and Windows Features;

--- a/SysManager/SysManager/Models/CliRequest.cs
+++ b/SysManager/SysManager/Models/CliRequest.cs
@@ -14,7 +14,17 @@ public enum CliCommand
     List,
     Health,
     Cleanup,
-    TrimRam,
+    /// <summary>
+    /// Purge the standby memory list (<c>--purge-standby</c>, or the retained <c>--trim-ram</c> alias).
+    /// </summary>
+    /// <remarks>
+    /// Was <c>TrimRam</c>, which named a DIFFERENT operation. Performance Mode's "Trim RAM" calls
+    /// <c>EmptyWorkingSet</c> per process and needs no elevation; this calls
+    /// <c>NtSetSystemInformation(MemoryPurgeStandbyList)</c> and needs administrator. They are
+    /// complementary ends of the same subject, not duplicates — so a user who scheduled "TrimRam" got a
+    /// different operation with a different elevation requirement from the button of that name (#1524).
+    /// </remarks>
+    PurgeStandby,
     /// <summary>A <c>--flag</c> that isn't a recognized verb — usage error.</summary>
     Unknown,
 }

--- a/SysManager/SysManager/Models/MaintenanceSchedule.cs
+++ b/SysManager/SysManager/Models/MaintenanceSchedule.cs
@@ -16,8 +16,18 @@ public enum MaintenanceAction
 {
     /// <summary>Delete temporary files (CLI <c>--cleanup</c>).</summary>
     Cleanup,
-    /// <summary>Purge the standby memory list (CLI <c>--trim-ram</c>).</summary>
-    TrimRam,
+    /// <summary>Purge the standby memory list (CLI <c>--purge-standby</c>).</summary>
+    /// <remarks>
+    /// Was <c>TrimRam</c>, which pointed at the wrong tab. Performance Mode's "Trim RAM" is
+    /// <c>EmptyWorkingSet</c> per process and needs no elevation; this is
+    /// <c>NtSetSystemInformation(MemoryPurgeStandbyList)</c> and needs administrator. Someone scheduling
+    /// "TrimRam" reasonably expected the button of that name and got the other operation, with a
+    /// different elevation requirement — so the name also misled about whether the task would work
+    /// unelevated (#1524). Renaming this value is safe because a schedule is never persisted by name: it
+    /// is built fresh from the view model and turned into a Windows scheduled task. The CLI verb is the
+    /// part that crosses a persistence boundary, which is why <c>--trim-ram</c> is still accepted.
+    /// </remarks>
+    PurgeStandby,
 }
 
 /// <summary>
@@ -38,16 +48,27 @@ public sealed record MaintenanceSchedule(
     public string CliArguments => Action switch
     {
         MaintenanceAction.Cleanup => "--cleanup --silent",
-        MaintenanceAction.TrimRam => "--trim-ram --silent",
+        MaintenanceAction.PurgeStandby => "--purge-standby --silent",
         _ => "--help",
     };
 
-    public string ActionLabel => Action switch
+    /// <summary>
+    /// The plain-language name of an action, for anything that shows one to the user.
+    /// </summary>
+    /// <remarks>
+    /// Static because the action picker needs a label for an enum value it has no schedule for. It used
+    /// to exist only as an instance property, so the picker fell back to the enum's own
+    /// <c>ToString()</c> — the dropdown offered "Cleanup" and "TrimRam" while the confirmation dialog
+    /// that followed said "Purge standby memory", two names for one thing in consecutive steps (#1524).
+    /// </remarks>
+    public static string LabelFor(MaintenanceAction action) => action switch
     {
         MaintenanceAction.Cleanup => "Clean temporary files",
-        MaintenanceAction.TrimRam => "Purge standby memory",
+        MaintenanceAction.PurgeStandby => "Purge standby memory",
         _ => "Unknown",
     };
+
+    public string ActionLabel => LabelFor(Action);
 
     /// <summary>A plain-language summary of when this runs (e.g. "Every Sunday at 03:00").</summary>
     public string Summary => Frequency == MaintenanceFrequency.Daily

--- a/SysManager/SysManager/Services/CliRunner.cs
+++ b/SysManager/SysManager/Services/CliRunner.cs
@@ -33,7 +33,14 @@ public sealed class CliRunner
     // route to their own startup branches and never get treated as a CLI command.
     private static readonly HashSet<string> CliVerbs = new(StringComparer.OrdinalIgnoreCase)
     {
-        "--help", "-h", "-?", "/?", "--version", "-v", "--list", "--health", "--cleanup", "--trim-ram",
+        "--help", "-h", "-?", "/?", "--version", "-v", "--list", "--health", "--cleanup",
+        // --trim-ram is a RETAINED ALIAS, not a second verb: a maintenance schedule registered before the
+        // rename has "--trim-ram --silent" baked into a Windows scheduled task's argument string on the
+        // user's machine (#1524). The arm in Parse is what keeps it working; this list does not, because
+        // IsCliToken below also accepts anything starting with - or /, which every entry here does. So
+        // the set decides nothing it is asked and reads as an allowlist it is not — worth removing on its
+        // own rather than inside a rename. Do not add a verb here and assume that made it work.
+        "--purge-standby", "--trim-ram",
     };
 
     // Internal startup sentinels that LOOK like CLI flags but are handled by their own
@@ -82,7 +89,8 @@ public sealed class CliRunner
                 case "--list": command = Pick(command, CliCommand.List); break;
                 case "--health": command = Pick(command, CliCommand.Health); break;
                 case "--cleanup": command = Pick(command, CliCommand.Cleanup); break;
-                case "--trim-ram": command = Pick(command, CliCommand.TrimRam); break;
+                case "--purge-standby" or "--trim-ram":
+                    command = Pick(command, CliCommand.PurgeStandby); break;
                 default:
                     // An unrecognized option flag is a usage error; bare tokens are ignored.
                     if (arg.StartsWith('-') || arg.StartsWith('/'))
@@ -108,7 +116,8 @@ public sealed class CliRunner
         ("--list", "List the available CLI commands."),
         ("--health", "Print a system health score (read-only)."),
         ("--cleanup", "Delete temporary files from user and Windows TEMP (safe, never follows junctions)."),
-        ("--trim-ram", "Purge the standby memory list (non-destructive; needs administrator)."),
+        ("--purge-standby", "Purge the standby memory list (non-destructive; needs administrator). "
+                          + "Also accepted as --trim-ram, its former name."),
         ("--json", "Modifier: emit machine-readable JSON instead of text."),
         ("--silent, -s", "Modifier: suppress non-essential output."),
     ];
@@ -126,7 +135,7 @@ public sealed class CliRunner
             CliCommand.Version => new CliResult(CliResult.Ok, request.Json ? Json(new { version = Version }) : Version),
             CliCommand.Health => await RunHealthAsync(request, ct).ConfigureAwait(false),
             CliCommand.Cleanup => await RunCleanupAsync(request, ct).ConfigureAwait(false),
-            CliCommand.TrimRam => RunTrimRam(request),
+            CliCommand.PurgeStandby => RunPurgeStandby(request),
             CliCommand.Unknown => new CliResult(CliResult.UsageError, request.Json
                 ? Json(new { error = $"Unknown option '{request.UnknownArg}'." })
                 : $"Unknown option '{request.UnknownArg}'.\n\n{BuildHelp(false)}"),
@@ -174,13 +183,13 @@ public sealed class CliRunner
         }
     }
 
-    private static CliResult RunTrimRam(CliRequest request)
+    private static CliResult RunPurgeStandby(CliRequest request)
     {
         var svc = new StandbyMemoryService();
         var before = svc.GetMemoryStatus();
         bool ok = svc.TryPurgeStandbyList(out var error);
         if (!ok)
-            return new CliResult(CliResult.Error, request.Json ? Json(new { error }) : $"Standby trim failed: {error}");
+            return new CliResult(CliResult.Error, request.Json ? Json(new { error }) : $"Standby purge failed: {error}");
 
         var after = svc.GetMemoryStatus();
         return request.Json

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.78.4</Version>
-    <FileVersion>1.78.4.0</FileVersion>
-    <AssemblyVersion>1.78.4.0</AssemblyVersion>
+    <Version>1.78.5</Version>
+    <FileVersion>1.78.5.0</FileVersion>
+    <AssemblyVersion>1.78.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ScheduledMaintenanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ScheduledMaintenanceViewModel.cs
@@ -22,7 +22,7 @@ public sealed partial class ScheduledMaintenanceViewModel : ViewModelBase
 {
     private readonly MaintenanceSchedulerService _service;
 
-    public IReadOnlyList<MaintenanceAction> Actions { get; } = [MaintenanceAction.Cleanup, MaintenanceAction.TrimRam];
+    public IReadOnlyList<MaintenanceAction> Actions { get; } = [MaintenanceAction.Cleanup, MaintenanceAction.PurgeStandby];
     public IReadOnlyList<MaintenanceFrequency> Frequencies { get; } = [MaintenanceFrequency.Daily, MaintenanceFrequency.Weekly];
     public IReadOnlyList<DayOfWeek> Days { get; } = Enum.GetValues<DayOfWeek>();
     public IReadOnlyList<int> Hours { get; } = [.. Enumerable.Range(0, 24)];

--- a/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
+++ b/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
@@ -74,8 +74,18 @@
                 <WrapPanel Orientation="Horizontal">
                     <StackPanel Margin="0,0,20,12">
                         <TextBlock Text="ACTION" Style="{StaticResource SectionLabel}"/>
+                        <!-- ItemTemplate, so the list shows the plain-language label instead of each
+                             enum value's ToString(). Without it the dropdown read "Cleanup" and
+                             "TrimRam" while the confirmation dialog that followed said "Purge standby
+                             memory" — two names for one thing, one step apart. -->
                         <ComboBox ItemsSource="{Binding Actions}" SelectedItem="{Binding SelectedAction}"
-                                  Width="200" Margin="0,4,0,0" AutomationProperties.Name="Maintenance action"/>
+                                  Width="200" Margin="0,4,0,0" AutomationProperties.Name="Maintenance action">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Converter={StaticResource MaintenanceActionText}}"/>
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
                     </StackPanel>
                     <StackPanel Margin="0,0,20,12">
                         <TextBlock Text="FREQUENCY" Style="{StaticResource SectionLabel}"/>


### PR DESCRIPTION
Two memory operations, one name between them.

Performance Mode's **Trim RAM** is `EmptyWorkingSet` per process, needs no elevation, and moves pages *to* the standby list. **Standby List Cleaner** is `NtSetSystemInformation(MemoryPurgeStandbyList)`, needs administrator, and clears it. Complementary ends of the same subject, not duplicates — worth stating plainly, because "these overlap, merge them" is the wrong conclusion and the issue was right to rule it out.

The defect: the CLI verb `--trim-ram` **ran the standby purge**, and `MaintenanceAction.TrimRam` inherited that name while its own `ActionLabel` correctly read "Purge standby memory". Someone scheduling "TrimRam" expected the button of that name and got the other operation — with a different elevation requirement, so the name also misled about whether the task would work unelevated.

### The rename, and the one part that cannot be renamed

`--purge-standby` / `MaintenanceAction.PurgeStandby`. **`--trim-ram` stays accepted**, and not out of politeness: a schedule registered before the rename has `"--trim-ram --silent"` baked into a Windows scheduled task's argument string on the user's machine, and an unrecognised flag parses to `Unknown` — so dropping it would leave that task running nightly, exiting 0, and doing nothing. It gets its own named test rather than another `[InlineData]` row, so deleting the alias fails something that reads like a broken promise instead of a parser typo.

The enum value is safe to rename because a schedule is never persisted by name — it is built fresh from the view model and turned into a scheduled task. The verb is the only part crossing a persistence boundary.

### Found while reading it: the picker was showing the enum

```xml
<ComboBox ItemsSource="{Binding Actions}" SelectedItem="{Binding SelectedAction}" … />
```

A list of `MaintenanceAction` values, no `ItemTemplate`, no `DisplayMemberPath` — so WPF fell back to `ToString()` and the dropdown offered **"Cleanup"** and **"TrimRam"**. `ActionLabel` existed the whole time and was used by the confirmation dialog, the activity log and the status line. The one control where the user *chooses* was the one place it was not. So you picked "TrimRam" and were then asked to confirm "Purge standby memory", one step apart.

That is the unreachable-surface shape this repo keeps finding: a property implemented, tested, and bound by nothing, which neither the compiler nor a view-model test can see. `ActionLabel` is now `LabelFor(action)` — static, so the picker can label a value it has no schedule for — with `ActionLabel` delegating to it, so the picker and the dialog cannot disagree.

### Red/green, six mutations

| | | |
|---|---|---|
| baseline | | GREEN |
| M1 | drop `--trim-ram` from `CliVerbs` | **GREEN, as designed** — see below |
| M2 | drop `--trim-ram` from `Parse`'s switch arm | RED, the alias test by name |
| M3 | `CliArguments` emits a verb `Parse` rejects | RED, the new round-trip test |
| M4 | `LabelFor` returns the enum name | RED, same test |
| M5 | remove the picker's `ItemTemplate` | RED, the new XAML guard |
| M6 | delete the converter from `App.xaml` | RED, the same guard's runtime-resolution half |
| restored, sha verified, rebuilt | | GREEN |

**M1 is the one worth keeping.** It was written expecting RED and came back GREEN, and the reason is a finding rather than a hole in the test: `IsCliToken` is

```csharp
=> CliVerbs.Contains(arg) || arg.StartsWith('-') || arg.StartsWith('/');
```

and every entry in `CliVerbs` starts with `-` or `/`. The set decides nothing it is asked; the arm in `Parse` is the real allowlist. It reads like a gate and is not one. I corrected the comment I had just written claiming otherwise, and left the set in place — removing it is a separate change, not something to fold into a rename. Worth a follow-up.

**M6 matters more than it looks.** A `StaticResource` inside a `DataTemplate` resolves at *runtime*, so deleting the converter from `App.xaml` still compiles and still passes a check that only reads the view. The guard asserts the definition exists too.

### Verification

- Four projects build, 0 errors 0 warnings
- 125 green, 1 red across every `ArchitectureTests` guard plus the maintenance and CLI tests; the red is the throwaway local runner's own file, which is not in this repository
- `dotnet format --verify-no-changes` clean, after converting four files back to CRLF — `sed -i` had stripped it and `dotnet format` caught it
- Leak scan: 43 patterns over 16,418 bytes of added lines, 0 hits
- README and ARCHITECTURE both updated for the new verb and the retained alias

Deferred to the workstation that runs the application: reading the corrected dropdown, which is a look rather than a question.

Closes #1524.
