### PR TITLE
refactor: delete the CLI verb set that decided nothing, and add the checks it looked like

### DIFF
--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -8831,4 +8831,97 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"<(summary|inheritdoc)\b", RegexOptions.CultureInvariant)]
     private static partial Regex CarriesASummary();
 
+    /// <summary>
+    /// Every verb <c>CliRunner.Parse</c> accepts must be findable in <c>Commands</c>, the catalog
+    /// <c>--help</c> and the CLI Interface tab are both built from — or be named here as deliberately
+    /// undocumented, with the reason.
+    /// </summary>
+    /// <remarks>
+    /// The other half of <c>CliRunnerTests.EveryFlagInTheHelpCatalog_Parses</c>. That one catches a flag
+    /// the help advertises and the parser rejects, which is the direction a user hits. This catches the
+    /// reverse: a verb that works and is documented nowhere, so the only way to discover it is to read the
+    /// source.
+    /// <para>Both exist because of #2159. <c>CliRunner</c> carried a third list, <c>CliVerbs</c>, that
+    /// named every verb and was never consulted — <c>IsCliToken</c>'s second clause already accepted
+    /// anything starting with <c>-</c> or <c>/</c>, which every entry did. It was found by a mutation that
+    /// deleted a verb from it expecting a red test and got a green one. Deleting the set removes the
+    /// misleading list; these two guards supply the checking it looked like it was doing.</para>
+    /// <para>Read from source text rather than by reflection because the mapping IS a switch: there is no
+    /// runtime collection of case labels to enumerate, and rewriting <c>Parse</c> around a dictionary to
+    /// make one would trade a readable switch for a table purely to satisfy a test. The exceptions are the
+    /// Windows-convention aliases and the one compatibility alias, and each is undocumented on purpose.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryVerbParseAccepts_IsDocumentedOrDeliberatelyNot()
+    {
+        // verb -> why it is absent from the help catalog on purpose.
+        var undocumented = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["-?"] = "Windows-convention alias for --help. Listing every alias of every verb would make "
+                     + "the help table wider than it is useful; the two long forms are what the table shows",
+            ["/?"] = "same, with the slash spelling a cmd.exe user reaches for first",
+            ["/silent"] = "slash spelling of --silent, kept for scripts written in cmd.exe style",
+            ["--trim-ram"] = "RETAINED ALIAS for --purge-standby, not a verb of its own (#1524). Named in "
+                             + "the --purge-standby DESCRIPTION rather than as a flag, so the help does not "
+                             + "advertise a spelling that only exists for schedules registered before the "
+                             + "rename. Pinned by CliRunnerTests.Parse_StillAcceptsTheFormerTrimRamSpelling",
+        };
+
+        var source = File.ReadAllText(Path.Combine(FindAppProjectDir(), "Services", "CliRunner.cs"));
+
+        // Only Parse's body. The file also contains the help catalog and the ExecuteAsync switch, and a
+        // whole-file scan would read the catalog's own strings as case labels and pass vacuously.
+        var start = source.IndexOf("public static CliRequest Parse(", StringComparison.Ordinal);
+        Assert.True(start > 0, "Parse's declaration was not found — this guard is reading the wrong shape.");
+        var end = source.IndexOf("private static CliCommand Pick(", start, StringComparison.Ordinal);
+        Assert.True(end > start, "the end of Parse was not found — this guard is reading the wrong shape.");
+        var body = source[start..end];
+
+        var verbs = CaseLabelLiteral().Matches(body)
+            .Select(m => m.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // Vacuity floor: 15 labels when measured (4 help + 2 version + list + health + cleanup +
+        // purge-standby + trim-ram + json + 3 silent spellings). A collapse means the slice or the
+        // pattern stopped matching and a clean result would prove nothing.
+        Assert.True(verbs.Count >= 12,
+            $"only {verbs.Count} case labels were read out of Parse — the slice or the pattern is out of "
+            + "date, so this guard is checking almost nothing.");
+
+        var catalog = string.Join(" | ", CliRunner.Commands.Select(c => $"{c.Flags} {c.Description}"));
+        Assert.True(catalog.Length > 200,
+            $"the help catalog rendered to only {catalog.Length} characters — Commands changed shape.");
+
+        var offenders = verbs
+            .Where(v => !undocumented.ContainsKey(v))
+            .Where(v => !catalog.Contains(v, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(v => v, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "Parse accepts these verbs and nothing in the help catalog mentions them, so the only way a "
+            + "user could find them is by reading the source. Add a row to CliRunner.Commands, mention the "
+            + "alias in a neighbouring description, or name it in the exception list in this test WITH the "
+            + "reason it stays hidden:\n  "
+            + string.Join("\n  ", offenders)
+            + $"\n({verbs.Count} case labels read from Parse)");
+
+        // The exception list must not outlive what it excuses. A verb removed from Parse and left here
+        // reads as a documented decision about code that no longer exists.
+        var stale = undocumented.Keys.Where(v => !verbs.Contains(v)).OrderBy(v => v, StringComparer.Ordinal);
+        Assert.Empty(stale);
+    }
+
+    /// <summary>
+    /// A string literal in a <c>case</c> label, including each alternative of an <c>or</c> pattern —
+    /// <c>case "--a" or "-b":</c> yields both.
+    /// </summary>
+    /// <remarks>
+    /// Matches the literal after <c>case</c> or after <c>or</c> rather than splitting a whole label, so a
+    /// label's alternatives are found without assuming how many there are. Anchoring on the keyword is what
+    /// keeps it from matching the help catalog's flag strings, which are ordinary string literals.
+    /// </remarks>
+    [GeneratedRegex(@"\b(?:case|or)\s+""([^""]+)""", RegexOptions.CultureInvariant)]
+    private static partial Regex CaseLabelLiteral();
+
 }

--- a/SysManager/SysManager.Tests/CliRunnerTests.cs
+++ b/SysManager/SysManager.Tests/CliRunnerTests.cs
@@ -97,6 +97,21 @@ public class CliRunnerTests
         // error (exit 2), NOT silently fall through and open the GUI window.
         => Assert.True(CliRunner.IsCliInvocation(["--bogus"]));
 
+    /// <summary>
+    /// The slash spelling reaches CLI mode too, so <c>SysManager.exe /?</c> prints help instead of
+    /// opening the window.
+    /// </summary>
+    /// <remarks>
+    /// Written while removing the dead <c>CliVerbs</c> set (#2159). Nothing asserted this: the parse
+    /// tests cover <c>/?</c> mapping to Help, but no test checked that a slash argument makes the app
+    /// headless in the first place, and it is the LEADING-SLASH clause of <c>IsCliToken</c> that decides
+    /// that. Dropping the clause left every test green, which is the same hole the deleted set created —
+    /// so the fix for it comes with the check that would have caught it.
+    /// </remarks>
+    [Fact]
+    public void IsCliInvocation_TrueForSlashSpelledHelp()
+        => Assert.True(CliRunner.IsCliInvocation(["/?"]));
+
     [Fact]
     public void IsCliInvocation_FalseForBareTokens()
         // Non-flag tokens (no leading - or /) never trigger CLI mode.
@@ -209,6 +224,42 @@ public class CliRunnerTests
             Assert.False(string.IsNullOrWhiteSpace(c.Flags));
             Assert.False(string.IsNullOrWhiteSpace(c.Description));
         });
+    }
+
+    /// <summary>
+    /// Every flag the help text advertises must actually parse. A documented verb that returns
+    /// <see cref="CliCommand.Unknown"/> is worse than an undocumented one: the user reads it in
+    /// <c>--help</c>, types it, and gets "Unknown option" back from the same program.
+    /// </summary>
+    /// <remarks>
+    /// <c>Commands</c> and <c>Parse</c>'s switch are two independent lists of the same flags, and
+    /// nothing compared them. That is the shape of defect the deleted <c>CliVerbs</c> set had (#2159):
+    /// a list that looks authoritative, is never consulted, and drifts silently. This closes the
+    /// direction that hurts a user; <c>ArchitectureTests</c> closes the other one.
+    /// <para>Modifiers are included deliberately. <c>--json</c> on its own leaves the command at
+    /// <see cref="CliCommand.None"/> rather than naming one, so the assertion is "not a usage error"
+    /// rather than "is a command" — but it still catches a modifier being renamed in one place only.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryFlagInTheHelpCatalog_Parses()
+    {
+        var flags = CliRunner.Commands
+            .SelectMany(c => c.Flags.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+            .ToList();
+
+        // A floor, because the whole check passes over an empty catalog: Commands is a static list
+        // and a change to its shape (a rename, a different separator) would empty this silently.
+        Assert.True(flags.Count >= 8,
+            $"only {flags.Count} flags were read out of the help catalog — its shape changed and this "
+            + "guard is no longer reading it.");
+
+        foreach (var flag in flags)
+        {
+            var parsed = CliRunner.Parse([flag]);
+            Assert.False(parsed.Command is CliCommand.Unknown,
+                $"'{flag}' is advertised by --help but Parse rejects it as an unknown option. Add an arm "
+                + "for it in Parse, or stop documenting it.");
+        }
     }
 
     [Fact]

--- a/SysManager/SysManager/Services/CliRunner.cs
+++ b/SysManager/SysManager/Services/CliRunner.cs
@@ -28,24 +28,17 @@ public sealed class CliRunner
     // const here had already gone stale by two minor releases.
     private static readonly string Version = UpdateService.CurrentVersion.ToString(3);
 
-    // CLI verbs that put startup into headless mode. The elevation sentinel
-    // (--relaunched-elevated) and the update-applier arg are deliberately absent, so they
-    // route to their own startup branches and never get treated as a CLI command.
-    private static readonly HashSet<string> CliVerbs = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "--help", "-h", "-?", "/?", "--version", "-v", "--list", "--health", "--cleanup",
-        // --trim-ram is a RETAINED ALIAS, not a second verb: a maintenance schedule registered before the
-        // rename has "--trim-ram --silent" baked into a Windows scheduled task's argument string on the
-        // user's machine (#1524). The arm in Parse is what keeps it working; this list does not, because
-        // IsCliToken below also accepts anything starting with - or /, which every entry here does. So
-        // the set decides nothing it is asked and reads as an allowlist it is not — worth removing on its
-        // own rather than inside a rename. Do not add a verb here and assume that made it work.
-        "--purge-standby", "--trim-ram",
-    };
-
     // Internal startup sentinels that LOOK like CLI flags but are handled by their own
     // OnStartup branches (elevation relaunch, in-process update applier). They must NEVER
     // be treated as a CLI invocation, so an unknown-flag dispatch can't hijack them.
+    //
+    // This is the ONLY list that decides anything here. There used to be a second one, a
+    // CliVerbs set naming every recognized verb, which read like the allowlist for headless
+    // mode and was not one: every entry began with - or /, so IsCliToken's second clause
+    // already accepted all of them and the set never changed an answer. It was found by a
+    // mutation that removed a verb from it expecting a red test and got a green one. The real
+    // allowlist is Parse's switch, and CliRunnerTests + ArchitectureTests now hold Parse and
+    // Commands to each other so neither can document a verb it cannot parse.
     private static readonly HashSet<string> NonCliSentinels = new(StringComparer.OrdinalIgnoreCase)
     {
         Helpers.AdminHelper.RelaunchedElevatedArg, UpdateApplier.ApplyUpdateArg,
@@ -62,9 +55,11 @@ public sealed class CliRunner
         return args.Any(a => IsCliToken(a.Trim()));
     }
 
-    // A recognized verb, or any unrecognized option flag (leading - or /). Bare tokens aren't.
+    // Any option flag, recognized or not (leading - or /). Bare tokens aren't. Deliberately does
+    // not consult a list of known verbs: a typo must reach Parse and come back as a usage error
+    // rather than opening the window, which is what IsCliInvocation promises above.
     private static bool IsCliToken(string arg)
-        => CliVerbs.Contains(arg) || arg.StartsWith('-') || arg.StartsWith('/');
+        => arg.StartsWith('-') || arg.StartsWith('/');
 
     /// <summary>
     /// Parses the argument list into a <see cref="CliRequest"/>. The first recognized verb


### PR DESCRIPTION
CliRunner carried a CliVerbs set naming every recognized verb, positioned as the allowlist for
headless mode. It was not one. Every entry began with - or /, and IsCliToken read

    CliVerbs.Contains(arg) || arg.StartsWith('-') || arg.StartsWith('/')

so the second clause already accepted every member and the set never changed an answer it was asked.
It was found by a mutation in #2158 that removed a verb from it expecting the alias test to go red;
the test stayed green, and nothing else observed a difference either.

Deleting it is the small half. The reason it was worth an issue of its own (#2159) is that it invited
two misreadings: add a verb here and conclude it is wired up (Parse's switch is the real allowlist,
and a verb missing there parses to Unknown, exit 2), or tighten IsCliToken to "recognised verbs only"
on the assumption this set was authoritative, which would silently make a typo open the window
instead of reporting a usage error. Behaviour here is unchanged; the comment on NonCliSentinels now
says which list actually decides something, and why the other one is gone.

## Documentation in the shape of a check, replaced by a check

Removing the set leaves the real gap it was pretending to cover. CliRunner.Commands — the catalog
--help and the CLI Interface tab are both built from — and Parse's switch are two independent lists
of the same flags, and nothing compared them. Both directions were unguarded:

- **CliRunnerTests.EveryFlagInTheHelpCatalog_Parses** — every flag the help advertises must parse to
  something other than Unknown. This is the direction that reaches a user: they read a verb in
  --help, type it, and the same program answers "Unknown option".
- **ArchitectureTests.EveryVerbParseAccepts_IsDocumentedOrDeliberatelyNot** — every case label in
  Parse must appear somewhere in the catalog, or be named in the test's exception list with a reason.
  Four are, and each is deliberate: -? and /? are Windows-convention aliases for --help, /silent is
  the cmd.exe spelling of --silent, and --trim-ram is the retained compatibility alias from #1524,
  named in --purge-standby's DESCRIPTION so the help does not advertise a spelling that only exists
  for schedules registered before the rename. The exception list is itself checked for staleness: a
  verb removed from Parse and left there fails, because an excuse for code that no longer exists
  reads as a decision somebody made.

Read from source text rather than by reflection because the mapping IS a switch — there is no runtime
collection of case labels — and rewriting Parse around a dictionary purely so a test could enumerate
it would trade a readable switch for a table. The slice is bounded by Parse's declaration and Pick's,
and refuses rather than widening if either marker moves, because a whole-file scan would read the
catalog's own strings as case labels and pass vacuously.

## One coverage hole the deletion exposed

Nothing asserted that a SLASH argument reaches CLI mode. The parse tests cover /? mapping to Help,
but no test checked that it makes the app headless in the first place, and that is IsCliToken's
leading-slash clause. Dropping the clause left every test green — the same hole the dead set created,
so IsCliInvocation_TrueForSlashSpelledHelp comes with the fix for it.

## Red/green, seven mutations

    baseline                                         7 green
    M0  guard floor raised to 99                     RED  prints "only 15 case labels" (the real count)
    M1  delete the --cleanup row from the catalog    RED  EveryVerbParseAccepts...
    M2  document a verb Parse rejects                RED  EveryFlagInTheHelpCatalog_Parses
    M3  drop the --trim-ram arm from Parse           RED  Parse_StillAccepts... + stale-exception check
    M4  break the end-of-Parse marker                RED  refuses: "the end of Parse was not found"
    M5  case-label regex loses `or` alternatives     RED  floor fires at 8 of 15
    M6  IsCliToken drops the slash clause            RED  IsCliInvocation_TrueForSlashSpelledHelp
    restored, sha verified for both files, rebuilt   7 green

M1's first draft renamed the flag instead of deleting its row, which left a documented-but-unparseable
entry and went red on the OTHER guard — proving guard A twice while claiming to prove guard B. Worth
recording because the mutation looked right and the verdict looked right.

M4 exists because a marker-bounded slice is only trustworthy if a missing marker REFUSES. Two spaces
in Pick's declaration compile identically, so it isolates the marker from the behaviour.

## Propagate

The defect is "a set positioned as authoritative whose members are all covered by a broader clause
beside it". Checked every other static string set in the app (9 of them) at its use sites. Only one
has the same shape — IconExtractorService.IsServiceProcess, `ServiceProcesses.Contains(name) ||
name.StartsWith("svchost")` — and there the set is load-bearing: it holds 40-odd names like mpssvc,
netprofm and Winmgmt that the svchost prefix does not cover. The rest are single-condition tests. No
second instance to fix.

Behaviour identical: the app builds 0 errors 0 warnings, all 36 CliRunnerTests pass unchanged, and
every ArchitectureTests guard is green at 113 of 113 (112 before, plus the new one). Format clean;
43 leak patterns over 10,121 bytes of added lines, 0 hits. No version bump and no CHANGELOG entry:
auto-release.yml bumps only on feat: or fix:, so refactor: releases nothing and there is nothing
user-visible to describe.

Closes #2159.
