### PR TITLE
fix: an elevated tab started a new PowerShell helper for every single call

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -184,6 +184,20 @@ Key services:
   use an in-process runspace and retain per-user modules. Elevated sessions use
   an isolated Windows PowerShell 5.1 child with module discovery limited to canonical
   machine-owned roots, avoiding process-global environment mutation.
+  An elevated runner REUSES its runspace across calls, because starting that child
+  and completing a remoting handshake with it is the slow part and the services
+  that use it call in bursts (`DnsService` six times, `EdgeOneDriveService` four).
+  Three properties make reuse safe: the runspace state is re-checked on every
+  lease, so a child killed from outside is discarded and rebuilt rather than
+  failing every later call; pipelines are serialised behind a gate, because a
+  runspace runs one at a time and a shared one turns concurrent calls into a
+  conflict; and the runspace is evicted after ~20 s idle, which matters because
+  nine runners are constructed directly in `MainWindowViewModel`'s designer graph
+  and nothing ever disposes them — without eviction a dozen `powershell.exe`
+  processes would be resident for the whole run. `Dispose` releases it
+  deterministically where a consumer is disposed. The unelevated path is
+  unchanged and still builds per call: it starts no child, so caching would add a
+  lifetime to reason about for almost no gain.
 - `WingetService` — shells out to `winget` and parses its table output.
 - `WindowsUpdateService` — drives Windows Update through the WUA COM API
   (scan, select, install) with progress reporting; backs `WindowsUpdateViewModel`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.78.7] - 2026-09-08
+
+Running SysManager as administrator made several tabs feel slower than they needed to. Every single thing
+they asked Windows to do started a fresh hidden helper first and waited for it to be ready — DNS &
+Hosts does that six times, Edge/OneDrive Remover four. Those tabs now start one helper and use it for the
+whole batch, and let it go once you have moved on.
+
+### Changed
+- **Administrator tasks reuse their helper instead of starting a new one every time.** The wait to start
+  one is the slow part, so a tab doing several things in a row is now noticeably quicker on the second
+  action onward. It is let go about twenty seconds after you stop, so nothing is left sitting in memory
+  while you use the rest of the app — and if it ever stops responding, the next action quietly starts a
+  fresh one rather than failing.
+
 ## [1.78.6] - 2026-09-08
 
 If your antivirus happened to be reading one of SysManager's own settings files at the exact moment

--- a/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
@@ -12,9 +12,19 @@ namespace SysManager.IntegrationTests;
 public class PowerShellRunnerTests
 {
     /// <summary>
-    /// A run's teardown STOPS the child process the runspace was built with, rather than only dropping its
-    /// handle.
+    /// Disposing the runner STOPS the child process its runspace was built with, rather than only dropping
+    /// the handle.
     /// </summary>
+    /// <remarks>
+    /// <para><b>Was "a run's teardown", and that changed.</b> An elevated runner now REUSES its runspace
+    /// across calls rather than building one per call (#2149), so the end of a run is no longer when the
+    /// child is released — the release points are eviction after
+    /// <see cref="PowerShellRunner.IdleRunspaceLifetime"/> and disposal of the runner. This asserts the
+    /// deterministic one.</para>
+    /// <para>Elevation is forced rather than inherited so the test exercises the reuse path on any machine.
+    /// The runspace itself is in-process, so nothing here needs administrator rights; the injected child
+    /// stands in for the <c>powershell.exe</c> that the real elevated path would have started.</para>
+    /// </remarks>
     /// <remarks>
     /// #2149(a), end to end through <c>RunAsync</c>. Disposing a <see cref="System.Diagnostics.Process"/>
     /// releases the HANDLE and does not stop the process. When <c>powershell.exe</c> outlived its runspace, its
@@ -41,7 +51,7 @@ public class PowerShellRunnerTests
     /// polled, so there is no sleeping and nothing to go flaky.</para>
     /// </remarks>
     [Fact]
-    public async Task RunspaceTeardown_StopsTheChildTheRunspaceWasBuiltWith()
+    public async Task DisposingTheRunner_StopsTheChildItsRunspaceWasBuiltWith()
     {
         var child = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(
             "cmd.exe", "/c ping -n 60 127.0.0.1 > nul")
@@ -60,16 +70,24 @@ public class PowerShellRunnerTests
                 System.Management.Automation.Runspaces.InitialSessionState.CreateDefault2());
             var runner = new PowerShellRunner(
                 action => Task.Run(action),
+                isElevated: static () => true,
                 createRunspace: () => (runspace, null, child));
 
             var result = await runner.RunAsync("2 + 2");
-            Assert.Equal(4, (int)result[0].BaseObject);   // the run really happened, so teardown really ran
+            Assert.Equal(4, (int)result[0].BaseObject);   // the run really happened
+
+            // Still alive, because the runspace is now cached for reuse rather than torn down per call.
+            Assert.False(observer.HasExited,
+                "the child was released at the end of the run — reuse is not taking effect, so every "
+                + "elevated call still spawns and hands-shakes its own powershell.exe");
+
+            runner.Dispose();
 
             using var bounded = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             await observer.WaitForExitAsync(bounded.Token);
 
             Assert.True(observer.HasExited,
-                "the child process outlived the run; its pipes stay open and the remoting transport's "
+                "the child process outlived the runner; its pipes stay open and the remoting transport's "
                 + "reader threads stay blocked on them forever");
         }
         finally
@@ -77,6 +95,190 @@ public class PowerShellRunnerTests
             try { if (!observer.HasExited) observer.Kill(entireProcessTree: true); }
             catch (InvalidOperationException) { /* already gone, which is the expected outcome */ }
         }
+    }
+
+    /// <summary>
+    /// An elevated runner builds ONE runspace for several calls, not one per call.
+    /// </summary>
+    /// <remarks>
+    /// The point of #2149's second half. Every elevated call used to spawn a <c>powershell.exe</c> 5.1 child
+    /// and complete a remoting handshake with it, then throw both away — and the services that use this make
+    /// their calls in bursts: <c>DnsService</c> six, <c>EdgeOneDriveService</c> four, three others three each.
+    /// <para>Counted through the <c>createRunspace</c> seam rather than by timing, so the assertion is
+    /// exact and cannot go flaky on a slow machine. The runspaces are in-process, so nothing here needs
+    /// administrator rights.</para>
+    /// </remarks>
+    [Fact]
+    public async Task ElevatedRunner_ReusesOneRunspaceAcrossCalls()
+    {
+        var built = 0;
+        using var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            isElevated: static () => true,
+            createRunspace: () =>
+            {
+                built++;
+                return (System.Management.Automation.Runspaces.RunspaceFactory.CreateRunspace(
+                            System.Management.Automation.Runspaces.InitialSessionState.CreateDefault2()),
+                        null, null);
+            });
+
+        for (var call = 0; call < 4; call++)
+            Assert.Equal(4, (int)(await runner.RunAsync("2 + 2"))[0].BaseObject);
+
+        Assert.Equal(1, built);
+    }
+
+    /// <summary>
+    /// The unelevated path is untouched: it still builds a runspace per call.
+    /// </summary>
+    /// <remarks>
+    /// Scope, asserted rather than described. The in-process runspace starts no child and opens in a
+    /// fraction of the time, so caching it would add a lifetime to reason about for almost no gain — and
+    /// #2149 is about the out-of-process branch only. Without this, narrowing or widening the elevation
+    /// check would go unnoticed.
+    /// </remarks>
+    [Fact]
+    public async Task UnelevatedRunner_StillBuildsARunspacePerCall()
+    {
+        var built = 0;
+        using var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            isElevated: static () => false,
+            createRunspace: () =>
+            {
+                built++;
+                return (System.Management.Automation.Runspaces.RunspaceFactory.CreateRunspace(
+                            System.Management.Automation.Runspaces.InitialSessionState.CreateDefault2()),
+                        null, null);
+            });
+
+        for (var call = 0; call < 3; call++)
+            await runner.RunAsync("2 + 2");
+
+        Assert.Equal(3, built);
+    }
+
+    /// <summary>
+    /// A reused runspace is released once it has been idle, not held for the session.
+    /// </summary>
+    /// <remarks>
+    /// The half of the design that keeps reuse from becoming a memory trade. Nothing disposes most of these
+    /// runners — nine are built directly in <c>MainWindowViewModel</c>'s designer graph and live as long as
+    /// the window — so without eviction a dozen <c>powershell.exe</c> processes would be resident for the
+    /// whole run, in an app whose pitch is making a PC feel faster.
+    /// <para>Driven with a 200&#160;ms lifetime through the constructor seam. The wait is bounded and
+    /// polls for the state change rather than sleeping a fixed interval and hoping.</para>
+    /// </remarks>
+    [Fact]
+    public async Task ElevatedRunner_ReleasesTheRunspaceOnceIdle()
+    {
+        var built = 0;
+        using var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            isElevated: static () => true,
+            idleRunspaceLifetime: TimeSpan.FromMilliseconds(200),
+            createRunspace: () =>
+            {
+                built++;
+                return (System.Management.Automation.Runspaces.RunspaceFactory.CreateRunspace(
+                            System.Management.Automation.Runspaces.InitialSessionState.CreateDefault2()),
+                        null, null);
+            });
+
+        await runner.RunAsync("2 + 2");
+        Assert.Equal(1, built);
+
+        // Longer than the lifetime, and doubling if a slow machine needs more. Waiting LESS than the
+        // lifetime cannot work: every run re-arms the countdown, so polling faster than it keeps it alive
+        // forever — which is what the first version of this test did.
+        using var bounded = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        var wait = TimeSpan.FromMilliseconds(400);
+        while (built == 1)
+        {
+            await Task.Delay(wait, bounded.Token);
+            await runner.RunAsync("2 + 2");   // rebuilds once the idle one has been evicted
+            wait *= 2;
+        }
+
+        Assert.Equal(2, built);
+    }
+
+    /// <summary>
+    /// A cached runspace that is no longer open is discarded and rebuilt.
+    /// </summary>
+    /// <remarks>
+    /// The recovery path, and the reason the state is re-checked on every lease rather than assumed. Things
+    /// outside this class can break a cached runspace — the child killed by the user or by cleanup, the
+    /// remoting channel dropped — and a runspace that is not <c>Opened</c> cannot run a pipeline at all.
+    /// Without the re-check, one broken child would make every later call on that consumer fail for the rest
+    /// of the session, which is a far worse failure than the per-call cost reuse removes.
+    /// <para><c>Close()</c> stands in for all of those: it is the state they leave behind, reached
+    /// deterministically instead of by killing something and hoping.</para>
+    /// </remarks>
+    [Fact]
+    public async Task ElevatedRunner_RebuildsARunspaceThatIsNoLongerOpen()
+    {
+        var built = 0;
+        System.Management.Automation.Runspaces.Runspace? last = null;
+        using var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            isElevated: static () => true,
+            createRunspace: () =>
+            {
+                built++;
+                last = System.Management.Automation.Runspaces.RunspaceFactory.CreateRunspace(
+                    System.Management.Automation.Runspaces.InitialSessionState.CreateDefault2());
+                return (last, null, null);
+            });
+
+        await runner.RunAsync("2 + 2");
+        Assert.Equal(1, built);
+
+        last!.Close();
+
+        Assert.Equal(4, (int)(await runner.RunAsync("2 + 2"))[0].BaseObject);
+        Assert.Equal(2, built);
+    }
+
+    /// <summary>
+    /// Two calls that overlap on an ALREADY-CACHED runspace both complete.
+    /// </summary>
+    /// <remarks>
+    /// The hazard reuse introduces. A runspace runs one pipeline at a time, so where a runspace per call made
+    /// concurrent calls independent, a shared one makes them a conflict — <c>BeginInvoke</c> against a busy
+    /// runspace throws. They are serialised behind a gate instead, and this is what says so.
+    /// <para><b>The warm-up call is the whole test.</b> Without it, two calls started back to back do not
+    /// conflict and this passes with the gate removed: the first has not cached anything by the time the
+    /// second leases, so each builds its own runspace and nothing is shared. Measured — the first version of
+    /// this test stayed GREEN under a mutation that deleted the gate entirely. Establishing the cache first is
+    /// what makes both callers actually reach for the same runspace.</para>
+    /// <para>The sleep exists to hold the first pipeline open while the second arrives. It creates the
+    /// overlap rather than being asserted on, so there is no timing in the assertions.</para>
+    /// <para>Cheap in practice: the type is registered Transient so each consumer has its own runner, and the
+    /// consumers that make several calls already serialise them. The gate is the guarantee rather than a
+    /// dependency on that staying true.</para>
+    /// </remarks>
+    [Fact]
+    public async Task ElevatedRunner_OverlappingCallsOnACachedRunspace_BothComplete()
+    {
+        using var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            isElevated: static () => true,
+            createRunspace: () =>
+                (System.Management.Automation.Runspaces.RunspaceFactory.CreateRunspace(
+                     System.Management.Automation.Runspaces.InitialSessionState.CreateDefault2()),
+                 null, null));
+
+        await runner.RunAsync("2 + 2");   // establishes the cache — see the remarks
+
+        var slow = runner.RunAsync("Start-Sleep -Milliseconds 300; 2 + 2");
+        var quick = runner.RunAsync("3 + 3");
+
+        var results = await Task.WhenAll(slow, quick);
+
+        Assert.Equal(4, (int)results[0][0].BaseObject);
+        Assert.Equal(6, (int)results[1][0].BaseObject);
     }
 
     [Fact]

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -24,8 +24,25 @@ namespace SysManager.Services;
 /// Violation of this contract creates a code injection vulnerability. The Bypass policy
 /// is safe ONLY because the script content is fully controlled by SysManager's source code.</para>
 /// </summary>
-public sealed class PowerShellRunner : IPowerShellRunner
+public sealed class PowerShellRunner : IPowerShellRunner, IDisposable
 {
+    /// <summary>
+    /// Serialises pipelines on this runner, because a reused runspace can only run one at a time.
+    /// </summary>
+    /// <remarks>
+    /// A runspace per call needed no gate — each pipeline had its own. Reuse makes concurrent calls on one
+    /// runner a conflict, so they queue. Low cost in practice: this type is registered Transient precisely
+    /// so each consumer gets its own instance, and the consumers that make several calls already serialise
+    /// them (<c>DnsService</c> has its own gate). The gate is here as the guarantee rather than as a
+    /// dependency on that continuing to be true.
+    /// </remarks>
+    private readonly SemaphoreSlim _pipeline = new(1, 1);
+
+    private readonly TimeSpan _idleRunspaceLifetime;
+    private RunspaceResources? _cached;
+    private Timer? _idleEviction;
+    private bool _disposed;
+
     private readonly Func<Action, Task> _scheduleProcessStart;
     private readonly Func<System.Diagnostics.Process, CancellationToken, Task> _waitForProcessExit;
     private readonly Action<System.Diagnostics.Process> _terminateProcessTree;
@@ -48,8 +65,10 @@ public sealed class PowerShellRunner : IPowerShellRunner
         string? trustedPowerShellModulePath = null,
         Func<Runspace, Task>? openRunspace = null,
         Func<(Runspace Runspace, IDisposable? ProcessInstance, IDisposable? Process)>? createRunspace = null,
-        TimeSpan? openRunspaceTimeout = null)
+        TimeSpan? openRunspaceTimeout = null,
+        TimeSpan? idleRunspaceLifetime = null)
     {
+        _idleRunspaceLifetime = idleRunspaceLifetime ?? IdleRunspaceLifetime;
         _scheduleProcessStart = scheduleProcessStart
             ?? throw new ArgumentNullException(nameof(scheduleProcessStart));
         _waitForProcessExit = waitForProcessExit
@@ -113,11 +132,29 @@ public sealed class PowerShellRunner : IPowerShellRunner
         IDictionary<string, object?>? parameters = null,
         CancellationToken cancellationToken = default)
     {
-        using var resources = CreateRunspaceResources();
-        var runspace = resources.Runspace;
+        await _pipeline.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await RunOnLeasedRunspaceAsync(script, parameters, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            ArmIdleEviction();
+            _pipeline.Release();
+        }
+    }
+
+    private async Task<Collection<PSObject>> RunOnLeasedRunspaceAsync(
+        string script,
+        IDictionary<string, object?>? parameters,
+        CancellationToken cancellationToken)
+    {
         // Open the runspace on a thread-pool thread — this can take
         // several hundred milliseconds and must not block the UI.
-        await OpenRunspaceAsync(runspace).ConfigureAwait(false);
+        var lease = await LeaseRunspaceAsync().ConfigureAwait(false);
+        using var perCall = lease.Reusable ? null : lease.Resources;
+        var runspace = lease.Resources.Runspace;
 
         using var ps = PowerShell.Create();
         ps.Runspace = runspace;
@@ -577,6 +614,147 @@ public sealed class PowerShellRunner : IPowerShellRunner
         {
             throw CreatePowerShellHostUnavailableException(ex);
         }
+    }
+
+    /// <summary>
+    /// How long a reusable runspace may sit unused before it and its child process are released.
+    /// </summary>
+    /// <remarks>
+    /// The benefit of reuse is in BURSTS, not over a session: <c>DnsService</c> makes six elevated calls,
+    /// <c>EdgeOneDriveService</c> four, three services three each, and those arrive together. Twenty seconds
+    /// covers a burst with room for a slow one in the middle.
+    /// <para>Keeping it for the session instead would be the obvious reading of "one runspace per session"
+    /// and it is the wrong one. Nothing disposes most of these runners — nine are constructed directly in
+    /// <c>MainWindowViewModel</c>'s designer graph and live as long as the window — so a session-long cache
+    /// would mean a dozen <c>powershell.exe</c> processes resident for the whole run, tens of MB each, in an
+    /// app whose entire pitch is making a PC feel faster. Eviction is what makes reuse a latency win rather
+    /// than a memory trade.</para>
+    /// </remarks>
+    internal static readonly TimeSpan IdleRunspaceLifetime = TimeSpan.FromSeconds(20);
+
+    /// <summary>
+    /// A runspace ready to run a pipeline, and whether it belongs to the cache or to this call alone.
+    /// </summary>
+    private readonly record struct RunspaceLease(RunspaceResources Resources, bool Reusable);
+
+    /// <summary>
+    /// Returns an open runspace: the cached one when it is still usable, otherwise a fresh one.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Elevated only.</b> The in-process runspace the unelevated path uses starts no child process
+    /// and opens in a fraction of the time, so caching it would add a lifetime to reason about and buy
+    /// almost nothing. The out-of-process branch is the one that spawns <c>powershell.exe</c> 5.1 and
+    /// completes a remoting handshake, and it is the only branch #2149 is about.</para>
+    /// <para><b>State is re-checked every time, not assumed.</b> A cached runspace can be broken by things
+    /// outside this class — the child killed by a user or by cleanup, the remoting channel dropped — and a
+    /// runspace that is not <c>Opened</c> cannot run a pipeline. Anything other than <c>Opened</c> means
+    /// discard and rebuild, which also covers the state this code cannot enumerate in advance.</para>
+    /// <para><b>A failed open leaves nothing cached.</b> The fresh resources are disposed and the exception
+    /// propagates, so the next call starts clean rather than retrying against a half-opened runspace.</para>
+    /// </remarks>
+    private async Task<RunspaceLease> LeaseRunspaceAsync()
+    {
+        if (!_isElevated)
+        {
+            var single = CreateRunspaceResources();
+            try
+            {
+                await OpenRunspaceAsync(single.Runspace).ConfigureAwait(false);
+            }
+            catch
+            {
+                single.Dispose();
+                throw;
+            }
+
+            return new RunspaceLease(single, Reusable: false);
+        }
+
+        if (_cached is { } cached)
+        {
+            if (cached.Runspace.RunspaceStateInfo.State == RunspaceState.Opened)
+                return new RunspaceLease(cached, Reusable: true);
+
+            Log.Debug("PowerShell: cached runspace is {State}; rebuilding it",
+                      cached.Runspace.RunspaceStateInfo.State);
+            _cached = null;
+            cached.Dispose();
+        }
+
+        var fresh = CreateRunspaceResources();
+        try
+        {
+            await OpenRunspaceAsync(fresh.Runspace).ConfigureAwait(false);
+        }
+        catch
+        {
+            fresh.Dispose();
+            throw;
+        }
+
+        _cached = fresh;
+        return new RunspaceLease(fresh, Reusable: true);
+    }
+
+    /// <summary>
+    /// Restarts the idle countdown after a run, creating the timer on first use.
+    /// </summary>
+    /// <remarks>
+    /// Called from the <c>finally</c> of every run, inside the pipeline gate, so it cannot race the lease.
+    /// Nothing is armed when there is no cache to evict — the unelevated path never creates a timer at all.
+    /// </remarks>
+    private void ArmIdleEviction()
+    {
+        if (_cached is null || _disposed) return;
+
+        _idleEviction ??= new Timer(_ => EvictIdleRunspace(), null, Timeout.Infinite, Timeout.Infinite);
+        _idleEviction.Change(_idleRunspaceLifetime, Timeout.InfiniteTimeSpan);
+    }
+
+    /// <summary>
+    /// Releases the cached runspace and its child process once it has been idle.
+    /// </summary>
+    /// <remarks>
+    /// Takes the pipeline gate with a zero wait rather than blocking on it. A run that started between the
+    /// timer firing and this callback holds the gate, and tearing its runspace down underneath it would turn
+    /// a working call into a broken one; re-arming instead costs one more idle period and cannot.
+    /// </remarks>
+    private void EvictIdleRunspace()
+    {
+        if (!_pipeline.Wait(0)) { ArmIdleEviction(); return; }
+
+        try
+        {
+            var idle = _cached;
+            _cached = null;
+            idle?.Dispose();
+        }
+        finally
+        {
+            _pipeline.Release();
+        }
+    }
+
+    /// <summary>
+    /// Releases the cached runspace, its child process and the idle timer.
+    /// </summary>
+    /// <remarks>
+    /// Deterministic release for the consumers that are disposed. It is NOT the only release path and must
+    /// not be: nine runners are constructed directly in <c>MainWindowViewModel</c>'s designer graph and
+    /// nothing ever disposes them, which is exactly why eviction is on a timer rather than on Dispose.
+    /// </remarks>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _idleEviction?.Dispose();
+
+        var cached = _cached;
+        _cached = null;
+        cached?.Dispose();
+
+        _pipeline.Dispose();
     }
 
     /// <summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.78.6</Version>
-    <FileVersion>1.78.6.0</FileVersion>
-    <AssemblyVersion>1.78.6.0</AssemblyVersion>
+    <Version>1.78.7</Version>
+    <FileVersion>1.78.7.0</FileVersion>
+    <AssemblyVersion>1.78.7.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Every elevated `RunAsync` built a runspace, and elevated means an **out-of-process** one: a `powershell.exe` 5.1 child, spawned, plus a remoting handshake with it, then thrown away. That is the slow part of the call — and the services that use it call in **bursts**: `DnsService` six times, `EdgeOneDriveService` four, TaskScheduler / RestorePoints / ScheduledMaintenance three each. Six spawns where one would do.

An elevated runner now keeps its runspace and reuses it. **Three properties make that safe, and each has a test that fails without it.**

| | why it is not optional |
|---|---|
| **State re-checked on every lease** | A cached runspace can be broken from outside — the child killed by the user or by cleanup, the channel dropped — and one that is not `Opened` cannot run a pipeline at all. Without the re-check, one broken child makes every later call on that consumer fail for the rest of the session: far worse than the cost being removed. |
| **Pipelines serialised behind a gate** | A runspace runs one at a time, so where a runspace per call made concurrent calls independent, a shared one makes them a conflict. Cheap in practice — Transient registration means one runner per consumer, and the consumers that make several calls already serialise them — so the gate is the guarantee rather than a dependency on that staying true. |
| **Evicted after ~20 s idle** | The half that keeps this a latency win rather than a memory trade. See below. |

### "One runspace per session" is the obvious reading and it is the wrong one

Nothing disposes most of these runners — **nine are constructed directly in `MainWindowViewModel`'s designer graph** and live as long as the window. A session-long cache would therefore mean a dozen `powershell.exe` processes resident for the whole run, tens of MB each, in an app whose entire pitch is making a PC feel faster. The benefit is in the burst; eviction takes the cost back once you have moved on.

`Dispose` releases it deterministically where a consumer *is* disposed. It is not the only release path and must not be, for the nine-runners reason.

**Scoped to the elevated path, asserted rather than described.** The in-process runspace starts no child and opens in a fraction of the time, so caching it would add a lifetime to reason about for almost no gain. `UnelevatedRunner_StillBuildsARunspacePerCall` is what would notice that scope being widened.

**The isolation boundary is unchanged, and reuse cannot weaken it:** the trusted machine-only `PSModulePath` is applied to the child's environment when it is spawned, so a cached child keeps the value it was given. `RunAsync_WhenElevated_IsolatesModuleDiscoveryInChildProcess` forces elevation and makes two calls, so it now exercises the reused runspace and still asserts the injected module is unreachable.

### Red/green, six mutations

| | | |
|---|---|---|
| baseline | | 8 green |
| M1 | no cache, always build fresh | RED — reuse test |
| M2 | invert the elevation check | RED — scope test |
| M3 | never arm idle eviction | RED — eviction test |
| M4 | `Dispose` leaves the cached runspace alone | RED — child-release test |
| M5 | reuse without re-checking runspace state | RED — rebuild test |
| M6 | drop the pipeline gate entirely | RED — overlap test |
| restored, sha verified, rebuilt | | 8 green |

**Three of those found real flaws, which is the reason to run them:**

1. **The concurrency test passed with the gate deleted.** Two calls started back to back do not conflict — the first has not cached anything by the time the second leases, so each builds its own runspace and nothing is shared. It needed a warm-up call first to make both callers reach for the same runspace. Without that fix the gate would have *looked* tested and been untested.
2. **`if (false)` / `if (true)` as mutations don't compile here** — they make the following statement unreachable and CS0162 is an error, so the proof reported BROKEN, which says nothing about the guard. Inverting a condition, or comparing against a state that cannot occur, mutates behaviour with a tree that still builds.
3. **Removing only the gate's `Wait`** left its `Release` over-releasing the semaphore, so every test died on `SemaphoreFullException` — red for the wrong reason. The mutation now removes both halves.

The idle-eviction test's first version polled *faster* than the idle period, and every call re-arms the countdown, so it kept the runspace alive forever and timed out. It now waits longer than the lifetime and doubles if a slow machine needs more.

**Renamed:** `RunspaceTeardown_StopsTheChildTheRunspaceWasBuiltWith` → `DisposingTheRunner_StopsTheChildItsRunspaceWasBuiltWith`, because the end of a run is no longer when the child is released. It also now asserts the child is **still alive** after the run, which is what says reuse is actually taking effect rather than merely not crashing.

### Verification

- Four projects build, 0 errors 0 warnings, on a full `--no-incremental` rebuild
- 111 green, 1 red across every `ArchitectureTests` guard; the red is the throwaway local runner's own file, which is not in this repository
- `dotnet format --verify-no-changes` clean
- Leak scan: 43 patterns over 20,636 bytes of added lines, 0 hits
- ARCHITECTURE's `PowerShellRunner` entry records the reuse and all three safety properties

Deferred to the workstation that runs the application: how much quicker DNS & Hosts and Edge/OneDrive Remover actually feel when elevated. The mechanism is proven by count through the `createRunspace` seam rather than by timing, so this is a look rather than a question.

Closes #2149.