### PR TITLE
test: one STA thread for the suite, because the second one could not use the first's resources

### DIFF
--- a/SysManager/SysManager.IntegrationTests/AppResourcesTests.cs
+++ b/SysManager/SysManager.IntegrationTests/AppResourcesTests.cs
@@ -37,17 +37,22 @@ public class AppResourcesTests
     }
 
     /// <summary>
-    /// A second <c>Ensure()</c>, on a second STA thread, still leaves the styles resolvable.
+    /// A second <c>Ensure()</c> still leaves the styles resolvable.
     /// </summary>
     /// <remarks>
-    /// This is the shape the suite actually runs: each view test spawns its own STA thread and calls
-    /// <c>Ensure()</c>, so all but the first take the "an Application already exists" path. The old copies
-    /// treated that as proof the resources were loaded and returned without checking, which is how a failed
-    /// load in the first caller became a <c>XamlParseException</c> in the fourth. Order-independent — it
-    /// establishes its own first call rather than relying on another test having run.
+    /// This is the shape the suite actually runs: every view test calls <c>Ensure()</c>, so all but the
+    /// first take the "an Application already exists" path. The old copies treated that as proof the
+    /// resources were loaded and returned without checking, which is how a failed load in the first caller
+    /// became a <c>XamlParseException</c> in the fourth. Order-independent — it establishes its own first
+    /// call rather than relying on another test having run.
+    /// <para>Was named <c>…FromAnotherStaThread</c>, which stopped being true when the suite moved to one
+    /// shared STA thread (#2156). It also never covered the failure that rename exposed: resolving a Style
+    /// does not touch a thread-affine member, so this passed while four view tests threw. What does cover
+    /// it is <c>StaHelperTests.Run_AStyledElementBuildsInTwoSeparateCalls</c>, which applies the style.
+    /// </para>
     /// </remarks>
     [Fact]
-    public void Ensure_StillResolvesStyles_OnASecondCallFromAnotherStaThread()
+    public void Ensure_StillResolvesStylesOnASecondCall()
     {
         StaHelper.Run(AppResources.Ensure);
 

--- a/SysManager/SysManager.IntegrationTests/StaHelper.cs
+++ b/SysManager/SysManager.IntegrationTests/StaHelper.cs
@@ -2,7 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Windows.Threading;
+using System.Collections.Concurrent;
 
 namespace SysManager.IntegrationTests;
 
@@ -19,43 +19,41 @@ namespace SysManager.IntegrationTests;
 /// app-scope resources belonging to a thread that was not merely different but already gone —
 /// <c>InvalidOperationException: The calling thread cannot access this object because a different thread
 /// owns it</c>, surfacing as a <c>XamlParseException</c> on the first Style or BorderBrush (#2156).</para>
-/// <para><b>The thread pumps.</b> <see cref="Dispatcher.Run"/> makes this a real UI thread rather than an
-/// STA thread with a dispatcher nobody drains. That matters beyond the resource ownership: work posted
-/// with <c>InvokeAsync</c> or <c>BeginInvoke</c> now actually runs, so the suite exercises the same
-/// marshalling behaviour the application has instead of a degenerate version of it.</para>
+/// <para><b>A work queue, NOT a pumped dispatcher, and that distinction is the whole design.</b> The
+/// obvious way to share one STA thread is <c>Dispatcher.Run()</c> plus <c>Dispatcher.Invoke</c>, and it was
+/// tried three ways. All three failed, each somewhere new: with no shutdown the run ended in an access
+/// violation at process exit; shutting down from <c>ProcessExit</c> replaced that with a hang; shutting
+/// down from a collection fixture passed locally and then crashed the CI test host mid-test, after 329
+/// tests and with 284 never run. The common factor was pumping. A pumping dispatcher schedules real layout
+/// passes over the views the tests built, <c>TextBlock.MeasureOverride</c> reaches DirectWrite through
+/// <c>FontFamily</c>'s static initialiser, and on a headless runner that dies with
+/// <c>0xC0000005</c>.</para>
+/// <para>What #2156 actually needs is that the thread owning the resources STAYS ALIVE. It does not need a
+/// message loop. So the thread drains a <see cref="BlockingCollection{T}"/> instead, and nothing schedules
+/// layout. <c>DispatcherTimer</c> and <c>InvokeAsync</c> remain as inert here as they were with a thread
+/// per call — that is the status quo, deliberately preserved, and it is why this cannot regress anything
+/// the old version supported.</para>
+/// <para><b>No shutdown hook, and none needed.</b> The thread is a background thread parked on
+/// <c>GetConsumingEnumerable</c>, so the runtime can discard it at exit with nothing in flight to
+/// interrupt. It was the in-flight native call that made the pumped version unsafe to abandon.</para>
 /// <para><b>What is traded away.</b> The per-call <c>Join</c> was also the isolation: a thread that dies
-/// takes its timers and pending operations with it. On a shared pumped thread a <c>DispatcherTimer</c>
-/// started by one test keeps ticking, and operations queued by an earlier test run before the current
-/// action rather than being discarded. Both are deliberate — the second is stricter ordering, not looser
-/// — but a test that leaves work on the dispatcher can now be observed by the next one, which was
-/// previously impossible. That is the cost of having resources a second test can use at all.</para>
-/// <para><b>The synchronous Invoke is correct here</b>, unlike in the application, where ten of them were
-/// removed for blocking on a dispatcher nothing pumped (#2152). The contract of this method is "run it
-/// there and wait", the dispatcher IS pumped by construction, and <c>Invoke</c> rethrows the action's
-/// exception on the caller's thread — which is what the old <c>captured</c>-and-rethrow did by hand.</para>
+/// takes anything it was holding with it. On a shared thread, state a test leaves in a thread-static or in
+/// <c>Application.Current.Resources</c> is visible to the next one. <c>Application.Current</c> was already
+/// process-wide, so that part is unchanged; what is new is that a second test can USE it, which is the
+/// point.</para>
 /// </remarks>
 public static class StaHelper
 {
-    private static readonly Lazy<Dispatcher> Sta = new(Start, LazyThreadSafetyMode.ExecutionAndPublication);
+    private static readonly BlockingCollection<Action> Queue = new();
 
-    /// <summary>
-    /// Starts the STA thread and returns its dispatcher once the thread is pumping.
-    /// </summary>
-    /// <remarks>
-    /// The handshake is required, not defensive: <c>Dispatcher.CurrentDispatcher</c> has to be read ON the
-    /// new thread — reading it from here would create and return a dispatcher for the CALLING thread, and
-    /// every <c>Invoke</c> would then run the action on the MTA test thread while appearing to work. The
-    /// thread is a background thread so it cannot keep the test host alive after the run.
-    /// </remarks>
-    private static Dispatcher Start()
+    private static readonly Lazy<Thread> Sta = new(Start, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static Thread Start()
     {
-        var ready = new TaskCompletionSource<Dispatcher>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-
         var thread = new Thread(() =>
         {
-            ready.SetResult(Dispatcher.CurrentDispatcher);
-            Dispatcher.Run();
+            foreach (var work in Queue.GetConsumingEnumerable())
+                work();
         })
         {
             Name = "SysManager integration STA",
@@ -63,44 +61,34 @@ public static class StaHelper
         };
         thread.SetApartmentState(ApartmentState.STA);
         thread.Start();
-
-        _thread = thread;
-        return ready.Task.GetAwaiter().GetResult();
+        return thread;
     }
-
-    private static Thread? _thread;
 
     /// <summary>
-    /// Ends the dispatcher and waits briefly for the thread. Called once, when the collection that owns
-    /// every STA test has finished; safe to call when the thread was never started.
+    /// Queues <paramref name="action"/> onto the STA thread, waits for it, and rethrows whatever it threw.
     /// </summary>
     /// <remarks>
-    /// <para><b>Why this exists at all.</b> A pumping dispatcher performs real layout passes over the views
-    /// the tests built, and <c>TextBlock.MeasureOverride</c> reaches DirectWrite through
-    /// <c>FontFamily</c>'s static initialiser. A background thread is killed where it stands when the
-    /// runtime tears down, so one inside that native call as the host exits takes the process down with
-    /// <c>0xC0000005</c> — after every test has already reported, which is the most confusing possible
-    /// place for it. Measured: six view tests passed and then the host died on the way out.</para>
-    /// <para><b>Why a collection fixture and not <c>ProcessExit</c>.</b> That was the first attempt and it
-    /// replaced the crash with a hang: shutting a dispatcher down from a <c>ProcessExit</c> handler asks
-    /// WPF to run work on a thread the runtime is already tearing down, and the host stopped exiting at
-    /// all. Measured too — 12 green and then a timeout instead of an exit. The end of the collection is the
-    /// right moment: every test has reported, and the runtime is still healthy enough to shut a dispatcher
-    /// down properly.</para>
-    /// <para>The join is bounded. A wedged dispatcher must not turn a completed run into a hung one — the
-    /// results are already in by this point, so giving up costs nothing that matters.</para>
+    /// The capture-and-rethrow is what the thread-per-call version did after its <c>Join</c>, kept
+    /// deliberately: a swallowed test failure is the worst outcome available here, so the exception has to
+    /// reach the caller as itself rather than wrapped in something the assertion cannot see through.
     /// </remarks>
-    internal static void Stop()
-    {
-        if (!Sta.IsValueCreated) return;
-
-        Sta.Value.InvokeShutdown();
-        _thread?.Join(TimeSpan.FromSeconds(5));
-    }
-
     public static void Run(Action action)
     {
         ArgumentNullException.ThrowIfNull(action);
-        Sta.Value.Invoke(action);
+
+        _ = Sta.Value;   // starts the thread on first use
+
+        using var done = new ManualResetEventSlim(initialState: false);
+        Exception? captured = null;
+
+        Queue.Add(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { captured = ex; }
+            finally { done.Set(); }
+        });
+
+        done.Wait();
+        if (captured is not null) throw captured;
     }
 }

--- a/SysManager/SysManager.IntegrationTests/StaHelper.cs
+++ b/SysManager/SysManager.IntegrationTests/StaHelper.cs
@@ -2,26 +2,105 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Windows.Threading;
+
 namespace SysManager.IntegrationTests;
 
 /// <summary>
-/// Runs an action on a dedicated STA thread. Required for tests that touch
-/// WPF Application / Dispatcher. xUnit's default runner is MTA.
+/// Runs an action on the suite's single STA thread and waits for it. Required for tests that touch
+/// WPF Application / Dispatcher: xUnit's own runner is MTA.
 /// </summary>
+/// <remarks>
+/// <para><b>One thread for the whole suite, not one per call.</b> This used to start a fresh STA thread
+/// per <see cref="Run"/> and <c>Join</c> it, which let the thread exit. That produced five failures the
+/// moment the suite ran to completion: <c>AppResources.Ensure()</c> creates the <c>Application</c> on
+/// whichever thread reaches it first, the brushes and styles in its <c>Resources</c> are
+/// <c>DispatcherObject</c>s owned by that thread, and every later view instantiation then resolved
+/// app-scope resources belonging to a thread that was not merely different but already gone —
+/// <c>InvalidOperationException: The calling thread cannot access this object because a different thread
+/// owns it</c>, surfacing as a <c>XamlParseException</c> on the first Style or BorderBrush (#2156).</para>
+/// <para><b>The thread pumps.</b> <see cref="Dispatcher.Run"/> makes this a real UI thread rather than an
+/// STA thread with a dispatcher nobody drains. That matters beyond the resource ownership: work posted
+/// with <c>InvokeAsync</c> or <c>BeginInvoke</c> now actually runs, so the suite exercises the same
+/// marshalling behaviour the application has instead of a degenerate version of it.</para>
+/// <para><b>What is traded away.</b> The per-call <c>Join</c> was also the isolation: a thread that dies
+/// takes its timers and pending operations with it. On a shared pumped thread a <c>DispatcherTimer</c>
+/// started by one test keeps ticking, and operations queued by an earlier test run before the current
+/// action rather than being discarded. Both are deliberate — the second is stricter ordering, not looser
+/// — but a test that leaves work on the dispatcher can now be observed by the next one, which was
+/// previously impossible. That is the cost of having resources a second test can use at all.</para>
+/// <para><b>The synchronous Invoke is correct here</b>, unlike in the application, where ten of them were
+/// removed for blocking on a dispatcher nothing pumped (#2152). The contract of this method is "run it
+/// there and wait", the dispatcher IS pumped by construction, and <c>Invoke</c> rethrows the action's
+/// exception on the caller's thread — which is what the old <c>captured</c>-and-rethrow did by hand.</para>
+/// </remarks>
 public static class StaHelper
 {
+    private static readonly Lazy<Dispatcher> Sta = new(Start, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Starts the STA thread and returns its dispatcher once the thread is pumping.
+    /// </summary>
+    /// <remarks>
+    /// The handshake is required, not defensive: <c>Dispatcher.CurrentDispatcher</c> has to be read ON the
+    /// new thread — reading it from here would create and return a dispatcher for the CALLING thread, and
+    /// every <c>Invoke</c> would then run the action on the MTA test thread while appearing to work. The
+    /// thread is a background thread so it cannot keep the test host alive after the run.
+    /// </remarks>
+    private static Dispatcher Start()
+    {
+        var ready = new TaskCompletionSource<Dispatcher>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var thread = new Thread(() =>
+        {
+            ready.SetResult(Dispatcher.CurrentDispatcher);
+            Dispatcher.Run();
+        })
+        {
+            Name = "SysManager integration STA",
+            IsBackground = true,
+        };
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+
+        _thread = thread;
+        return ready.Task.GetAwaiter().GetResult();
+    }
+
+    private static Thread? _thread;
+
+    /// <summary>
+    /// Ends the dispatcher and waits briefly for the thread. Called once, when the collection that owns
+    /// every STA test has finished; safe to call when the thread was never started.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Why this exists at all.</b> A pumping dispatcher performs real layout passes over the views
+    /// the tests built, and <c>TextBlock.MeasureOverride</c> reaches DirectWrite through
+    /// <c>FontFamily</c>'s static initialiser. A background thread is killed where it stands when the
+    /// runtime tears down, so one inside that native call as the host exits takes the process down with
+    /// <c>0xC0000005</c> — after every test has already reported, which is the most confusing possible
+    /// place for it. Measured: six view tests passed and then the host died on the way out.</para>
+    /// <para><b>Why a collection fixture and not <c>ProcessExit</c>.</b> That was the first attempt and it
+    /// replaced the crash with a hang: shutting a dispatcher down from a <c>ProcessExit</c> handler asks
+    /// WPF to run work on a thread the runtime is already tearing down, and the host stopped exiting at
+    /// all. Measured too — 12 green and then a timeout instead of an exit. The end of the collection is the
+    /// right moment: every test has reported, and the runtime is still healthy enough to shut a dispatcher
+    /// down properly.</para>
+    /// <para>The join is bounded. A wedged dispatcher must not turn a completed run into a hung one — the
+    /// results are already in by this point, so giving up costs nothing that matters.</para>
+    /// </remarks>
+    internal static void Stop()
+    {
+        if (!Sta.IsValueCreated) return;
+
+        Sta.Value.InvokeShutdown();
+        _thread?.Join(TimeSpan.FromSeconds(5));
+    }
+
     public static void Run(Action action)
     {
-        Exception? captured = null;
-        var t = new Thread(() =>
-        {
-            try { action(); }
-            catch (Exception ex) { captured = ex; }
-        });
-        t.SetApartmentState(ApartmentState.STA);
-        t.IsBackground = true;
-        t.Start();
-        t.Join();
-        if (captured != null) throw captured;
+        ArgumentNullException.ThrowIfNull(action);
+        Sta.Value.Invoke(action);
     }
 }

--- a/SysManager/SysManager.IntegrationTests/StaHelperTests.cs
+++ b/SysManager/SysManager.IntegrationTests/StaHelperTests.cs
@@ -4,18 +4,19 @@
 
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Threading;
 
 namespace SysManager.IntegrationTests;
 
 /// <summary>
-/// Pins what <see cref="StaHelper"/> guarantees: one STA thread for the whole suite, pumping, with the
-/// action's exception reaching the caller.
+/// Pins what <see cref="StaHelper"/> guarantees: one STA thread for the whole suite, and the action's
+/// exception reaching the caller.
 /// </summary>
 /// <remarks>
 /// Each of these was a property the previous thread-per-call version either lacked or provided by
 /// accident, and the first is the one that produced five failures the moment the suite ran to completion
 /// (#2156).
+/// <para>Nothing here asserts that a dispatcher runs, on purpose. The thread deliberately does not pump —
+/// see <see cref="StaHelper"/> for the three attempts that did and what each of them broke.</para>
 /// </remarks>
 [Collection("Network")] // shares the process-wide Application with the other Windows-level tests
 public class StaHelperTests
@@ -63,35 +64,22 @@ public class StaHelperTests
     }
 
     /// <summary>
-    /// The STA thread pumps, so work posted to its dispatcher actually runs.
+    /// The shared thread is an STA thread, which is the reason it exists.
     /// </summary>
     /// <remarks>
-    /// A thread that merely HAS a dispatcher is not a UI thread. Without <see cref="Dispatcher.Run"/>
-    /// anything posted with <c>InvokeAsync</c> or <c>BeginInvoke</c> sits in a queue nobody drains, which
-    /// is the condition that hid #2152 — and would now hide it again, since the application posts rather
-    /// than blocks.
-    /// <para>The ceiling is a bound on a wait, not a timing assumption: correct behaviour completes in
-    /// microseconds, and the only thing ten seconds distinguishes is "ran" from "never will".</para>
+    /// WPF refuses to construct a visual on an MTA thread, so a shared thread that lost its apartment
+    /// state would fail every view test with a different and far less obvious error than the one this
+    /// change is about. One line to assert, and it pins the one property of the thread that no other test
+    /// here would notice going missing.
     /// </remarks>
     [Fact]
-    public async Task Run_TheThreadPumps_SoPostedWorkRuns()
+    public void Run_RunsOnAnStaThread()
     {
-        var posted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var invoker = 0;
+        var state = ApartmentState.Unknown;
 
-        StaHelper.Run(() =>
-        {
-            invoker = Environment.CurrentManagedThreadId;
-            Dispatcher.CurrentDispatcher.InvokeAsync(
-                () => posted.SetResult(Environment.CurrentManagedThreadId));
-        });
+        StaHelper.Run(() => state = Thread.CurrentThread.GetApartmentState());
 
-        var settled = await Task.WhenAny(posted.Task, Task.Delay(TimeSpan.FromSeconds(10)));
-        Assert.True(ReferenceEquals(settled, posted.Task),
-            "work posted to the STA dispatcher never ran — the thread is not pumping");
-
-        // And it ran on that same thread, not somewhere the dispatcher happened to hand it to.
-        Assert.Equal(invoker, await posted.Task);
+        Assert.Equal(ApartmentState.STA, state);
     }
 
     /// <summary>

--- a/SysManager/SysManager.IntegrationTests/StaHelperTests.cs
+++ b/SysManager/SysManager.IntegrationTests/StaHelperTests.cs
@@ -1,0 +1,117 @@
+// SysManager · StaHelperTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+
+namespace SysManager.IntegrationTests;
+
+/// <summary>
+/// Pins what <see cref="StaHelper"/> guarantees: one STA thread for the whole suite, pumping, with the
+/// action's exception reaching the caller.
+/// </summary>
+/// <remarks>
+/// Each of these was a property the previous thread-per-call version either lacked or provided by
+/// accident, and the first is the one that produced five failures the moment the suite ran to completion
+/// (#2156).
+/// </remarks>
+[Collection("Network")] // shares the process-wide Application with the other Windows-level tests
+public class StaHelperTests
+{
+    /// <summary>
+    /// A styled WPF element can be built in one <c>Run</c> and again in the next.
+    /// </summary>
+    /// <remarks>
+    /// THE regression test. App-scope resources are <c>DispatcherObject</c>s owned by the thread that
+    /// created the <c>Application</c>; with a thread per call, the second build resolved a Style belonging
+    /// to a thread that had already exited and threw <c>InvalidOperationException: The calling thread
+    /// cannot access this object because a different thread owns it</c>, wrapped in a
+    /// <c>XamlParseException</c>.
+    /// <para>Applying the style is what matters, not finding it. <c>TryFindResource</c> returns the object
+    /// without touching a thread-affine member, which is why
+    /// <c>AppResourcesTests.Ensure_StillResolvesStylesOnASecondCall</c> passed throughout while four
+    /// <c>AboutViewUiTests</c> failed — so this assigns it to a real element and lets WPF's own thread
+    /// check run.</para>
+    /// </remarks>
+    [Fact]
+    public void Run_AStyledElementBuildsInTwoSeparateCalls()
+    {
+        static void BuildOne()
+        {
+            AppResources.Ensure();
+            var border = new Border { Style = (Style)Application.Current!.FindResource("Card") };
+            Assert.NotNull(border.Style);
+        }
+
+        StaHelper.Run(BuildOne);
+        StaHelper.Run(BuildOne);   // threw here, every time, before one thread was shared
+    }
+
+    [Fact]
+    public void Run_UsesTheSameThreadEveryTime_AndNotTheCallers()
+    {
+        var first = 0;
+        var second = 0;
+
+        StaHelper.Run(() => first = Environment.CurrentManagedThreadId);
+        StaHelper.Run(() => second = Environment.CurrentManagedThreadId);
+
+        Assert.Equal(first, second);
+        Assert.NotEqual(Environment.CurrentManagedThreadId, first);
+    }
+
+    /// <summary>
+    /// The STA thread pumps, so work posted to its dispatcher actually runs.
+    /// </summary>
+    /// <remarks>
+    /// A thread that merely HAS a dispatcher is not a UI thread. Without <see cref="Dispatcher.Run"/>
+    /// anything posted with <c>InvokeAsync</c> or <c>BeginInvoke</c> sits in a queue nobody drains, which
+    /// is the condition that hid #2152 — and would now hide it again, since the application posts rather
+    /// than blocks.
+    /// <para>The ceiling is a bound on a wait, not a timing assumption: correct behaviour completes in
+    /// microseconds, and the only thing ten seconds distinguishes is "ran" from "never will".</para>
+    /// </remarks>
+    [Fact]
+    public async Task Run_TheThreadPumps_SoPostedWorkRuns()
+    {
+        var posted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var invoker = 0;
+
+        StaHelper.Run(() =>
+        {
+            invoker = Environment.CurrentManagedThreadId;
+            Dispatcher.CurrentDispatcher.InvokeAsync(
+                () => posted.SetResult(Environment.CurrentManagedThreadId));
+        });
+
+        var settled = await Task.WhenAny(posted.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+        Assert.True(ReferenceEquals(settled, posted.Task),
+            "work posted to the STA dispatcher never ran — the thread is not pumping");
+
+        // And it ran on that same thread, not somewhere the dispatcher happened to hand it to.
+        Assert.Equal(invoker, await posted.Task);
+    }
+
+    /// <summary>
+    /// The action's exception reaches the caller, with its type and message.
+    /// </summary>
+    /// <remarks>
+    /// The old version captured it into a local and rethrew after <c>Join</c>. <c>Dispatcher.Invoke</c>
+    /// does the same thing, and this asserts it rather than assuming the framework's behaviour matches the
+    /// hand-rolled one it replaced — a swallowed test failure is the worst outcome available here.
+    /// </remarks>
+    [Fact]
+    public void Run_PropagatesTheActionsExceptionToTheCaller()
+    {
+        var thrown = Assert.Throws<InvalidOperationException>(
+            () => StaHelper.Run(() => throw new InvalidOperationException("raised on the STA thread")));
+
+        Assert.Equal("raised on the STA thread", thrown.Message);
+    }
+
+    [Fact]
+    public void Run_RejectsANullAction()
+        => Assert.Throws<ArgumentNullException>(() => StaHelper.Run(null!));
+}

--- a/SysManager/SysManager.IntegrationTests/TestCollections.cs
+++ b/SysManager/SysManager.IntegrationTests/TestCollections.cs
@@ -5,8 +5,32 @@
 namespace SysManager.IntegrationTests;
 
 /// <summary>
-/// Groups tests that touch the network stack so they run sequentially.
-/// Prevents cross-test interference when using ICMP sockets in parallel.
+/// Groups tests that touch the network stack or the process-wide WPF <c>Application</c> so they run
+/// sequentially. Prevents cross-test interference when using ICMP sockets in parallel, and gives the
+/// suite's single STA thread a defined end.
 /// </summary>
 [CollectionDefinition("Network", DisableParallelization = true)]
-public class NetworkCollection { }
+public class NetworkCollection : ICollectionFixture<StaThreadFixture> { }
+
+/// <summary>
+/// Ends <see cref="StaHelper"/>'s STA thread when the last test in the collection has finished.
+/// </summary>
+/// <remarks>
+/// The thread pumps a dispatcher, which performs real layout passes over the views the tests built. Left
+/// running into process teardown it takes the host down with an access violation from inside DirectWrite,
+/// after every test has already reported. A collection fixture is disposed once the collection completes
+/// and while the runtime is still healthy, which is the only moment a dispatcher can be shut down
+/// properly — a <c>ProcessExit</c> handler was tried first and turned the crash into a hang.
+/// <para>Every class that calls <see cref="StaHelper.Run"/> is in this collection, so the fixture's
+/// lifetime covers all of them. Nothing injects it: a collection fixture is created before the first test
+/// and disposed after the last whether or not a test class asks for it, and there is nothing here for a
+/// test to use.</para>
+/// </remarks>
+public sealed class StaThreadFixture : IDisposable
+{
+    public void Dispose()
+    {
+        StaHelper.Stop();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/SysManager/SysManager.IntegrationTests/TestCollections.cs
+++ b/SysManager/SysManager.IntegrationTests/TestCollections.cs
@@ -6,31 +6,8 @@ namespace SysManager.IntegrationTests;
 
 /// <summary>
 /// Groups tests that touch the network stack or the process-wide WPF <c>Application</c> so they run
-/// sequentially. Prevents cross-test interference when using ICMP sockets in parallel, and gives the
-/// suite's single STA thread a defined end.
+/// sequentially. Prevents cross-test interference when using ICMP sockets in parallel, and keeps the
+/// tests that share <see cref="StaHelper"/>'s single STA thread from overlapping.
 /// </summary>
 [CollectionDefinition("Network", DisableParallelization = true)]
-public class NetworkCollection : ICollectionFixture<StaThreadFixture> { }
-
-/// <summary>
-/// Ends <see cref="StaHelper"/>'s STA thread when the last test in the collection has finished.
-/// </summary>
-/// <remarks>
-/// The thread pumps a dispatcher, which performs real layout passes over the views the tests built. Left
-/// running into process teardown it takes the host down with an access violation from inside DirectWrite,
-/// after every test has already reported. A collection fixture is disposed once the collection completes
-/// and while the runtime is still healthy, which is the only moment a dispatcher can be shut down
-/// properly — a <c>ProcessExit</c> handler was tried first and turned the crash into a hang.
-/// <para>Every class that calls <see cref="StaHelper.Run"/> is in this collection, so the fixture's
-/// lifetime covers all of them. Nothing injects it: a collection fixture is created before the first test
-/// and disposed after the last whether or not a test class asks for it, and there is nothing here for a
-/// test to use.</para>
-/// </remarks>
-public sealed class StaThreadFixture : IDisposable
-{
-    public void Dispose()
-    {
-        StaHelper.Stop();
-        GC.SuppressFinalize(this);
-    }
-}
+public class NetworkCollection { }


### PR DESCRIPTION
`StaHelper` started a fresh STA thread per call and `Join`ed it, letting the thread exit. `AppResources.Ensure()` creates the `Application` on whichever STA thread reaches it first, and the brushes and styles in its `Resources` are `DispatcherObject`s owned by that thread — so every later view instantiation resolved app-scope resources belonging to a thread that was not merely different but already gone:

```
XamlParseException : Set property 'System.Windows.FrameworkElement.Style' threw an exception.
---- InvalidOperationException : The calling thread cannot access this object because a different
     thread owns it.
```

Five failures — `AboutViewUiTests` ×4 and `DeepCleanupViewUiTests.View_Instantiates_OnStaThread`. It also explains which ones *passed*: whichever test got the thread that created the `Application` was fine. Unreachable before, because the suite aborted at test 202 of 613; visible the moment #2155 let it finish.

### Reproduced and verified locally, four ways

| | result | exit |
|---|---|---|
| thread per call, as shipped | 1 green **5 red — exactly the CI failures** | 1 |
| one shared pumped thread | 12 green | **crash 0xC0000005** |
| … + shutdown from `ProcessExit` | 12 green | **hang** (timeout) |
| … + shutdown at the end of the collection | **12 green** | **0** |

The middle two rows are the part worth reading, and neither was predictable from the issue.

**Why the crash.** A pumping dispatcher performs real layout passes over the views the tests built, and `TextBlock.MeasureOverride` reaches DirectWrite through `FontFamily`'s static initialiser. A background thread is killed where it stands when the runtime tears down, so one inside that native call as the host exits takes the process with it — *after* every test has reported, which is the most confusing possible place for a crash. The thread-per-call version could not hit it, because the thread ended before any layout pass could be scheduled.

**Why not `ProcessExit`.** That was the obvious fix and it replaced the crash with a hang: it asks WPF to run work on a thread the runtime is already tearing down. The end of the collection is the right moment — every test has reported and the runtime is still healthy — so `NetworkCollection` gained an `ICollectionFixture` that calls `StaHelper.Stop()`. Every class that calls `Run` is in that collection, verified rather than assumed, and nothing injects the fixture because a collection fixture is created and disposed whether or not a test class asks for it.

### The synchronous `Invoke` here is correct

Unlike the ten removed from the application in #2152: the contract of `Run` is "run it there and wait", the dispatcher **is** pumped by construction, and `Invoke` rethrows the action's exception on the caller's thread — which is what the hand-rolled `captured`-and-rethrow did. A test asserts that, rather than assuming the framework matches the code it replaced.

### What is traded away, deliberately

The per-call `Join` was also the isolation. On a shared pumped thread a `DispatcherTimer` started by one test keeps ticking, and work queued by an earlier test runs *before* the current action rather than being discarded. The second is stricter ordering, not looser — but a test that leaves work on the dispatcher can now be observed by the next one, which was previously impossible. That is the cost of having resources a second test can use at all.

### Tests

`StaHelperTests` pins the four properties. The regression test applies a `Style` in two separate `Run` calls, which is what threw — **applying** it is the point, because `TryFindResource` returns the object without touching a thread-affine member. That is why `AppResourcesTests.Ensure_StillResolvesStyles…` passed throughout while four view tests failed; it is renamed (it said `FromAnotherStaThread`, now untrue) with its remarks recording what it does not cover.

**What only CI can prove:** that xUnit creates and disposes the collection fixture as expected. The local runs above stand in for it by calling `Stop()` through reflection at the end. If the integration job comes back with 0 failures, that is the confirmation, and I will report it here either way.

### Verification

- Four projects build, 0 errors 0 warnings
- 111 green, 1 red across every `ArchitectureTests` guard; the red is the throwaway local runner's own file, which is not in this repository
- `dotnet format --verify-no-changes` clean
- Leak scan: 43 patterns over 13,599 bytes of added lines, 0 hits

`test:` — no behaviour change in the app, no version bump, no CHANGELOG, no release.

Closes #2156.