### PR TITLE
test: a Performance test read its PropertyChanged log while the view model was still writing it

### DIFF
--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections.Concurrent;
 using System.IO;
 using System.Reflection;
 using NSubstitute;
@@ -195,12 +196,38 @@ public class PerformanceViewModelTests
         Assert.False(vm.HasNvidiaGpu);
     }
 
+    /// <summary>
+    /// Records every property name this view model raises, safely enough to read while it is still
+    /// raising them.
+    /// </summary>
+    /// <remarks>
+    /// A plain <c>List&lt;string&gt;</c> here is a data race, and it fired on CI as
+    /// <c>InvalidOperationException: Collection was modified; enumeration operation may not execute</c>
+    /// from inside <c>Assert.Contains</c> (#2169). The second writer is the view model's own
+    /// initialization: the constructor calls <c>InitializeAsync</c>, whose continuations resume on the
+    /// thread pool because <c>ViewModelBase</c> awaits with <c>ConfigureAwait(false)</c>, and
+    /// <see cref="NewVm"/> deliberately does NOT wait for it — its <c>RunProcessAsync</c> returns a task
+    /// that never completes, which is what keeps these constructor-state tests independent of the host.
+    /// So the writer cannot be removed; the recorder has to tolerate it.
+    /// <para><c>ConcurrentQueue</c> rather than a snapshot: <c>changed.ToList()</c> would enumerate too,
+    /// and throw in exactly the same place. Its enumerator is a moment-in-time snapshot, so a concurrent
+    /// <c>Enqueue</c> cannot invalidate a read in progress.</para>
+    /// <para>It took ~5,000 concurrent tests to surface once and passes six for six in isolation, which
+    /// is precisely why it is worth fixing rather than watching: the next occurrence would read as a
+    /// one-off flake on an unrelated pull request.</para>
+    /// </remarks>
+    private static ConcurrentQueue<string> RecordPropertyChanges(PerformanceViewModel vm)
+    {
+        var changed = new ConcurrentQueue<string>();
+        vm.PropertyChanged += (_, e) => changed.Enqueue(e.PropertyName!);
+        return changed;
+    }
+
     [Fact]
     public void SelectedPlan_NotifiesPropertyChanged()
     {
         var vm = NewVm();
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = RecordPropertyChanges(vm);
         vm.SelectedPlan = "high";
         Assert.Contains("SelectedPlan", changed);
     }
@@ -227,8 +254,7 @@ public class PerformanceViewModelTests
     public void IsProcessorStateLocked_NotifiesEditable()
     {
         var vm = NewVm();
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = RecordPropertyChanges(vm);
         vm.IsProcessorStateLocked = true;
         Assert.Contains("IsProcessorStateLocked", changed);
         Assert.Contains("IsProcessorStateEditable", changed);


### PR DESCRIPTION
`SelectedPlan_NotifiesPropertyChanged` collected raised property names into a plain `List<string>` from
a `PropertyChanged` handler and then enumerated that list to assert. It failed on CI with:

    System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
       at System.Linq.Enumerable.ContainsIterate[TSource](...)
       at System.Linq.Enumerable.Contains[TSource](...)
       SysManager/SysManager.Tests/PerformanceViewModelTests.cs(205,0)

`List<T>` throws that only when it is mutated during enumeration, so the stack trace is the proof: a
second thread appended while `Assert.Contains` walked the list.

The second writer is the view model's own initialization, and it cannot be removed. The constructor
calls `InitializeAsync`, `ViewModelBase` awaits it with `ConfigureAwait(false)`, so its continuations
resume on the thread pool — and `NewVm()` deliberately does NOT wait for that to finish: it leaves
`RunProcessAsync` returning a `TaskCompletionSource` task that never completes, which is what keeps
these constructor-state tests independent of the host's registry and P/Invoke state. Waiting would
hang. So the recorder is what has to tolerate a concurrent writer.

Both recorders in the file now go through one helper returning a `ConcurrentQueue<string>`, whose
enumerator is a moment-in-time snapshot. Snapshotting by hand would not have worked:
`changed.ToList()` enumerates too, and would throw in exactly the same place.

## Red/green, and why a mutation alone would have proved nothing

The failure needed ~5,000 concurrent tests to surface once, and the test passes six for six in
isolation. Reverting the fix and watching for green is therefore worthless. So the proof AMPLIFIES it:
a temporary probe raises `SelectedPlan` from a background thread in a loop while the foreground
enumerates the recorder up to 400,000 times — the same shape as the CI failure, deterministically.

    A1  amplified probe, plain List<string>       RED    "Collection was modified; enumeration
                                                         operation may not execute." — the CI exception
    A2  amplified probe, the shipped recorder      GREEN
    probe deleted, target restored, sha verified, suite rebuilt: 26 green

`SelectedPlan` was chosen after checking it is a bare `[ObservableProperty]` with no changed-hook, so
the loop raises notifications and touches nothing else. The probe file was added to the test project
for the duration and its removal is asserted, so nothing temporary survives in the repo.

Two flaws in the probe itself, both worth recording because each produced a confident wrong verdict:

1. `writer.GetAwaiter().GetResult()` in a `[Fact]` fails to compile under xUnit1031 ("test methods
   should not use blocking task operations"). The run reported BROKEN rather than a verdict, which is
   the behaviour a proof runner needs — a build failure says nothing about the defect.
2. The first working version asserted the name was present from iteration zero, before anything had
   raised it. With a `List` the concurrency exception fired first and hid this; with the queue the
   first read legitimately saw `Collection: []` and A2 failed for a reason that was not the race.
   Raising once on the foreground thread first, as the real test does, fixed it.

## The wider pattern, and why it is not swept here

`PropertyChanged +=` appending to a plain collection appears in 30 test files. Most are safe, because
most of these view models raise notifications synchronously on the setter's own thread and there is no
second writer at all.

Narrowing that to the genuinely exposed set needs reading each test factory, and two attempts to
measure it by grep both mis-classified — the second one reported this very file as safe, because it
matched the phrase "await InitializationComplete" inside `NewVm`'s explanatory COMMENT rather than in
its code. So no population number is claimed here. The durable answer is a shared recorder helper plus
a guard that requires it, which is its own change; filed as a follow-up rather than guessed at.

Regression: every ArchitectureTests guard green at 113 of 113, and the unit suite on this branch is
5128 with 6 failures, which are exactly App Blocker's elevation-dependent tests that #2172 fixes and
that this branch predates. Format clean; 43 leak patterns over 1,930 bytes of added lines, 0 hits.

Closes #2169.
