### PR TITLE
test: migrate the suite to xUnit v3 on Microsoft.Testing.Platform

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -123,3 +123,12 @@ dotnet_diagnostic.CS8600.severity = warning
 dotnet_diagnostic.CS8602.severity = warning
 dotnet_diagnostic.CS8603.severity = warning
 dotnet_diagnostic.CS8625.severity = warning
+
+# xUnit1051 — "pass TestContext.Current.CancellationToken to methods that accept one".
+# Kept visible in the editor and out of the build. The rule arrived with xunit.analyzers 2.x
+# and fires at 450 call sites, and it is not a uniform sweep: some of those sites are
+# NSubstitute argument matchers, where substituting a real token would change what the
+# assertion matches. Threading the ambient token is a behaviour change to the suite (tests
+# become cancellable mid-await) and belongs in its own change, not in the runner migration
+# that surfaced it.
+dotnet_diagnostic.xUnit1051.severity = suggestion

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,17 +31,6 @@ updates:
     commit-message:
       prefix: "deps(tests)"
       include: "scope"
-    ignore:
-      # Xunit.StaFact majors target xUnit v3. Verified on 4.0.23 (dependabot PR #2025): it pulls
-      # xunit.v3.core alongside this suite's xunit.core 2.9.3, and the "Build tests" step fails with
-      # hundreds of CS0433 — "the type 'FactAttribute' exists in both" — because every [Fact] and
-      # [Collection] becomes ambiguous.
-      #
-      # Adopting it is an xUnit v2 -> v3 migration of the whole suite, not a version bump, so it is
-      # tracked separately. Without this rule dependabot reopens the same unbuildable PR every Monday.
-      # Minor and patch updates inside 1.x are still wanted, which is why this is major-only.
-      - dependency-name: "Xunit.StaFact"
-        update-types: ["version-update:semver-major"]
     groups:
       nuget-minor-patch:
         update-types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,14 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# The app sends nothing anywhere, and neither should the tools that build it. xUnit v3 test
+# projects are Microsoft.Testing.Platform applications, and that platform ships a telemetry
+# extension that is registered automatically and reads both of these; the SDK reads the second
+# one. Set here rather than per-job so a new job cannot be added without them.
+env:
+  TESTINGPLATFORM_TELEMETRY_OPTOUT: 1
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
 jobs:
   build-and-test:
     name: Build & unit tests
@@ -483,6 +491,30 @@ jobs:
         if: steps.ui-tests.outcome == 'failure'
         run: echo "::warning::UI automation tests failed — review the ui-test-results artifact for details."
 
+      # A test that FAILS is a warning here, on purpose. A test that is never RUN is an error, and the
+      # two are not the same finding: a failure means the job worked and found something, while a
+      # collapsed count means this job's green says nothing at all. Nothing distinguished them until
+      # now, so a runner or package change that stopped finding tests would have looked like a clean
+      # pass. The floor sits between the 64 test METHODS in the project and the 136 cases they expand
+      # to, so it catches theory rows silently stopping being enumerated as well as an outright
+      # truncation, while leaving room for tests to be legitimately deleted.
+      - name: Verify the UI suite actually ran
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          report=TestResults/ui-results.trx
+          if [ ! -s "$report" ]; then
+            echo "::error::$report is missing or empty, so no UI test result was recorded at all. Written instead:"
+            ls -la TestResults || true
+            exit 1
+          fi
+          cases=$({ grep -o "<UnitTestResult " "$report" || true; } | wc -l)
+          echo "TRX report: $(wc -c < "$report") bytes, $cases test results."
+          if [ "$cases" -lt 100 ]; then
+            echo "::error::the UI suite recorded only $cases results, under the floor of 100. Tests stopped being discovered rather than failing, so this job's result is meaningless."
+            exit 1
+          fi
+
       - name: Upload UI test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -563,6 +595,26 @@ jobs:
       - name: Annotate integration test failures
         if: steps.integration-tests.outcome == 'failure'
         run: echo "::warning::Integration tests failed — review the integration-test-results artifact. This job is non-blocking, so the merge is not gated; the failure is still real."
+
+      # Same reasoning as "Verify the UI suite actually ran" above: a failure is a warning, an empty or
+      # collapsed run is an error. The floor sits between the 497 test METHODS in the project and the
+      # 623 cases they expand to.
+      - name: Verify the integration suite actually ran
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          report=TestResults/integration-results.trx
+          if [ ! -s "$report" ]; then
+            echo "::error::$report is missing or empty, so no integration test result was recorded at all. Written instead:"
+            ls -la TestResults || true
+            exit 1
+          fi
+          cases=$({ grep -o "<UnitTestResult " "$report" || true; } | wc -l)
+          echo "TRX report: $(wc -c < "$report") bytes, $cases test results."
+          if [ "$cases" -lt 550 ]; then
+            echo "::error::the integration suite recorded only $cases results, under the floor of 550. Tests stopped being discovered rather than failing, so this job's result is meaningless."
+            exit 1
+          fi
 
       - name: Upload integration test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,19 +319,31 @@ jobs:
       - name: Build integration tests (compile check)
         run: dotnet build SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj -c Release --no-restore
 
-      # DIAGNOSING A RED CHECK HERE: read the "Passed! - Failed: N" line in this step's log first.
-      # If it says Failed: 0, the tests passed and the JOB was killed — either by the timeout above
-      # or by a transient GitHub failure ("Failed to resolve action download info"). A killed job's
-      # conclusion is `cancelled`, which `gh pr checks` displays as `fail`, so it looks identical to
-      # a broken test. The fix in that case is `gh run rerun <id> --failed`, not a code change.
+      # DIAGNOSING A RED CHECK HERE: read the failure summary at the end of this step's log first.
+      # If it reports zero failures, the tests passed and the JOB was killed — either by the timeout
+      # above or by a transient GitHub failure ("Failed to resolve action download info"). A killed
+      # job's conclusion is `cancelled`, which `gh pr checks` displays as `fail`, so it looks identical
+      # to a broken test. The fix in that case is `gh run rerun <id> --failed`, not a code change.
+      #
+      # Microsoft.Testing.Platform arguments, not VSTest ones — the test projects are MTP applications
+      # and the .NET 10 SDK refuses to run those through VSTest at all, so global.json opts `dotnet
+      # test` into the MTP command. The reports are xunit.v3's own, which is why there is no separate
+      # TRX/JUnit logger package any more.
+      #
+      # --minimum-expected-tests is the floor that used to have no equivalent: the runner itself fails
+      # the run when fewer tests execute than that, so a change that stops DISCOVERING tests can no
+      # longer pass as a green run of nothing. 5000 against a real count of ~5160 leaves room to delete
+      # a class without editing CI, while still catching any collapse.
       - name: Run unit tests
         run: >
-          dotnet test SysManager/SysManager.Tests/SysManager.Tests.csproj
+          dotnet test --project SysManager/SysManager.Tests/SysManager.Tests.csproj
           -c Release --no-build
-          --logger "trx;LogFileName=unit-results.trx"
-          --logger "junit;LogFileName=unit-results.junit.xml"
-          --collect:"XPlat Code Coverage"
           --results-directory TestResults
+          --minimum-expected-tests 5000
+          --report-xunit-trx --report-xunit-trx-filename unit-results.trx
+          --report-xunit-junit --report-xunit-junit-filename unit-results.junit.xml
+          --coverage --coverage-output-format cobertura
+          --coverage-output unit-coverage.cobertura.xml
 
       # Skip Codecov on fork PRs: forked pull requests have no access to repository
       # secrets, so CODECOV_TOKEN is empty there and the upload would fail noisily for
@@ -343,6 +355,26 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
           fail_ci_if_error: false
+
+      # The same argument as the JUnit guard below, applied to the other artifact. The upload step
+      # above discovers the coverage report by searching, and it is configured not to fail the build
+      # when it finds nothing, so a run that stopped producing coverage would look exactly like a run
+      # that produced it — the badge would simply stop moving. Checked after the upload for the same
+      # reason that one is: a failing step skips what follows, and a coverage problem is no reason to
+      # lose the test-results upload too.
+      - name: Verify a coverage report was produced
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          mapfile -t reports < <(find TestResults -name "*.cobertura.xml" -size +1k 2>/dev/null)
+          if [ "${#reports[@]}" -eq 0 ]; then
+            echo "::error::no *.cobertura.xml over 1 KB under TestResults, so nothing was uploaded to Codecov and the coverage number is stale. Written instead:"
+            find TestResults -type f 2>/dev/null || ls -la
+            exit 1
+          fi
+          for report in "${reports[@]}"; do
+            echo "coverage report: $report ($(wc -c < "$report") bytes)"
+          done
 
       # Codecov's test-analytics parser reads JUnit XML and nothing else. A TRX is accepted by the CLI,
       # uploaded, and discarded server-side without a word, which is how the upload step below stayed
@@ -476,10 +508,10 @@ jobs:
       - name: Run UI tests
         id: ui-tests
         run: >
-          dotnet test SysManager/SysManager.UITests/SysManager.UITests.csproj
+          dotnet test --project SysManager/SysManager.UITests/SysManager.UITests.csproj
           -c Release --no-build
-          --logger "trx;LogFileName=ui-results.trx"
           --results-directory TestResults
+          --report-xunit-trx --report-xunit-trx-filename ui-results.trx
         continue-on-error: true
 
       # Surface UI test failures as a visible warning annotation. Use `outcome`,
@@ -498,6 +530,12 @@ jobs:
       # pass. The floor sits between the 64 test METHODS in the project and the 136 cases they expand
       # to, so it catches theory rows silently stopping being enumerated as well as an outright
       # truncation, while leaving room for tests to be legitimately deleted.
+      #
+      # Counted from the report rather than with the runner's own --minimum-expected-tests, which is
+      # what the blocking unit job uses: the step above is deliberately continue-on-error, so the
+      # runner's exit code is discarded there and a floor enforced by it would arrive as a warning
+      # alongside the ordinary failures it is supposed to be distinguished from. The floor has to live
+      # in a step that can fail.
       - name: Verify the UI suite actually ran
         if: ${{ !cancelled() }}
         shell: bash
@@ -572,7 +610,7 @@ jobs:
       - name: Build integration tests
         run: dotnet build SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj -c Release --no-restore
 
-      # --blame-hang is not optional here, it is the whole reason this job is usable. The first run of this
+      # Hang detection is not optional here, it is the whole reason this job is usable. The first run of this
       # job proved the suite HANGS on a clean runner: it reported five failures in the first eight minutes and
       # then produced no output at all for twenty-one, until the job's own 30-minute ceiling cancelled it. A
       # cancelled job reports `cancelled`, which `gh pr checks` renders as `fail` — indistinguishable from a
@@ -580,14 +618,20 @@ jobs:
       #
       # With a hang timeout, the run stops at five minutes of silence, NAMES the test that stopped responding,
       # and writes a dump next to the results. A hang becomes a finding instead of a timeout.
+      # --hangdump replaces VSTest's --blame-hang, and --xunit-diagnostics is what makes the NAMING
+      # half work: the dump alone says a hang happened, while xunit.runner.json's
+      # longRunningTestSeconds reports WHICH test stopped responding, and those are diagnostic
+      # messages that are hidden unless diagnostics are on. The threshold sits below the dump timeout
+      # on purpose, so the name is already in the log by the time the dump lands.
       - name: Run integration tests
         id: integration-tests
         run: >
-          dotnet test SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
+          dotnet test --project SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
           -c Release --no-build
-          --blame-hang --blame-hang-timeout 5m
-          --logger "trx;LogFileName=integration-results.trx"
           --results-directory TestResults
+          --hangdump --hangdump-timeout 5m
+          --xunit-diagnostics on
+          --report-xunit-trx --report-xunit-trx-filename integration-results.trx
         continue-on-error: true
 
       # `outcome`, NOT `conclusion`: continue-on-error forces the step's conclusion to 'success', so a
@@ -596,9 +640,10 @@ jobs:
         if: steps.integration-tests.outcome == 'failure'
         run: echo "::warning::Integration tests failed — review the integration-test-results artifact. This job is non-blocking, so the merge is not gated; the failure is still real."
 
-      # Same reasoning as "Verify the UI suite actually ran" above: a failure is a warning, an empty or
-      # collapsed run is an error. The floor sits between the 497 test METHODS in the project and the
-      # 623 cases they expand to.
+      # Same reasoning as "Verify the UI suite actually ran" above, including why the floor is counted
+      # here rather than passed to the runner: a failure is a warning, an empty or collapsed run is an
+      # error. The floor sits between the 497 test METHODS in the project and the 623 cases they expand
+      # to.
       - name: Verify the integration suite actually ran
         if: ${{ !cancelled() }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,12 +117,16 @@ jobs:
       - name: Restore
         run: dotnet restore SysManager/SysManager/SysManager.csproj
 
+      # Microsoft.Testing.Platform arguments; see the same step in ci.yml for why. The floor is here too
+      # rather than only there, because a release can be dispatched manually without passing through a PR
+      # — a gate that lets a run of nothing through is not a gate.
       - name: Run unit tests (must pass)
         run: >
-          dotnet test SysManager/SysManager.Tests/SysManager.Tests.csproj
+          dotnet test --project SysManager/SysManager.Tests/SysManager.Tests.csproj
           -c Release
-          --logger "trx;LogFileName=unit-results.trx"
           --results-directory TestResults
+          --minimum-expected-tests 5000
+          --report-xunit-trx --report-xunit-trx-filename unit-results.trx
 
       - name: Publish single-file exe
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,13 @@ concurrency:
   group: release-${{ github.event.inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
+# See the same block in ci.yml: xUnit v3 test projects are Microsoft.Testing.Platform
+# applications and that platform auto-registers a telemetry extension. The unit gate below
+# runs them, so the opt-out belongs here too.
+env:
+  TESTINGPLATFORM_TELEMETRY_OPTOUT: 1
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
 jobs:
   guard:
     name: Skip if release already exists (tag move / re-push)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,7 +187,7 @@ dotnet test SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.c
 Generate a coverage report:
 
 ```powershell
-dotnet test SysManager/SysManager.Tests/SysManager.Tests.csproj -c Release --collect:"XPlat Code Coverage"
+dotnet test --project SysManager/SysManager.Tests/SysManager.Tests.csproj -c Release --coverage --coverage-output-format cobertura
 ```
 
 **Every non-trivial PR should include at least one test.** If you're

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -125,12 +125,13 @@ Ordered by how often they come up, not by effort.
 
 Not user-visible, and the reason the rest can move at all.
 
-- **Migrating the test suite to xUnit v3**, which `Xunit.StaFact` now requires
-  ([#2028](https://github.com/laurentiu021/SystemManager/issues/2028))
-- **One PowerShell runspace per elevated session** instead of one per call
-  ([#2149](https://github.com/laurentiu021/SystemManager/issues/2149))
-- **Replacing the blocking dispatcher marshals**
-  ([#2152](https://github.com/laurentiu021/SystemManager/issues/2152))
+- **Spacing, radius and type scales that the views actually use.** Three token sets exist
+  and the views mostly bypass them with raw numbers, so a change to the scale changes
+  nothing ([#1633](https://github.com/laurentiu021/SystemManager/issues/1633),
+  [#1634](https://github.com/laurentiu021/SystemManager/issues/1634))
+- **Command-line parsing that rejects what it does not recognise.** Today an unknown
+  `-something` is accepted and ignored
+  ([#2159](https://github.com/laurentiu021/SystemManager/issues/2159))
 
 ## How this list changes
 

--- a/SysManager/Directory.Packages.props
+++ b/SysManager/Directory.Packages.props
@@ -34,15 +34,22 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" />
   </ItemGroup>
 
-  <!-- Test dependencies -->
+  <!--
+    Test dependencies.
+
+    These target Microsoft.Testing.Platform, not VSTest. The .NET 10 SDK refuses to run an MTP test
+    project through the VSTest target at all ("Testing with VSTest target is no longer supported by
+    Microsoft.Testing.Platform on .NET 10 SDK and later"), so global.json opts `dotnet test` into the
+    MTP-based command and the VSTest packages are gone rather than dormant: no Microsoft.NET.Test.Sdk,
+    no xunit.runner.visualstudio, no coverlet.collector, no JunitXml.TestLogger. Their jobs are done by
+    xunit.v3's own reports (TRX, JUnit, and four more) plus the two MTP extensions below.
+  -->
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="JunitXml.TestLogger" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.4.0" />
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="xunit.v3" Version="4.0.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
     <PackageVersion Include="Xunit.StaFact" Version="4.0.23" />
     <PackageVersion Include="FlaUI.Core" Version="5.0.0" />
     <PackageVersion Include="FlaUI.UIA3" Version="5.0.0" />

--- a/SysManager/Directory.Packages.props
+++ b/SysManager/Directory.Packages.props
@@ -41,9 +41,9 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
-    <PackageVersion Include="Xunit.StaFact" Version="1.2.69" />
+    <PackageVersion Include="Xunit.StaFact" Version="4.0.23" />
     <PackageVersion Include="FlaUI.Core" Version="5.0.0" />
     <PackageVersion Include="FlaUI.UIA3" Version="5.0.0" />
   </ItemGroup>

--- a/SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
+++ b/SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
+    <OutputType>Exe</OutputType>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -13,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
+++ b/SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
@@ -12,10 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <!-- HangDump replaces VSTest's blame-hang collector: this suite touches the live system, so a
+         test that stops responding has to be NAMED rather than ending the job at its ceiling. -->
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SysManager/SysManager.IntegrationTests/xunit.runner.json
+++ b/SysManager/SysManager.IntegrationTests/xunit.runner.json
@@ -1,6 +1,6 @@
 {
   "parallelizeAssembly": false,
-  "parallelizeTestCollections": false,
+  "parallelMode": "none",
   "maxParallelThreads": 1,
-  "longRunningTestSeconds": 300
+  "longRunningTestSeconds": 120
 }

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1286,7 +1286,7 @@ public partial class ArchitectureTests
         var excluded = typeof(ProfileServiceTests)
             .GetMethod(nameof(ProfileServiceTests.AvailableSections_NeverCarriesMachineSpecificState))!
             .GetCustomAttributes<Xunit.InlineDataAttribute>()
-            .Select(a => (string)a.GetData(null!).First()[0]!)
+            .Select(a => (string)a.Data[0]!)
             .ToHashSet(StringComparer.Ordinal);
 
         // Both sources must yield SOMETHING, and deliberately not a population-sized floor. A floor of

--- a/SysManager/SysManager.Tests/SysManager.Tests.csproj
+++ b/SysManager/SysManager.Tests/SysManager.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+    <OutputType>Exe</OutputType>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -14,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NetArchTest.Rules" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Xunit.StaFact" />
   </ItemGroup>

--- a/SysManager/SysManager.Tests/SysManager.Tests.csproj
+++ b/SysManager/SysManager.Tests/SysManager.Tests.csproj
@@ -10,13 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="JunitXml.TestLogger" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NetArchTest.Rules" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Xunit.StaFact" />
   </ItemGroup>
 

--- a/SysManager/SysManager.Tests/xunit.runner.json
+++ b/SysManager/SysManager.Tests/xunit.runner.json
@@ -1,6 +1,6 @@
 {
   "parallelizeAssembly": false,
-  "parallelizeTestCollections": true,
+  "parallelMode": "collections",
   "maxParallelThreads": 0,
   "longRunningTestSeconds": 30
 }

--- a/SysManager/SysManager.UITests/SysManager.UITests.csproj
+++ b/SysManager/SysManager.UITests/SysManager.UITests.csproj
@@ -12,12 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FlaUI.Core" />
     <PackageReference Include="FlaUI.UIA3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SysManager/SysManager.UITests/SysManager.UITests.csproj
+++ b/SysManager/SysManager.UITests/SysManager.UITests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
+    <OutputType>Exe</OutputType>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -15,7 +16,7 @@
     <PackageReference Include="FlaUI.Core" />
     <PackageReference Include="FlaUI.UIA3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -67,6 +67,25 @@ dotnet test SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.c
 dotnet test SysManager/SysManager.UITests/SysManager.UITests.csproj -c Release
 ```
 
+## Running one class or one test
+
+Under xUnit v3 each test project builds an executable, so a single class can run without
+starting the whole suite:
+
+```powershell
+dotnet build SysManager/SysManager.Tests/SysManager.Tests.csproj -c Release
+./SysManager/SysManager.Tests/bin/Release/net10.0-windows/SysManager.Tests.exe `
+    -class SysManager.Tests.ArchitectureTests
+```
+
+`-method <name>` narrows to one test, and `-list methods` prints every test the runner
+discovered without running any of it. `-list` is the check to reach for after touching the
+project file or a package version: it answers "is everything still being found" separately
+from "does everything still pass", and those fail in different ways.
+
+Use `-?` for the full option list. This is the same runner `dotnet test` drives, so a result
+here and a result on CI mean the same thing.
+
 ## Coverage
 
 Coverage is collected automatically on CI via `coverlet` and uploaded to
@@ -86,7 +105,7 @@ happily as a readable one and Codecov never reports the rejection back.
 
 | Package | Purpose |
 |---|---|
-| xUnit 2.9 | Test framework |
+| xUnit v3 4.0 | Test framework |
 | NSubstitute 6.2 | Mocking/substitution for interface-based testing |
 | NetArchTest.Rules 1.3 | Architecture fitness functions — MVVM dependency direction, and guards that pin recurring defect classes |
 | coverlet | Code coverage collection |

--- a/TESTING.md
+++ b/TESTING.md
@@ -88,16 +88,17 @@ here and a result on CI mean the same thing.
 
 ## Coverage
 
-Coverage is collected automatically on CI via `coverlet` and uploaded to
+Coverage is collected automatically on CI by `Microsoft.Testing.Extensions.CodeCoverage`
+(`--coverage --coverage-output-format cobertura`) and uploaded to
 [Codecov](https://codecov.io/gh/laurentiu021/SystemManager). The badge in
 `README.md` reflects the latest `main` branch result.
 
 The same CI job uploads test results to Codecov's test analytics, which reads JUnit XML
-and no other format. `dotnet test` therefore runs two loggers: `trx` for the CI artifact
-and the `Passed! - Failed: N` diagnostic line, and `junit` for the upload. A guard step
-checks the JUnit report exists, has a `<testsuites>` root, and holds at least 4000 test
-cases before the upload runs, because the CLI uploads an unreadable report just as
-happily as a readable one and Codecov never reports the rejection back.
+and no other format. The run therefore emits two reports: TRX for the CI artifact, and
+JUnit for the upload. A guard step checks the JUnit report exists, has a `<testsuites>`
+root, and holds at least 4000 test cases before the upload runs, because the CLI uploads
+an unreadable report just as happily as a readable one and Codecov never reports the
+rejection back.
 
 ## Test infrastructure
 
@@ -108,13 +109,31 @@ happily as a readable one and Codecov never reports the rejection back.
 | xUnit v3 4.0 | Test framework |
 | NSubstitute 6.2 | Mocking/substitution for interface-based testing |
 | NetArchTest.Rules 1.3 | Architecture fitness functions — MVVM dependency direction, and guards that pin recurring defect classes |
-| coverlet | Code coverage collection |
-| JunitXml.TestLogger | JUnit XML test report — the only format Codecov's test analytics parses |
+| Microsoft.Testing.Extensions.CodeCoverage | Code coverage collection (unit project only) |
+| Microsoft.Testing.Extensions.HangDump | Dump on hang (integration project only) |
 | Xunit.StaFact | STA thread support for WPF-dependent tests |
 
 Package versions are managed centrally in `SysManager/Directory.Packages.props`
 (`ManagePackageVersionsCentrally`), so a `PackageReference` in a `.csproj` carries no
 `Version` attribute — adding one fails the restore.
+
+There is no VSTest in that list, deliberately. xUnit v3 test projects are
+[Microsoft.Testing.Platform](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro)
+applications, and the .NET 10 SDK refuses to run one through the VSTest target at all, so
+`global.json` opts `dotnet test` into the MTP-based command:
+
+```json
+"test": {
+  "runner": "Microsoft.Testing.Platform"
+}
+```
+
+Two consequences worth knowing before editing a workflow. The command line is MTP's, not
+VSTest's — `--report-xunit-trx` rather than `--logger trx`, `--coverage` rather than
+`--collect`, `--hangdump` rather than `--blame-hang` — and every report format comes from
+xUnit itself, so there is no logger package to add for TRX, JUnit, NUnit, HTML, CTRF or
+xUnit XML. `dotnet test --project <csproj> --help` prints the full option list for a given
+project, including the extension options its packages contribute.
 
 ### Parallelism
 
@@ -195,9 +214,10 @@ registration is covered.
 To generate a local coverage report:
 
 ```powershell
-dotnet test SysManager/SysManager.Tests/SysManager.Tests.csproj `
-  --collect:"XPlat Code Coverage" `
-  --results-directory TestResults
+dotnet test --project SysManager/SysManager.Tests/SysManager.Tests.csproj `
+  --results-directory TestResults `
+  --coverage --coverage-output-format cobertura `
+  --coverage-output coverage.cobertura.xml
 
 # Install reportgenerator once:
 dotnet tool install -g dotnet-reportgenerator-globaltool

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
   "sdk": {
     "version": "10.0.100",
     "rollForward": "latestMinor"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }


### PR DESCRIPTION
Xunit.StaFact stopped shipping v2-compatible releases, so every dependabot attempt to update it
produced an unbuildable PR: 1.x targets xUnit v2, 4.x targets v3, and referencing both makes every
`[Fact]` ambiguous. The hold-back rule that stopped the weekly reopen is removed here along with the
reason it existed.

Two commits, because the second one is the half CI had to tell me about.

## 1. The framework swap

Four lines of project file. `xunit` 2.9.3 becomes `xunit.v3` 4.0.0, Xunit.StaFact 1.2.69 becomes
4.0.23, and each test project gains `<OutputType>Exe</OutputType>` because a v3 test project is an
executable and the package fails the build with an explicit error if it is not.

Only one line of test code had to change. `InlineDataAttribute.GetData` is async in v3 and takes a
`DisposalTracker`, so ArchitectureTests' reflection over another test's `[InlineData]` rows now reads
the v3 `Data` property instead, which is what the v2 workaround was reaching for.

`xunit.analyzers` 2.x arrives with the framework and brings xUnit1051 — pass
`TestContext.Current.CancellationToken` to anything that accepts one — which fires at 450 call sites
and, under `TreatWarningsAsErrors`, as 450 errors. It is set to `suggestion` in `.editorconfig` with
the reason: it is not a uniform sweep, because some of those sites are NSubstitute argument matchers
where a real token would change what the assertion matches, and threading the ambient token makes
tests cancellable mid-await, which is a behaviour change to the suite rather than part of a runner
swap.

## 2. Microsoft.Testing.Platform, which .NET 10 leaves no choice about

The first commit left `dotnet test` alone and CI answered immediately:

> Testing with VSTest target is no longer supported by Microsoft.Testing.Platform on .NET 10 SDK and
> later. If you use dotnet test, you should opt-in to the new dotnet test experience.

A refusal, not a fallback — the run produced no results file at all. An xUnit v3 project *is* an MTP
application, so `global.json` now opts `dotnet test` into the MTP command:

```json
"test": { "runner": "Microsoft.Testing.Platform" }
```

That keeps one documented command for contributors and CI, rather than having the workflows invoke the
test executables directly while the docs describe something else.

### Four packages removed, not replaced

`Microsoft.NET.Test.Sdk`, `xunit.runner.visualstudio`, `coverlet.collector` and
`JunitXml.TestLogger` were all VSTest plumbing. Reporting is now xunit.v3's own — TRX, JUnit, NUnit,
HTML, CTRF and xUnit XML all come from the framework, so the JUnit logger Codecov's test analytics
needs is no longer a package at all. Two MTP extensions cover the rest: CodeCoverage on the unit
project, HangDump on the integration project. Neither is referenced by a project that does not use it.
The output directory is the visible result: no `testhost.exe`, no adapter, no VSTest object model.

### Arguments, translated

| before | after |
|---|---|
| `--logger "trx;LogFileName=x"` | `--report-xunit-trx --report-xunit-trx-filename x` |
| `--logger "junit;LogFileName=x"` | `--report-xunit-junit --report-xunit-junit-filename x` |
| `--collect:"XPlat Code Coverage"` | `--coverage --coverage-output-format cobertura` |
| `--blame-hang --blame-hang-timeout` | `--hangdump --hangdump-timeout` |
| `dotnet test <csproj>` | `dotnet test --project <csproj>` |

`xunit.runner.json` moved with them: `parallelizeTestCollections` is deprecated in v3 and will be
removed in the next major, so both files use `parallelMode` now. Verified rather than assumed — the
runner prints the mode it resolved, and it reads `parallel mode = none` for the integration project
and `parallel mode = collections [32 threads]` for the unit one.

### What replaces blame-hang's other half

blame-hang did two things: it dumped, and it NAMED the test that stopped responding, which is what the
integration job's comment credits for making a hang a finding instead of a timeout. `--hangdump`
covers the dump. The naming comes from `longRunningTestSeconds`, and those are diagnostic messages
that are hidden unless diagnostics are on — so the job passes `--xunit-diagnostics on`, and the
threshold drops from 300s to 120s so the name lands well before the 5-minute dump rather than at the
same moment. Proven with a deliberately slow class and a 3-second threshold:

```
[Long Running Test] 'DeepCleanupServiceTests.ScanAsync_IncludesIntelCategory', Elapsed: 00:00:05
```

### Three floors, because each suite fails differently

MTP has `--minimum-expected-tests`, enforced by the runner itself. The blocking unit job uses it in
**both** `ci.yml` and `release.yml` — a release can be dispatched manually without passing through a
PR, so a gate only on the PR path is not a gate. Verified by asking for an impossible floor:

```
Test run summary: Minimum expected tests policy violation, tests ran 4251, minimum expected 999999
Test run completed with non-success exit code: 143
```

The UI and integration jobs cannot use it. Their test step is deliberately `continue-on-error`, so the
runner's exit code is discarded there and a floor enforced by it would arrive as a warning next to the
ordinary failures it exists to be distinguished from. Those two count their own TRX in a step that
**can** fail, with the floor between each project's method count and its case count. A test that
FAILS in those jobs stays a warning; a suite that never RAN is an error, because then the job's green
means nothing.

A fourth guard covers the artifact nobody was watching: the Codecov coverage upload discovers its file
by searching and is configured not to fail the build when it finds none, so a run that stopped
producing coverage would look identical to one that produced it, with only a badge that quietly stops
moving. Same argument as the JUnit guard beside it, which was written after exactly that happened to
test analytics.

## Verification

The failure mode of a runner migration is tests that quietly stop being discovered, so the count was
checked from both ends. Discovery per project, against the `[Fact]`/`[Theory]`/`[StaFact]` attributes
in that project's source:

```
SysManager.Tests              3221 discovered  ==  3221 in source
SysManager.IntegrationTests    497 discovered  ==   497 in source
SysManager.UITests              64 discovered  ==    64 in source
```

Then execution, which is what CI counts. Running the unit suite locally, excluding only
`DeepCleanupServiceTests` (39 cases; #2167 explains why it cannot finish in a sane time on a real
machine) gives **5125** — exactly the 5164 CI reported under v2, minus those 39. The four
theory-heaviest classes were spot-checked individually and match v2 case for case: 572, 113, 99, 93.

Also: four projects build 0 errors 0 warnings on `--no-incremental`; every ArchitectureTests guard
green, 112 of 112, which is the first fully green sweep — the persistent one red was a throwaway local
runner's own file, and that runner is retired because the v3 executable does its job properly
(`-class`, `-method`, `-list`); `[StaFact]` genuinely gets an STA apartment under StaFact 4.0.23 (13
WPF element tests green); format clean; every workflow re-parsed after editing, plus assertions that
no VSTest argument survives in any step, that all four `dotnet test` invocations use `--project` and
request a TRX, and that each floor is where it should be; 43 leak patterns over 14,256 bytes of added
lines, 0 hits.

## Docs

TESTING.md gains an MTP section, the argument table, a corrected framework list, and a "Running one
class or one test" section — under v3 each project builds an executable, and `-list methods` answers
"is everything still being found" separately from "does everything still pass", which is the check to
reach for after touching a project file or a package version. CONTRIBUTING's coverage command is
updated. ROADMAP's "Under the floor" section listed this migration plus two items that shipped in
v1.78.x, so it now names what is actually still under the floor.

## Two defects this shook out

Running the suite outside CI for the first time in a while surfaced 7 failures, neither caused by the
migration and both filed rather than fixed here:

- **#2168** — six App Blocker confirmation-gate tests only assert anything on an ELEVATED host. CI's
  runner is elevated; a developer's shell is not, and there the view model's `if (!IsElevated)` guard
  returns before `Confirm` is ever called. The seam to fix it (`AdminHelper.ForceElevation`) already
  exists and was added for this exact trap one class over.
- **#2169** — a PropertyChanged test collects into a plain `List` while the view model's unawaited
  constructor work appends from the thread pool. It failed once under full-suite load with "Collection
  was modified", and passes six for six in isolation, which is how a race stays alive.

And **#2167**, which is why the local count had to exclude one class: Deep Cleanup runs a full
real-disk scan 29 times in the blocking suite, 16 of them over 30 seconds on a machine with real
caches, serialized because they share a collection.

Closes #2028.
