### PR TITLE
test: Deep Cleanup scanned the whole machine 27 times to assert one scan's properties

### DIFF
--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -8913,6 +8913,72 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// The one shared Deep Cleanup scan must stay read-only: no test may iterate it with a view to
+    /// changing an item, and it must never be handed to <c>CleanAsync</c>.
+    /// </summary>
+    /// <remarks>
+    /// <c>DeepCleanupServiceTests</c> shares a single real disk scan across 27 read-only tests, because
+    /// performing one per test made the class take 23 minutes on a machine with real caches against 2.4
+    /// with the fixture (#2167). Sharing is only safe while nothing mutates it, and
+    /// <c>CleanupCategory.IsSelected</c> is a settable property, so "read-only" is a convention rather
+    /// than something the type enforces.
+    /// <para>Nothing would have caught a breach. The two tests that DO change a category —
+    /// <c>CleanAsync_NoneSelected_DoesNothing</c> clears <c>IsSelected</c> on everything it is given, and
+    /// <c>CleanAsync_CancelledToken_ReturnsImmediately</c> hands its list to <c>CleanAsync</c> — keep their
+    /// own scans for that reason, and switching either to the shared list would have left every test in
+    /// the class green: the remaining assertions are "empty categories are not selected" and "Windows.old
+    /// is not selected", both of which stay true after everything is deselected. So the comment saying
+    /// "do not share this" was the only thing standing between a plausible edit and 27 tests quietly
+    /// asserting against a list something else had emptied.</para>
+    /// <para>Two rules, both narrow on purpose. <c>foreach</c> over the shared field is banned outright
+    /// because no read-only assertion here needs it — they all use <c>Assert.All</c>, <c>Assert.Contains</c>
+    /// or LINQ — so its appearance means someone is walking the list to change it. And the field may not be
+    /// passed to <c>CleanAsync</c>, which is the only method in reach that acts on a category list.</para>
+    /// </remarks>
+    [Fact]
+    public void TheSharedDeepCleanupScan_IsNeverMutatedOrCleaned()
+    {
+        var testsDir = Path.Combine(
+            Directory.GetParent(FindAppProjectDir())!.FullName, "SysManager.Tests");
+        var source = File.ReadAllText(Path.Combine(testsDir, "DeepCleanupServiceTests.cs"));
+
+        // The field name is read from the declaration rather than hardcoded, so a rename breaks this
+        // guard loudly instead of turning it into a check on a name that no longer exists.
+        var declaration = SharedScanField().Match(source);
+        Assert.True(declaration.Success,
+            "the shared-scan field was not found in DeepCleanupServiceTests. If the class-fixture "
+            + "arrangement was removed on purpose, remove this guard with it; if it was renamed, this "
+            + "guard is now checking nothing and must be updated.");
+        var field = declaration.Groups[1].Value;
+
+        // Floor: the whole point is that MANY tests read this field. A couple of uses means the fixture
+        // arrangement has been unwound and a clean result here would prove nothing.
+        var uses = Regex.Matches(source, @"\b" + Regex.Escape(field) + @"\b").Count;
+        Assert.True(uses >= 20,
+            $"'{field}' is used only {uses} times, so the shared scan is barely shared and this guard is "
+            + "no longer watching what it was written for.");
+
+        var offenders = new List<string>();
+        if (Regex.IsMatch(source, @"foreach\s*\([^)]*\bin\s+" + Regex.Escape(field) + @"\b"))
+            offenders.Add($"a foreach over {field} — walk a private scan if an item has to change");
+        if (Regex.IsMatch(source, @"CleanAsync\(\s*" + Regex.Escape(field) + @"\b"))
+            offenders.Add($"{field} passed to CleanAsync — give it a scan of its own");
+
+        Assert.True(offenders.Count == 0,
+            $"'{field}' is one real disk scan shared by every read-only test in the class. Mutating it "
+            + "would make later tests assert against a list an earlier test had changed, and none of the "
+            + "current assertions would fail:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The declaration of the field holding the shared Deep Cleanup scan, capturing its name.
+    /// </summary>
+    [GeneratedRegex(@"private\s+readonly\s+IReadOnlyList<CleanupCategory>\s+(\w+)\s*=\s*scan\.",
+                    RegexOptions.CultureInvariant)]
+    private static partial Regex SharedScanField();
+
+    /// <summary>
     /// A string literal in a <c>case</c> label, including each alternative of an <c>or</c> pattern —
     /// <c>case "--a" or "-b":</c> yields both.
     /// </summary>

--- a/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
@@ -8,8 +8,46 @@ using SysManager.Services;
 
 namespace SysManager.Tests;
 
-public class DeepCleanupServiceTests
+/// <summary>
+/// One real scan of this machine, shared by every test that only READS the result.
+/// </summary>
+/// <remarks>
+/// <c>DeepCleanupService.ScanAsync</c> walks the machine: <c>LocalApplicationData</c>,
+/// <c>CommonApplicationData</c>, the Windows directory, both Program Files trees, and every drive root
+/// looking for Steam, Riot and shader caches. It reaches the filesystem through
+/// <c>Environment.GetFolderPath</c> and <c>Directory.EnumerateFiles</c> directly, so there is no seam to
+/// substitute and a test can only scan the real disk.
+/// <para>27 tests here assert properties of one scan's output — names are non-empty, sizes are
+/// non-negative, the list contains Recycle Bin — and each used to perform its own. The class carries no
+/// <c>[Collection]</c>, so it is its own collection and its tests run SEQUENTIALLY: 27 serial disk walks.
+/// On a fresh CI runner each is near-instant and the whole unit suite takes about 78 seconds. On a
+/// machine with real caches, 16 of these tests were measured at 31 to 52 seconds EACH, and the class
+/// alone did not finish inside a 20-minute budget while every other class in the suite had completed
+/// (#2167). The blocking suite's runtime was a function of how much junk was on the machine running it.
+/// </para>
+/// <para>Four tests still call <c>ScanAsync</c> themselves, and only two of those are a full walk. The
+/// two cancellation tests must drive it directly, because cancellation is the thing under test, and both
+/// stop almost immediately. <c>CleanAsync_NoneSelected_DoesNothing</c> MUTATES <c>IsSelected</c> on what
+/// it is given, and <c>CleanAsync_CancelledToken_ReturnsImmediately</c> hands its list to
+/// <c>CleanAsync</c>; neither may be given the shared instance, so each keeps its own scan. 27 walks
+/// down to 3.</para>
+/// </remarks>
+public sealed class DeepCleanupScanFixture : IAsyncLifetime
 {
+    /// <summary>The one scan's categories. Treat as read-only — every consumer shares this instance.</summary>
+    public IReadOnlyList<CleanupCategory> Categories { get; private set; } = [];
+
+    public async ValueTask InitializeAsync()
+        => Categories = await new DeepCleanupService().ScanAsync();
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}
+
+public class DeepCleanupServiceTests(DeepCleanupScanFixture scan) : IClassFixture<DeepCleanupScanFixture>
+{
+    // The shared scan. Read only: a test that needs to change a category scans for itself.
+    private readonly IReadOnlyList<CleanupCategory> _scanned = scan.Categories;
+
     [Fact]
     public void Constructs()
     {
@@ -18,52 +56,41 @@ public class DeepCleanupServiceTests
     }
 
     [Fact]
-    public async Task ScanAsync_ReturnsNonNull()
+    public void ScanAsync_ReturnsNonNull()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.NotNull(r);
+        Assert.NotNull(_scanned);
     }
 
     [Fact]
-    public async Task ScanAsync_ReturnsSeveralCategories()
+    public void ScanAsync_ReturnsSeveralCategories()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        // System + gaming categories should always be scanned even if empty.
-        Assert.True(r.Count >= 10, $"Expected >=10 categories, got {r.Count}");
+        // System + gaming categories should always be scanned even if empty. Also the floor that keeps
+        // every other test in this class from passing over an empty shared scan.
+        Assert.True(_scanned.Count >= 10, $"Expected >=10 categories, got {_scanned.Count}");
     }
 
     [Fact]
-    public async Task ScanAsync_AllCategoriesHaveName()
+    public void ScanAsync_AllCategoriesHaveName()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.All(r, c => Assert.False(string.IsNullOrWhiteSpace(c.Name)));
+        Assert.All(_scanned, c => Assert.False(string.IsNullOrWhiteSpace(c.Name)));
     }
 
     [Fact]
-    public async Task ScanAsync_AllCategoriesHaveDescription()
+    public void ScanAsync_AllCategoriesHaveDescription()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.All(r, c => Assert.False(string.IsNullOrWhiteSpace(c.Description)));
+        Assert.All(_scanned, c => Assert.False(string.IsNullOrWhiteSpace(c.Description)));
     }
 
     [Fact]
-    public async Task ScanAsync_AllSizesNonNegative()
+    public void ScanAsync_AllSizesNonNegative()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.All(r, c => Assert.True(c.TotalSizeBytes >= 0));
+        Assert.All(_scanned, c => Assert.True(c.TotalSizeBytes >= 0));
     }
 
     [Fact]
-    public async Task ScanAsync_AllCountsNonNegative()
+    public void ScanAsync_AllCountsNonNegative()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.All(r, c => Assert.True(c.FileCount >= 0));
+        Assert.All(_scanned, c => Assert.True(c.FileCount >= 0));
     }
 
     [Fact]
@@ -101,173 +128,133 @@ public class DeepCleanupServiceTests
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesNvidiaCategory()
+    public void ScanAsync_IncludesNvidiaCategory()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("NVIDIA", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("NVIDIA", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesAmdCategory()
+    public void ScanAsync_IncludesAmdCategory()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("AMD", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("AMD", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesIntelCategory()
+    public void ScanAsync_IncludesIntelCategory()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("Intel", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("Intel", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesWindowsUpdateCache()
+    public void ScanAsync_IncludesWindowsUpdateCache()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("Windows Update", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("Windows Update", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesTempFiles()
+    public void ScanAsync_IncludesTempFiles()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("Temporary", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("Temporary", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesPrefetch()
+    public void ScanAsync_IncludesPrefetch()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("Prefetch", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("Prefetch", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesRecycleBin()
+    public void ScanAsync_IncludesRecycleBin()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("Recycle", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("Recycle", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_RecycleBinCategory_IsFlaggedForShellApi()
+    public void ScanAsync_RecycleBinCategory_IsFlaggedForShellApi()
     {
         // The Recycle Bin must be emptied through the shell API (SHEmptyRecycleBin),
         // not the generic file-delete path which corrupts the per-SID bin metadata.
         // CleanAsync routes on IsRecycleBin, so a regression that drops the flag would
         // silently send the bin back to raw delete. Pin the flag here.
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        var bin = r.FirstOrDefault(c => c.Name.Contains("Recycle", StringComparison.OrdinalIgnoreCase));
+        var bin = _scanned.FirstOrDefault(c => c.Name.Contains("Recycle", StringComparison.OrdinalIgnoreCase));
         Assert.NotNull(bin);
         Assert.True(bin!.IsRecycleBin, "Recycle Bin category must be flagged IsRecycleBin so cleanup uses the shell API");
         // And no other category should carry the flag.
-        Assert.All(r.Where(c => !c.Name.Contains("Recycle", StringComparison.OrdinalIgnoreCase)),
+        Assert.All(_scanned.Where(c => !c.Name.Contains("Recycle", StringComparison.OrdinalIgnoreCase)),
             c => Assert.False(c.IsRecycleBin));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesSteam()
+    public void ScanAsync_IncludesSteam()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.StartsWith("Steam", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.StartsWith("Steam", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesEpic()
+    public void ScanAsync_IncludesEpic()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("Epic", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("Epic", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesBattleNet()
+    public void ScanAsync_IncludesBattleNet()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("Battle", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("Battle", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesRiot()
+    public void ScanAsync_IncludesRiot()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("Riot", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("Riot", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesGog()
+    public void ScanAsync_IncludesGog()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("GOG", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("GOG", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesEaApp()
+    public void ScanAsync_IncludesEaApp()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("EA ", StringComparison.OrdinalIgnoreCase) || c.Name.Contains("Origin", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("EA ", StringComparison.OrdinalIgnoreCase) || c.Name.Contains("Origin", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesDirectXShaderCache()
+    public void ScanAsync_IncludesDirectXShaderCache()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("DirectX", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("DirectX", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesCrashDumps()
+    public void ScanAsync_IncludesCrashDumps()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("Crash", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("Crash", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesPatchCache()
+    public void ScanAsync_IncludesPatchCache()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("Installer patch", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("Installer patch", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_IncludesDeliveryOptimization()
+    public void ScanAsync_IncludesDeliveryOptimization()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.Contains(r, c => c.Name.Contains("Delivery", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(_scanned, c => c.Name.Contains("Delivery", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public async Task ScanAsync_CategoriesHaveUniqueNames()
+    public void ScanAsync_CategoriesHaveUniqueNames()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        var names = r.Select(c => c.Name).ToList();
+        var names = _scanned.Select(c => c.Name).ToList();
         Assert.Equal(names.Count, names.Distinct().Count());
     }
 
     [Fact]
-    public async Task ScanAsync_WindowsOldNeverSelectedByDefault()
+    public void ScanAsync_WindowsOldNeverSelectedByDefault()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        var wo = r.FirstOrDefault(c => c.Name.Contains("Windows.old", StringComparison.OrdinalIgnoreCase));
+        var wo = _scanned.FirstOrDefault(c => c.Name.Contains("Windows.old", StringComparison.OrdinalIgnoreCase));
         if (wo != null)
         {
             Assert.False(wo.IsSelected, "Windows.old must never auto-select");
@@ -276,11 +263,9 @@ public class DeepCleanupServiceTests
     }
 
     [Fact]
-    public async Task ScanAsync_EmptyCategoriesAreNotSelected()
+    public void ScanAsync_EmptyCategoriesAreNotSelected()
     {
-        var s = new DeepCleanupService();
-        var r = await s.ScanAsync();
-        Assert.All(r, c =>
+        Assert.All(_scanned, c =>
         {
             if (c.TotalSizeBytes == 0) Assert.False(c.IsSelected);
         });
@@ -299,6 +284,8 @@ public class DeepCleanupServiceTests
     [Fact]
     public async Task CleanAsync_NoneSelected_DoesNothing()
     {
+        // Its own scan, not the class fixture's: this test clears IsSelected on every category it is
+        // given, and the fixture's list is shared with 27 read-only tests in the same collection.
         var s = new DeepCleanupService();
         var cats = await s.ScanAsync();
         foreach (var c in cats) c.IsSelected = false;
@@ -310,6 +297,9 @@ public class DeepCleanupServiceTests
     [Fact]
     public async Task CleanAsync_CancelledToken_ReturnsImmediately()
     {
+        // Its own scan for the same reason: the list is handed to CleanAsync, and a shared instance must
+        // not be passed to something whose job is to act on it — even when a cancelled token means it
+        // will not.
         var s = new DeepCleanupService();
         var cats = await s.ScanAsync();
         using var cts = new CancellationTokenSource();


### PR DESCRIPTION
`DeepCleanupService.ScanAsync` walks `LocalApplicationData`, `CommonApplicationData`, the Windows
directory, both Program Files trees, and every drive root looking for Steam, Riot and shader caches. It
reaches the filesystem through `Environment.GetFolderPath` and `Directory.EnumerateFiles` directly, so
there is no seam and a test can only scan the real disk.

27 tests in `DeepCleanupServiceTests` assert properties of ONE scan's output — names are non-empty,
sizes are non-negative, the list contains Recycle Bin, Windows.old is never auto-selected — and each
performed its own. The class carries no `[Collection]`, so it is its own collection and its tests run
sequentially: 27 serial walks of the machine.

Measured on this workstation, same class, same machine, isolated runs:

    before   39 tests, 1377.8s   (23 minutes)
    after    39 tests,  141.2s   (2.4 minutes)

CI never noticed because a fresh `windows-latest` runner has almost nothing in those caches: the whole
5,000-test unit suite takes about 78 seconds there. The cost only appears on a machine with real
caches — which is every machine a contributor would run the suite on, and the blocking suite's runtime
was therefore a function of how much junk was on it.

A class fixture now performs one scan and hands the result to those 27. Three walks remain and each is
named where it happens: the two cancellation tests must drive `ScanAsync` themselves because
cancellation is the thing under test, and the two `CleanAsync` tests keep their own because one MUTATES
`IsSelected` on what it is given and the other hands its list to `CleanAsync`.

## The part that needed a guard, not a comment

Sharing is only safe while nothing mutates the list, and `CleanupCategory.IsSelected` is a settable
property — so "read-only" was a convention with a comment behind it and nothing else.

Nothing would have caught a breach. Switching `CleanAsync_NoneSelected_DoesNothing` to the shared list
would have left every test in the class GREEN, because the only remaining assertions about selection are
"empty categories are not selected" and "Windows.old is not selected", and both stay true after
everything has been deselected. So a plausible edit could have had 27 tests asserting against a list an
earlier test had emptied, silently.

`ArchitectureTests.TheSharedDeepCleanupScan_IsNeverMutatedOrCleaned` enforces two narrow rules: no
`foreach` over the shared field, because none of the read-only assertions needs one (they use
`Assert.All`, `Assert.Contains` or LINQ), so its appearance means someone is walking the list to change
it; and the field may not be passed to `CleanAsync`, the only method in reach that acts on a category
list. It reads the field's NAME out of its declaration rather than hardcoding it, and refuses if the
declaration is not found — a guard that cannot locate what it checks must fail, not pass.

## Red/green, six mutations

    baseline                                          5 green
    M1  fixture hands out an empty list                RED  "Expected >=10 categories, got 0"
    M2  fixture stops implementing IAsyncLifetime       RED  same — proves the lifetime is wired
    M3  the mutating test walks the SHARED list         RED  guard rule 1, by name
    M4  the shared list handed to CleanAsync            RED  guard rule 2, by name
    M5  the declaration's shape changes                 RED  guard refuses: "field was not found"
    M6  guard's use floor raised to 999                 RED  prints the real count: 30 uses
    restored, sha verified for both files, rebuilt      5 green

M5's first draft renamed the field, which does not compile — 29 call sites still used the old name — so
the run reported BROKEN and said nothing about the guard. Dropping `readonly` compiles identically and
is exactly what the regex keys on, which isolates the declaration's shape from the behaviour.

Behaviour of every assertion is unchanged; 21 of the rewritten tests also stop being `async` because
nothing in them awaits any more. Every ArchitectureTests guard green at 114 of 114 (113 before, plus the
new one). Format clean; 43 leak patterns over 9,242 bytes of added lines, 0 hits.

The second half of #2167 — giving the scan a path seam so its LOGIC can be asserted against a fixture
tree instead of the real machine — is a production change and a Gate-ARCH question, so it is filed on its
own as #2176. This change makes the class affordable to run; that one would make it deterministic, and
it matters more now that 27 tests depend on one scan of one machine rather than 27.

Closes #2167.
