### PR TITLE
fix: App Blocker asked permission to unblock, then failed every change without saying why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.78.8] - 2026-09-08
+
+App Blocker's Unblock button asked you to confirm even when it could not do the job. Without
+administrator rights it would show the confirmation, quietly fail every change, and report "Unblocked 0
+applications" without saying why — while the Block button on the same tab had always refused up front and
+explained itself. Unblock now does the same. It also says how many it could not change, instead of
+reporting the number that worked as if it were all of them.
+
+### Fixed
+
+- **App Blocker — Unblock now refuses without administrator rights instead of failing silently.**
+  Unblocking writes the same protected Windows setting that blocking does, so without admin every change
+  fails. The command checked nothing: it showed a confirmation promising the applications "will be allowed
+  to run again", tried anyway, and reported a count of zero with nothing connecting it to permissions. It
+  now checks before the confirmation, so it never asks permission for something it cannot do, and says
+  "Unblocking requires administrator privileges." The check sits ahead of the dialog on purpose — behind
+  it, the wording would have been right while the user had still been asked.
+
+### Changed
+
+- **App Blocker — a partly successful unblock says so.** Even with administrator rights an individual
+  change can fail, and "Unblocked 2 applications" after selecting three read as complete success. It now
+  reports "Unblocked 2 of 3" and how many could not be changed.
+
 ## [1.78.7] - 2026-09-08
 
 Running SysManager as administrator made several tabs feel slower than they needed to. Every single thing

--- a/README.md
+++ b/README.md
@@ -738,7 +738,9 @@ a confirmation before it runs:
   from launching
 - Fully reversible — unblock restores normal execution
 - Shows list of currently blocked apps with select/deselect and batch unblock
-- Requires admin privileges for registry modifications
+- Requires admin privileges for registry modifications, in **both** directions —
+  blocking and unblocking write the same protected setting, and each says so
+  before asking you to confirm anything
 
 ### Debloater & Ads
 Remove preinstalled Windows Store apps you don't use:

--- a/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AppBlockerViewModelTests.cs
@@ -294,8 +294,10 @@ public class AppBlockerViewModelTests
     [Fact]
     public void UnblockSelected_WhenUserDeclinesConfirm_DoesNotUnblock()
     {
+        using var elevated = AdminHelper.ForceElevation(true);
         var blocker = Substitute.For<IAppBlockerService>();
         var vm = NewVm(blocker);
+        Assert.True(vm.IsElevated, "the scope must reach the view-model's constructor");
         vm.BlockedApps.Add(new BlockedApp { ExecutableName = "game.exe", IsSelected = true });
 
         var prevDialog = DialogService.Instance;
@@ -318,9 +320,11 @@ public class AppBlockerViewModelTests
     [Fact]
     public void UnblockSelected_WhenUserConfirms_UnblocksSelected()
     {
+        using var elevated = AdminHelper.ForceElevation(true);
         var blocker = Substitute.For<IAppBlockerService>();
         blocker.UnblockApp(Arg.Any<string>()).Returns(true);
         var vm = NewVm(blocker);
+        Assert.True(vm.IsElevated, "the scope must reach the view-model's constructor");
         vm.BlockedApps.Add(new BlockedApp { ExecutableName = "game.exe", IsSelected = true });
 
         var prevDialog = DialogService.Instance;
@@ -333,6 +337,84 @@ public class AppBlockerViewModelTests
 
             dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
             blocker.Received(1).UnblockApp("game.exe");
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    /// <summary>
+    /// Without administrator rights, Unblock refuses the same way Block does: it says why, it does not
+    /// ask the user to approve something that cannot happen, and it never reaches the service.
+    /// </summary>
+    /// <remarks>
+    /// Unblock had no elevation check at all, though <c>UnblockApp</c> writes the same HKLM IFEO key that
+    /// blocking does and its own catch logs "admin required" (#2173). So a user without admin got a
+    /// confirmation dialog promising "they will be allowed to run again", clicked Yes, and read
+    /// "Unblocked 0 applications" — a number with nothing connecting it to permissions.
+    /// <para>The <c>Confirm</c> assertion is the load-bearing one. A gate below the dialog would produce
+    /// the same status text while still having asked, which is the defect rather than the fix.</para>
+    /// </remarks>
+    [Fact]
+    public void UnblockSelected_WhenNotElevated_SaysWhyAndNeverReachesTheService()
+    {
+        using var notElevated = AdminHelper.ForceElevation(false);
+        var blocker = Substitute.For<IAppBlockerService>();
+        var vm = NewVm(blocker);
+        Assert.False(vm.IsElevated, "the scope must reach the view-model's constructor");
+        vm.BlockedApps.Add(new BlockedApp { ExecutableName = "game.exe", IsSelected = true });
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true); // would say yes if asked
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.UnblockSelectedCommand.Execute(null);
+
+            Assert.Contains("administrator", vm.BlockStatus, StringComparison.OrdinalIgnoreCase);
+            dialog.DidNotReceive().Confirm(Arg.Any<string>(), Arg.Any<string>());
+            blocker.DidNotReceive().UnblockApp(Arg.Any<string>());
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    /// <summary>
+    /// When only some of the selected applications could be unblocked, the status says so rather than
+    /// reporting the number that worked as if it were all of them.
+    /// </summary>
+    /// <remarks>
+    /// Elevated, a single write can still fail — the key changed underneath, the hive is locked — and
+    /// "Unblocked 2 applications" after selecting three reads as complete success. Three selected, the
+    /// middle one refused by the service.
+    /// </remarks>
+    [Fact]
+    public void UnblockSelected_WhenSomeFail_ReportsHowManyDidNot()
+    {
+        using var elevated = AdminHelper.ForceElevation(true);
+        var blocker = Substitute.For<IAppBlockerService>();
+        blocker.UnblockApp("a.exe").Returns(true);
+        blocker.UnblockApp("b.exe").Returns(false);
+        blocker.UnblockApp("c.exe").Returns(true);
+        var vm = NewVm(blocker);
+        vm.BlockedApps.Add(new BlockedApp { ExecutableName = "a.exe", IsSelected = true });
+        vm.BlockedApps.Add(new BlockedApp { ExecutableName = "b.exe", IsSelected = true });
+        vm.BlockedApps.Add(new BlockedApp { ExecutableName = "c.exe", IsSelected = true });
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.UnblockSelectedCommand.Execute(null);
+
+            Assert.Contains("2 of 3", vm.BlockStatus);
+            Assert.Contains("could not be changed", vm.BlockStatus);
         }
         finally
         {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.78.7</Version>
-    <FileVersion>1.78.7.0</FileVersion>
-    <AssemblyVersion>1.78.7.0</AssemblyVersion>
+    <Version>1.78.8</Version>
+    <FileVersion>1.78.8.0</FileVersion>
+    <AssemblyVersion>1.78.8.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
@@ -142,6 +142,17 @@ public sealed partial class AppBlockerViewModel : ViewModelBase
             return;
         }
 
+        // Before the confirmation, exactly like BlockApp. Unblocking writes the same HKLM key that
+        // blocking does, so without administrator rights every write fails — and asking the user to
+        // approve "they will be allowed to run again" and then reporting "Unblocked 0 applications"
+        // told them nothing about why. Placing the check after the dialog would still produce the
+        // right words while having asked permission for something that cannot happen.
+        if (!IsElevated)
+        {
+            BlockStatus = "Unblocking requires administrator privileges.";
+            return;
+        }
+
         if (!DialogService.Instance.Confirm(
             $"Unblock {selected.Count} application{(selected.Count == 1 ? "" : "s")}?\n\nThey will be allowed to run again.",
             "Unblock Applications — Confirm")) return;
@@ -154,8 +165,14 @@ public sealed partial class AppBlockerViewModel : ViewModelBase
         }
 
         RefreshList();
-        BlockStatus = $"Unblocked {unblocked} application{(unblocked == 1 ? "" : "s")}.";
-        Log.Information("User unblocked {Count} applications", unblocked);
+        // Say so when some of them did not work. Elevated, a single write can still fail — the key
+        // changed underneath, or the file is locked — and "Unblocked 2 applications" after selecting
+        // three reads as complete success.
+        BlockStatus = unblocked == selected.Count
+            ? $"Unblocked {unblocked} application{(unblocked == 1 ? "" : "s")}."
+            : $"Unblocked {unblocked} of {selected.Count}. "
+              + $"{selected.Count - unblocked} could not be changed — try again, or restart and retry.";
+        Log.Information("User unblocked {Count} of {Selected} applications", unblocked, selected.Count);
     }
 
     [RelayCommand]


### PR DESCRIPTION
Block refused without administrator rights and explained itself. Unblock checked nothing, though
`UnblockApp` opens the same HKLM IFEO key with `writable: true` and its own catch logs "admin required".
So without admin the sequence was: click Unblock, read "Unblock 1 application? They will be allowed to
run again", click Yes, and get back `Unblocked 0 applications.` A number, with nothing on screen
connecting it to permissions.

Two operations with identical privilege requirements behaved differently inside one tab. The
`AdminBanner` at the top does say blocking needs administrator rights, but the Unblock button stayed
enabled and the dialog promised something that then did not happen.

`UnblockSelected` now carries the same gate as `BlockApp`, **before** the confirmation rather than after.
That order is the fix, not an implementation detail: below the dialog the status text would have been
correct while the user had still been asked to approve an operation that refuses itself. The new test
asserts `Confirm` is never reached, and the mutation that moves the gate down is red only because of
that assertion.

## The other half of the same complaint

Even elevated, an individual write can fail — the key changed underneath, the hive is locked — and
`Unblocked 2 applications.` after selecting three read as complete success. It now reports
`Unblocked 2 of 3.` and how many could not be changed. The log line gained the selected count too, so a
partial result is legible there as well.

## Regression the fix creates, and handled

The two existing Unblock tests passed on any host precisely BECAUSE there was no gate. Adding one makes
them depend on elevation, so both now force it on with `AdminHelper.ForceElevation(true)` around the
view model's construction — the same treatment #2172 gave the Block tests, and for the same reason: the
value is cached in the constructor.

## Red/green, four mutations, on a host that is NOT elevated

    baseline                                    18 green
    M1  delete the new gate                     RED  status was "Unblocked 0 of 1. 1 could not be
                                                     changed" — informative, still not the reason
    M2  move the gate below the Confirm          RED  "Actually received 1 matching call"
    M3  revert to the single-count message       RED  "Unblocked 2 applications." vs "2 of 3"
    M4  drop ForceElevation from the confirms
        test                                     RED  proves the gate is really in the command's path
    restored, sha verified for both files        18 green

M1's status is worth reading: with the message fix but no gate, the user learns that something failed
and still not why. The two halves answer different questions and neither replaces the other.

## Verification

The unit suite on this non-elevated machine, excluding only `DeepCleanupServiceTests`: 5131 tests, 0
failures. Every ArchitectureTests guard green at 113 of 113. App project and tests build 0 errors 0
warnings. Format clean; 43 leak patterns over 7,223 bytes of added lines, 0 hits. The CHANGELOG heading
guard was run immediately after the entry was inserted, not at the end of the sweep.

README's App Blocker section already said admin is required for registry modifications; it now says in
both directions, which is what the app tells the user per-command.

This view model is one of the ten in #2171, and its Unblock path is part of why it is on that list —
the sweep there covers the nine whose elevation branches are still asserted nowhere.

Closes #2173.
