### PR TITLE
test: the console test answered differently depending on what ran before it

### DIFF
--- a/SysManager/SysManager.IntegrationTests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/WindowsUpdateViewModelTests.cs
@@ -177,21 +177,62 @@ public class WindowsUpdateViewModelTests
 
     // ---------- runner plumbing ----------
 
+    /// <summary>
+    /// A line from the runner reaches the console.
+    /// </summary>
+    /// <remarks>
+    /// Run on the UI thread, and that is the whole fix. <c>ConsoleViewModel.Append</c> marshals when it is
+    /// called from anywhere else:
+    /// <code>
+    /// if (Application.Current?.Dispatcher.CheckAccess() == false)
+    /// {
+    ///     Application.Current.Dispatcher.BeginInvoke(() => Append(line));
+    ///     return;
+    /// }
+    /// </code>
+    /// Raised from the MTA test thread it therefore queued the append and returned, leaving
+    /// <c>Lines.Count</c> at zero on the next statement — but only when an <c>Application</c> existed. With
+    /// none, the guard is false and <c>Append</c> runs inline, so the same assertion passed. Which of those
+    /// the test got depended on whether a UI test had run first: it failed once and passed twice across
+    /// three consecutive suite runs with nothing between them touching either class (#2157). A test that
+    /// reports green two times in three while asserting nothing reliable is worse than a red one.
+    /// <para>On the STA thread the marshal is a no-op — <c>CheckAccess()</c> is true, because that thread
+    /// is the one the <c>Application</c> was created on — so the append happens before the assertion, in
+    /// every ordering. The premise is asserted rather than assumed: if <c>StaHelper</c> ever stops being
+    /// the dispatcher's own thread this fails loudly instead of quietly going order-dependent again.</para>
+    /// <para>Deliberately NOT fixed by waiting for the queued operation. The suite's STA thread drains a
+    /// work queue rather than pumping a dispatcher (#2156), so posted work never runs and there would be
+    /// nothing to wait for. Nor by making <c>Append</c> synchronous: it marshals for a reason —
+    /// <c>LineReceived</c> arrives from PowerShell on a pool thread and <c>Lines</c> is bound — and a
+    /// blocking marshal is the defect removed from ten other places in #2152.</para>
+    /// <para>No <c>[Collection]</c> change needed. <see cref="StaHelper"/> serialises everything through
+    /// one queue, so this cannot interleave with the Windows-level collection even though it runs
+    /// alongside it.</para>
+    /// </remarks>
     [Fact]
     public void RunnerLineReceived_AppendsToConsole()
     {
-        var runner = new PowerShellRunner();
-        var vm = new WindowsUpdateViewModel(runner, new WindowsUpdateService(), new WindowsUpdatePolicyService());
+        StaHelper.Run(() =>
+        {
+            AppResources.Ensure();
+            Assert.True(System.Windows.Application.Current!.Dispatcher.CheckAccess(),
+                "this test is only deterministic on the dispatcher's own thread — Append marshals from "
+                + "anywhere else, and the assertion below would race the queued operation");
 
-        var ev = typeof(PowerShellRunner)
-            .GetField(nameof(PowerShellRunner.LineReceived),
-                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
-        var del = (MulticastDelegate?)ev?.GetValue(runner);
-        Assert.NotNull(del);
+            var runner = new PowerShellRunner();
+            var vm = new WindowsUpdateViewModel(
+                runner, new WindowsUpdateService(), new WindowsUpdatePolicyService());
 
-        del!.DynamicInvoke(Models.PowerShellLine.Output("wu test"));
+            var ev = typeof(PowerShellRunner)
+                .GetField(nameof(PowerShellRunner.LineReceived),
+                    BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            var del = (MulticastDelegate?)ev?.GetValue(runner);
+            Assert.NotNull(del);
 
-        Assert.True(vm.Console.Lines.Count >= 1);
+            del!.DynamicInvoke(Models.PowerShellLine.Output("wu test"));
+
+            Assert.Contains(vm.Console.Lines, line => line.Text.Contains("wu test", StringComparison.Ordinal));
+        });
     }
 
     [Fact]


### PR DESCRIPTION
`RunnerLineReceived_AppendsToConsole` raised `LineReceived` from the MTA test thread and asserted `Lines.Count >= 1` on the next statement. `ConsoleViewModel.Append` marshals when called from anywhere but the UI thread:

```csharp
if (Application.Current?.Dispatcher.CheckAccess() == false)
{
    Application.Current.Dispatcher.BeginInvoke(() => Append(line));
    return;
}
```

So it queued the append and returned, leaving the count at zero — **but only when an `Application` existed.** With none, the guard is false, `Append` runs inline, and the same assertion passed. Which one the test got depended on whether a UI test had run first: it **failed once and passed twice** across three consecutive suite runs with nothing between them touching either class.

A test that reports green two times in three while asserting nothing reliable is worse than a red one, which is why this is worth doing rather than leaving the suite at 0 failures.

### The fix

Run it on the UI thread, where the marshal is a no-op and the append therefore happens before the assertion in every ordering. The **premise is asserted rather than assumed** — if `StaHelper` ever stops being the dispatcher's own thread, this fails loudly instead of quietly going order-dependent again.

Two things deliberately not done:

- **Waiting for the queued operation.** The suite's STA thread drains a work queue rather than pumping a dispatcher (#2156), so posted work never runs and there would be nothing to wait for.
- **Making `Append` synchronous.** It marshals for a reason — `LineReceived` arrives from PowerShell on a pool thread and `Lines` is bound — and a blocking marshal is the defect removed from ten other places in #2152.

No `[Collection]` change: `StaHelper` serialises everything through one queue, so this cannot interleave with the Windows-level collection even though it runs alongside it.

### Red/green — the proof is the order dependence itself

The same test, run in two orderings:

| | alone | after a UI test |
|---|---|---|
| **fixed body** | GREEN | GREEN |
| M1 the old body, asserting on the MTA thread | GREEN | **RED** |
| M2 new assertion, no `StaHelper.Run` wrapper | GREEN | **RED** |
| M3 premise assertion inverted | RED | RED |
| restored, sha verified | GREEN | GREEN |

**M1 is the defect, demonstrated rather than argued:** two different answers from one test with no code change between them.

**M2 shows the wrapper is what fixes it**, not the reworded assertion — and its failure message is the smoking gun:

```
ContainsException: Assert.Contains() Failure: Filter not matched in collection | Collection: []
```

The console is empty because the append is still sitting in the queue.

`Assert.Contains` on the line's text replaces `Assert.True(Count >= 1)`: a count says something arrived, and what this test is about is that the **line** did.

### Verification

- Both test projects build, 0 errors 0 warnings
- 111 green, 1 red across every `ArchitectureTests` guard; the red is the throwaway local runner's own file, which is not in this repository
- `dotnet format --verify-no-changes` clean
- Leak scan: 43 patterns over 3,365 bytes of added lines, 0 hits

`test:` — no behaviour change in the app, no version bump, no CHANGELOG, no release.

Closes #2157.