### PR TITLE
test: App Blocker's confirmation tests asserted whichever branch the host was on

### DIFF
--- a/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using NSubstitute;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
@@ -108,11 +109,20 @@ public class AppBlockerViewModelTests
 
     // ── Confirmation-gate tests (destructive ops must route through Confirm) ──
 
+    // Every test below forces elevation ON, and the view-model is built INSIDE the scope because it caches
+    // IsElevated in its constructor. Without that, these tests asserted nothing about blocking: BlockApp
+    // returns at `if (!IsElevated)` before it ever reaches Confirm, so on a non-elevated host all six failed
+    // with "Blocking requires administrator privileges." while on CI — whose runner IS elevated — all six
+    // passed. Neither run said whether a safety refusal is reported as a safety refusal (#2168). The same
+    // trap AdminHelper.ForceElevation was added for one class over, in CleanupViewModelTests.
+
     [Fact]
     public void BlockApp_WhenUserDeclinesConfirm_DoesNotBlock()
     {
+        using var elevated = AdminHelper.ForceElevation(true);
         var blocker = Substitute.For<IAppBlockerService>();
         var vm = NewVm(blocker);
+        Assert.True(vm.IsElevated, "the scope must reach the view-model's constructor");
         vm.NewExeName = "game.exe";
 
         var prevDialog = DialogService.Instance;
@@ -138,11 +148,13 @@ public class AppBlockerViewModelTests
     [Fact]
     public void BlockApp_WhenUserConfirms_BlocksApp()
     {
+        using var elevated = AdminHelper.ForceElevation(true);
         var blocker = Substitute.For<IAppBlockerService>();
         // The view model calls TryBlockApp now, so it can tell a safety refusal from a
         // permissions problem instead of reporting every failure as "check admin privileges".
         blocker.TryBlockApp(Arg.Any<string>()).Returns(AppBlockerService.BlockResult.Success);
         var vm = NewVm(blocker);
+        Assert.True(vm.IsElevated, "the scope must reach the view-model's constructor");
         vm.NewExeName = "game.exe";
 
         var prevDialog = DialogService.Instance;
@@ -173,9 +185,11 @@ public class AppBlockerViewModelTests
     {
         // Each of these is SysManager deliberately declining. Reporting them as a permissions
         // problem sent the user to relaunch elevated, where the same guard refuses again.
+        using var elevated = AdminHelper.ForceElevation(true);
         var blocker = Substitute.For<IAppBlockerService>();
         blocker.TryBlockApp(Arg.Any<string>()).Returns(refusal);
         var vm = NewVm(blocker);
+        Assert.True(vm.IsElevated, "the scope must reach the view-model's constructor");
         vm.NewExeName = "something.exe";
 
         var prevDialog = DialogService.Instance;
@@ -195,12 +209,25 @@ public class AppBlockerViewModelTests
         }
     }
 
+    /// <summary>
+    /// <c>AccessDenied</c> from the service is the one refusal that SHOULD talk about administrator
+    /// rights — and it must get there through the service, not through the view-model's own gate.
+    /// </summary>
+    /// <remarks>
+    /// This was the worst of the seven (#2168), because it PASSED on a non-elevated host for the wrong
+    /// reason: the elevation gate's own message also contains "administrator", so the assertion was
+    /// satisfied by a code path that never called <c>TryBlockApp</c> at all. A false pass hides better than
+    /// a false failure. Forcing elevation on and asserting the service was actually reached is what makes
+    /// the assertion mean what its name says.
+    /// </remarks>
     [Fact]
     public void BlockApp_AccessDenied_IsTheOnlyCaseThatMentionsAdminRights()
     {
+        using var elevated = AdminHelper.ForceElevation(true);
         var blocker = Substitute.For<IAppBlockerService>();
         blocker.TryBlockApp(Arg.Any<string>()).Returns(AppBlockerService.BlockResult.AccessDenied);
         var vm = NewVm(blocker);
+        Assert.True(vm.IsElevated, "the scope must reach the view-model's constructor");
         vm.NewExeName = "something.exe";
 
         var prevDialog = DialogService.Instance;
@@ -211,7 +238,52 @@ public class AppBlockerViewModelTests
         {
             vm.BlockAppCommand.Execute(null);
 
+            blocker.Received(1).TryBlockApp("something.exe");
             Assert.Contains("administrator", vm.BlockStatus, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    /// <summary>
+    /// Without elevation, Block refuses before it touches anything: it says why, it does not ask the user
+    /// to confirm something it cannot do, and it never reaches the service.
+    /// </summary>
+    /// <remarks>
+    /// The branch a user without admin rights actually sees, and it was asserted nowhere for any of the ten
+    /// view models that have one (#2168, swept in #2171). Every existing test here drove the ELEVATED path,
+    /// so the gate could have been deleted, moved below the Confirm, or given a misleading message without
+    /// a single failure — on CI, whose runner is elevated, or on a developer machine, where the six tests
+    /// that did notice failed for a reason that looked like a broken parser.
+    /// <para>Asserting the absence matters as much as the message: <c>Confirm</c> must NOT be reached. A gate
+    /// that runs after the confirmation dialog would still produce the right status text while asking the
+    /// user to approve an operation that then refuses itself — which is the shape of the Unblock path's own
+    /// problem, filed separately.</para>
+    /// </remarks>
+    [Fact]
+    public void BlockApp_WhenNotElevated_SaysWhyAndNeverReachesTheService()
+    {
+        using var notElevated = AdminHelper.ForceElevation(false);
+        var blocker = Substitute.For<IAppBlockerService>();
+        var vm = NewVm(blocker);
+        Assert.False(vm.IsElevated, "the scope must reach the view-model's constructor");
+        vm.NewExeName = "game.exe";
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true); // would say yes if asked
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.BlockAppCommand.Execute(null);
+
+            Assert.Contains("administrator", vm.BlockStatus, StringComparison.OrdinalIgnoreCase);
+            dialog.DidNotReceive().Confirm(Arg.Any<string>(), Arg.Any<string>());
+            blocker.DidNotReceive().TryBlockApp(Arg.Any<string>());
+            blocker.DidNotReceive().BlockApp(Arg.Any<string>());
+            Assert.Equal("game.exe", vm.NewExeName); // the typed name survives, so a relaunch can use it
         }
         finally
         {


### PR DESCRIPTION
Seven tests drove `BlockApp` without controlling elevation, and the view model caches
`AdminHelper.IsElevated()` in its constructor and returns at `if (!IsElevated)` before it reaches
`Confirm`. On CI, whose runner IS elevated, all seven passed. On an ordinary shell, six failed with
"Blocking requires administrator privileges." — and the seventh passed for the wrong reason, which is
the one worth pausing on:

    BlockApp_AccessDenied_IsTheOnlyCaseThatMentionsAdminRights

asserted that the status mentions "administrator". The elevation gate's own message says
"administrator" too, so the assertion was satisfied by a path that never called `TryBlockApp` at all. A
false pass hides better than a false failure, and this one hid in the green column on both hosts.

So neither run answered the question the tests are named for: is a safety refusal reported as a safety
refusal, or as a permissions problem? That distinction is the whole point of the code they cover —
reporting a deliberate refusal as "check admin privileges" sent the user to relaunch elevated, where
the same guard refuses again without explaining itself.

All seven now force elevation ON with `AdminHelper.ForceElevation(true)`, the seam added for exactly
this trap one class over in `CleanupViewModelTests`. The scope wraps the CONSTRUCTOR, not just the
command, because that is where the value is read, and each test asserts `vm.IsElevated` so a scope that
does not reach the constructor fails by name rather than by symptom. The AccessDenied test additionally
asserts `TryBlockApp` was reached, so it can no longer be satisfied by the gate it was never about.

## The branch a user without admin actually sees, asserted for the first time

`BlockApp_WhenNotElevated_SaysWhyAndNeverReachesTheService` did not exist, for App Blocker or for any
of the other nine view models with an elevation branch. It forces elevation OFF and asserts four
things: the status explains the reason, `Confirm` is NOT reached, neither `TryBlockApp` nor `BlockApp`
is called, and the name the user typed survives so a relaunch can use it.

The `Confirm` assertion is not padding. A gate placed after the confirmation dialog would still produce
the right status text while asking the user to approve an operation that then refuses itself — and the
mutation that reorders them is red only because of that line.

## Red/green, five mutations, on a host that is NOT elevated

    baseline                                        16 green
    M1  delete the elevation gate                   RED  status became "Blocked game.exe." — an
                                                         unelevated block APPEARS to succeed
    M2  move the gate below the Confirm             RED  "Actually received 1 matching call"
    M3  drop ForceElevation from the theory         RED  all 4 safety-refusal rows
    M4  drop ForceElevation from AccessDenied       RED  its new Received(1).TryBlockApp assertion
    M5  gate stops saying "administrator"           RED  the message assertion
    restored, sha verified for both files, rebuilt  16 green

M1's status text is the finding inside the finding: with no gate, the view model reports success for a
block that the registry never accepted.

## Regression

The whole unit suite on this non-elevated machine, excluding only `DeepCleanupServiceTests` (39
real-disk scans, #2167): **5129 tests, 0 failures**, where the same run before this change was 5125
with 7 failures. Every ArchitectureTests guard green at 113 of 113. Format clean; 43 leak patterns over
4,508 bytes of added lines, 0 hits.

## Propagate

Measured the class rather than assuming App Blocker was alone: ten view models branch on elevation and
nine of them have no test that pins it, with two having no test file at all. `CleanupViewModel` is the
only one that already controls it. That sweep is #2171, with the table, and deliberately carries the
fitness check that would make this mechanical — adding the guard here would have shipped it with eight
"not done yet" exceptions, and an exception list nobody has verified is a false claim sitting in the
test suite.

One thing found while reading and filed separately: `UnblockSelected` has NO elevation gate, though
`UnblockApp` writes the same HKLM IFEO key and its own catch logs "admin required". Without admin it
asks the user to confirm, fails every write, and reports "Unblocked 0 applications" without saying why.

Closes #2168.
