### PR TITLE
fix: a save was lost when anything held the file open for a fraction of a second

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -599,6 +599,14 @@ Key utility classes that don't fit neatly into Services or ViewModels (not an ex
   `FlushOntoDevice` alone, because replacing the app's own executable must not
   inherit the outgoing build's attributes. A fitness function asserts nobody
   swaps a file into place without one of the two.
+  The swap retries a refused attempt three times over ~155 ms, because
+  `File.Replace` has to delete the destination and anything holding that file
+  open — an antivirus scanner mid-read, a backup agent, Windows Search — refuses
+  it. Without the retry a lock that would be gone in 50 ms lost the save
+  silently. Only `IOException` is retried: a permission failure will not improve
+  on a second attempt. After the budget the exception propagates exactly as
+  before and the previous file is intact, so the class's promise is unchanged.
+  The pause is a parameter so the retry can be tested without sleeping.
 - `BulkObservableCollection<T>` — `ObservableCollection` subclass that
   suppresses change notifications during bulk add/remove for UI performance
   (in `ObservableCollectionExtensions.cs`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.78.6] - 2026-09-08
+
+If your antivirus happened to be reading one of SysManager's own settings files at the exact moment
+SysManager tried to save it, the save was abandoned — and nothing told you. Your previous settings were
+never damaged, but the change you had just made was gone. It now waits a moment and tries again.
+
+### Fixed
+- **A save is no longer lost because something else had the file open for a fraction of a second.** This
+  affects everything SysManager remembers for you: volume presets, gaming profiles, scheduled maintenance,
+  activity history, speed-test history. Antivirus scanners, backup tools and Windows Search all open files
+  briefly as they go, and a save that landed in one of those windows was simply dropped. Three quick
+  retries over about a sixth of a second cover it. A file that is genuinely locked still fails, and still
+  leaves your previous settings exactly as they were — that part has not changed.
+
 ## [1.78.5] - 2026-09-08
 
 Scheduled Maintenance offered you "TrimRam" in its dropdown and then asked you to confirm "Purge standby

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -8234,7 +8234,7 @@ public partial class ArchitectureTests
     private static partial Regex DirectShutdown();
 
     [Fact]
-    public void AtomicFile_FlushesTheTempOntoTheDevice_BeforeEverySwap()
+    public void AtomicFile_FlushesBeforeEverySwap_AndTheProductionPathRetriesARefusedOne()
     {
         // Closing a handle hands the bytes to the OS write-back cache; it does not ask the drive to persist
         // them. The swap that follows is a metadata change NTFS journals, so the rename can become durable
@@ -8265,6 +8265,26 @@ public partial class ArchitectureTests
             "SwapIntoPlace must flush the temp onto the device before the swap, or a power cut can leave "
             + "the destination durable under its final name while its contents are still in the operating "
             + "system's write-back cache");
+
+        // The swap SwapIntoPlace reaches has to be the retrying one. The retry lives on a three-argument
+        // overload so a test can drive it without sleeping, and the two-argument form the line above
+        // matched is a one-line delegation to it. Nothing stops that delegation being replaced by a bare
+        // File.Replace again, which would compile, pass every AtomicFile test that calls the overload
+        // directly, and quietly restore the defect on the production path — the same shape as #2149, where
+        // a test invoked a method the production code did not use.
+        var twoArgSwap = code.IndexOf("private static void Swap(string temp, string path)",
+                                      StringComparison.Ordinal);
+        Assert.True(twoArgSwap > 0,
+            "AtomicFile's two-argument Swap was not found — this guard would otherwise pass vacuously");
+        var delegation = code[twoArgSwap..code.IndexOf('\n', twoArgSwap)];
+        Assert.Contains("Swap(temp, path,", delegation, StringComparison.Ordinal);
+
+        var retrying = code.IndexOf("internal static void Swap(string temp, string path, Action<TimeSpan>",
+                                    StringComparison.Ordinal);
+        Assert.True(retrying > 0, "the retrying Swap overload is gone — a refused swap loses the save");
+        var retryBody = code[retrying..];
+        Assert.Contains("catch (IOException", retryBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("catch (UnauthorizedAccessException", retryBody[..600]);
 
         // And neither writer may bypass it and swap on its own.
         string[] writers = ["private static void Write(", "private static async Task WriteAsync("];

--- a/SysManager/SysManager.Tests/AtomicFileTests.cs
+++ b/SysManager/SysManager.Tests/AtomicFileTests.cs
@@ -229,6 +229,82 @@ public class AtomicFileTests : IDisposable
         Assert.False(File.Exists(temp), "the temp must not be left behind once it has been swapped in");
     }
 
+    /// <summary>
+    /// A lock that clears while the swap is retrying costs the user nothing.
+    /// </summary>
+    /// <remarks>
+    /// <c>File.Replace</c> has to delete the destination, so anything holding that file open refuses it —
+    /// an antivirus scanner mid-read, a backup agent, an indexer. Before the retry, a lock that would be
+    /// gone in 50&#160;ms lost the save, and silently: this helper is how every service persists user data
+    /// and callers log a failed save at Debug.
+    /// <para>Not hypothetical. It failed the <c>Release</c> workflow's unit gate for v1.78.5 with
+    /// <c>IOException: Unable to remove the file to be replaced</c>, on two sequential writes to the same
+    /// path, on a CI runner with the usual background services — leaving the tag with no release behind it
+    /// until the gate was re-run and passed with no code change (#2160).</para>
+    /// <para><b>No sleeping and no timing.</b> The pause is a parameter, and this test's pause is what
+    /// releases the lock — so the callback IS the synchronisation point. The alternative, holding the file
+    /// for a wall-clock interval and hoping the retry lands inside it, is the flake this is written to
+    /// avoid.</para>
+    /// </remarks>
+    [Fact]
+    public void Swap_WhenTheLockClearsWhileRetrying_TheSaveSucceeds()
+    {
+        var path = Path_("scanned.json");
+        File.WriteAllText(path, "the previous save");
+        var temp = AtomicFile.UniqueTempPath(path);
+        File.WriteAllText(temp, "the new save");
+
+        var held = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.None);
+        var waits = new List<TimeSpan>();
+        try
+        {
+            AtomicFile.Swap(temp, path, delay =>
+            {
+                waits.Add(delay);
+                held?.Dispose();      // the scanner finishes reading, on the first retry
+                held = null;
+            });
+        }
+        finally
+        {
+            held?.Dispose();
+        }
+
+        Assert.Equal("the new save", File.ReadAllText(path));
+        Assert.Single(waits);         // one refusal, one wait, then it went through
+    }
+
+    /// <summary>
+    /// A lock that never clears still fails, still without touching the previous file.
+    /// </summary>
+    /// <remarks>
+    /// The retry must not soften the promise of the class: after the budget the exception propagates
+    /// exactly as it did before, and the destination is byte-for-byte what it was. It also pins the budget
+    /// as finite — an unbounded retry on a permanently locked file would hang a save forever, which is a
+    /// worse failure than losing it.
+    /// <para>The delays are asserted as a rising sequence rather than as literal values. Restating the
+    /// production numbers here would make this test pass whatever they became, which is the mistake of
+    /// asserting a constant against itself.</para>
+    /// </remarks>
+    [Fact]
+    public void Swap_WhenTheLockNeverClears_GivesUpAndLeavesThePreviousSave()
+    {
+        var path = Path_("held-open.json");
+        const string previous = "{\"presets\":[\"the user's data\"]}";
+        File.WriteAllText(path, previous);
+        var temp = AtomicFile.UniqueTempPath(path);
+        File.WriteAllText(temp, "the save that cannot land");
+
+        var waits = new List<TimeSpan>();
+        using (File.Open(path, FileMode.Open, FileAccess.Read, FileShare.None))
+            Assert.ThrowsAny<IOException>(() => AtomicFile.Swap(temp, path, waits.Add));
+
+        Assert.Equal(previous, File.ReadAllText(path));
+        Assert.True(waits.Count is > 1 and < 10,
+            $"the retry budget is {waits.Count} waits — more than one, and finite");
+        Assert.Equal(waits.OrderBy(w => w), waits);   // each wait is at least as long as the last
+    }
+
     [Fact]
     public void MoveIntoPlace_TempIsMissing_StillFails()
     {

--- a/SysManager/SysManager/Helpers/AtomicFile.cs
+++ b/SysManager/SysManager/Helpers/AtomicFile.cs
@@ -226,12 +226,74 @@ internal static class AtomicFile
         Swap(temp, path);
     }
 
-    private static void Swap(string temp, string path)
+    /// <summary>
+    /// How long to wait before each retry of a refused swap. Three attempts in all.
+    /// </summary>
+    /// <remarks>
+    /// Sized for an antivirus or indexer read window, which is tens of milliseconds — long enough to
+    /// outlast one, short enough that a genuinely blocked save still fails inside 155&#160;ms rather than
+    /// hanging. The values rise so a slower scanner gets a longer second chance without making the common
+    /// case slow.
+    /// </remarks>
+    private static readonly TimeSpan[] SwapRetryDelays =
+    [
+        TimeSpan.FromMilliseconds(15),
+        TimeSpan.FromMilliseconds(40),
+        TimeSpan.FromMilliseconds(100),
+    ];
+
+    private static void Swap(string temp, string path) => Swap(temp, path, Thread.Sleep);
+
+    /// <summary>
+    /// Turns <paramref name="temp"/> into <paramref name="path"/>, retrying a refused swap a few times
+    /// before giving up. <paramref name="wait"/> is the pause between attempts.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Why a retry.</b> <see cref="File.Replace(string, string, string?)"/> has to delete the
+    /// destination, so anything holding that file open refuses it — an antivirus scanner mid-read, a
+    /// backup agent, a search indexer. Without a retry a lock that would be gone in 50&#160;ms costs the
+    /// user their save, and silently: <see cref="AtomicFile"/> is how every service persists user data and
+    /// callers log a failed save at Debug.</para>
+    /// <para>Not hypothetical. It failed the <c>Release</c> workflow's unit gate for v1.78.5 —
+    /// <c>IOException: Unable to remove the file to be replaced</c>, on two sequential writes to the same
+    /// path, on a CI runner with the usual background services. The tag existed with no release behind it
+    /// until the gate was re-run, which passed with no code change (#2160).</para>
+    /// <para><b>What is NOT retried.</b> Only <see cref="IOException"/>. An
+    /// <see cref="UnauthorizedAccessException"/> is a permission problem and will not improve on the
+    /// second attempt; retrying it would only delay the failure. The caller's write of the temp is not
+    /// retried either — it has already succeeded and been flushed, and re-running it would change what is
+    /// being swapped in.</para>
+    /// <para><b>The branch is re-evaluated every attempt</b>, not decided once. A destination that is
+    /// deleted between attempts would otherwise leave <c>File.Replace</c> throwing
+    /// <see cref="FileNotFoundException"/> — an <c>IOException</c> — for the rest of the budget, when the
+    /// move branch would have succeeded immediately.</para>
+    /// <para><b>Failing safely is unchanged.</b> After the last attempt the exception propagates exactly as
+    /// before, and the previous file is still there byte-for-byte. That is the promise of the class and a
+    /// retry does not soften it — it only stops a transient refusal from being treated as a permanent one.
+    /// </para>
+    /// <para>The pause is a parameter so a test can drive the retry without sleeping: passing a callback
+    /// that releases the lock on the first wait makes the whole thing deterministic, with the callback
+    /// itself as the synchronisation point.</para>
+    /// </remarks>
+    internal static void Swap(string temp, string path, Action<TimeSpan> wait)
     {
-        if (File.Exists(path))
-            File.Replace(temp, path, destinationBackupFileName: null);
-        else
-            MoveIntoPlace(temp, path);
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                if (File.Exists(path))
+                    File.Replace(temp, path, destinationBackupFileName: null);
+                else
+                    MoveIntoPlace(temp, path);
+                return;
+            }
+            catch (IOException ex) when (attempt < SwapRetryDelays.Length)
+            {
+                Log.Debug(ex, "Swap of {Temp} into {Path} was refused; retrying in {Delay}",
+                          temp, path, SwapRetryDelays[attempt]);
+                wait(SwapRetryDelays[attempt]);
+            }
+        }
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.78.5</Version>
-    <FileVersion>1.78.5.0</FileVersion>
-    <AssemblyVersion>1.78.5.0</AssemblyVersion>
+    <Version>1.78.6</Version>
+    <FileVersion>1.78.6.0</FileVersion>
+    <AssemblyVersion>1.78.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
`AtomicFile.Swap` gave up the moment `File.Replace` was refused:

```csharp
private static void Swap(string temp, string path)
{
    if (File.Exists(path))
        File.Replace(temp, path, destinationBackupFileName: null);
    else
        MoveIntoPlace(temp, path);
}
```

`File.Replace` has to **delete** the destination, so anything holding that file open refuses it — an antivirus scanner mid-read, a backup agent, Windows Search. `AtomicFile` is the single way every service persists user data and callers log a failed save at Debug, so a lock that would have been gone in 50 ms cost the user their volume preset, gaming profile, maintenance schedule or history, without a word.

### Found by it happening, not by reading

It failed the `Release` workflow's unit gate for **v1.78.5**:

```
AtomicFileTests.WriteAllText_LeavesNoTemporaryFileBehind [FAIL]
  System.IO.IOException : Unable to remove the file to be replaced.
     at AtomicFile.Swap(...) line 232
```

Two sequential writes to the same path, on a CI runner with the usual background services. The tag `v1.78.5` existed with **no release behind it** until the gate was re-run, which passed with no code change. Production path, production exception, stack trace.

### Three attempts over ~155 ms, and deliberately narrow

Delays rise 15/40/100, so a slower scanner gets a longer second chance without making the common case slow.

- **`IOException` only.** An `UnauthorizedAccessException` is a permission problem and will not improve on the second attempt; retrying it only delays the error the caller needs.
- **The caller's write of the temp is not retried.** It has already succeeded and been flushed; re-running it would change what is being swapped in.
- **The exists/replace branch is re-evaluated every attempt**, not decided once. A destination deleted between attempts would otherwise leave `File.Replace` throwing `FileNotFoundException` — an `IOException` — for the rest of the budget, when the move branch would have succeeded immediately.
- **Failing safely is unchanged.** After the budget the exception propagates exactly as before and the previous file is intact byte-for-byte. The retry stops a transient refusal from being treated as permanent; it does not soften the promise.

The pause is a parameter, so the test drives the retry with **no sleeping and no timing**: its callback is what releases the lock, which makes the callback the synchronisation point. Holding the file for a wall-clock interval and hoping the retry lands inside it is the flake this avoids.

### The guard grew a wiring half, and is renamed to say so

It asserted the flush order and would not have noticed the production path losing the retry. The retry lives on a three-argument overload so it can be tested; the two-argument form is a one-line delegation, and nothing stopped that delegation being replaced by a bare `File.Replace` again — it would compile, pass every test that calls the overload directly, and quietly restore the defect. That is the #2149 shape exactly, so M2 mutates it.

### Red/green, four mutations

| | | |
|---|---|---|
| baseline | | GREEN |
| M1 | no retry at all, one attempt as it shipped | RED — the regression test, failing with the real production error: *"The process cannot access the file because it is being used by another process"* |
| M2 | production path bypasses the retrying overload | RED on the guard, the only thing that can see it |
| M3 | retry `UnauthorizedAccessException` too | RED on the guard |
| M4 | unbounded retry, no ceiling | RED on the never-clears test |
| restored, sha verified, rebuilt | | GREEN |

M4 is worth a note: it does **not** hang. `SwapRetryDelays[attempt]` overruns and it throws `IndexOutOfRangeException`, which the test catches as the wrong exception type. Different failure, still caught.

The never-clears test asserts the delays are a **rising sequence** rather than the literal 15/40/100. Restating production constants in a test makes it pass whatever they become — the mistake made once already with the health-score weights.

### Verification

- Four projects build, 0 errors 0 warnings
- 117 green, 1 red across every `ArchitectureTests` guard plus the AtomicFile suite; the red is the throwaway local runner's own file, which is not in this repository
- `dotnet format --verify-no-changes` clean on both projects
- Leak scan: 43 patterns over 11,317 bytes of added lines, 0 hits
- ARCHITECTURE's `AtomicFile` entry records the retry and why only `IOException`

Closes #2160.