### PR TITLE
test: eight elevation refusals that no test had ever entered

### DIFF
--- a/SysManager/SysManager.Tests/NetworkRepairViewModelTests.cs
+++ b/SysManager/SysManager.Tests/NetworkRepairViewModelTests.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using NSubstitute;
+using SysManager.Helpers;
 using SysManager.Services;
 using SysManager.ViewModels;
 
@@ -78,4 +79,72 @@ public class NetworkRepairViewModelTests
             DialogService.Instance = prevDialog;
         }
     }
+
+    // ── Elevation gate on Winsock / TCP-IP reset ─────────────────────────────
+    //
+    // Both resets refuse without administrator rights and neither refusal was asserted (#2171). Flush DNS
+    // deliberately has no gate — it needs no elevation — which is why only these two are covered here.
+    //
+    // The elevated counterpart DECLINES the confirmation. Past the dialog these commands run netsh
+    // against the machine's real network stack and require a reboot, so a test that confirmed would
+    // reset Winsock on whatever ran the suite. Declining proves the gate let it through and stops there.
+
+    [Theory]
+    [InlineData("Winsock")]
+    [InlineData("TcpIp")]
+    public async Task Reset_WhenNotElevated_SaysSoAndNeverPromptsConfirm(string which)
+    {
+        using var notElevated = AdminHelper.ForceElevation(false);
+        var vm = new NetworkRepairViewModel(NewShared());
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true); // would say yes if asked
+        DialogService.Instance = dialog;
+        try
+        {
+            await ExecuteResetAsync(vm, which);
+
+            Assert.Contains("administrator", vm.RepairStatus, StringComparison.OrdinalIgnoreCase);
+            dialog.DidNotReceive().Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.False(vm.IsRepairing);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Theory]
+    [InlineData("Winsock")]
+    [InlineData("TcpIp")]
+    public async Task Reset_WhenElevated_AsksBeforeTouchingTheNetworkStack(string which)
+    {
+        using var elevated = AdminHelper.ForceElevation(true);
+        var vm = new NetworkRepairViewModel(NewShared());
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // decline, so nothing runs
+        DialogService.Instance = dialog;
+        try
+        {
+            await ExecuteResetAsync(vm, which);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.Equal("", vm.RepairStatus);
+            Assert.False(vm.IsRepairing);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    private static Task ExecuteResetAsync(NetworkRepairViewModel vm, string which) => which switch
+    {
+        "Winsock" => vm.ResetWinsockCommand.ExecuteAsync(null),
+        "TcpIp" => vm.ResetTcpIpCommand.ExecuteAsync(null),
+        _ => throw new ArgumentOutOfRangeException(nameof(which), which, "unknown reset"),
+    };
 }

--- a/SysManager/SysManager.Tests/ServicesViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ServicesViewModelTests.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Reflection;
 using NSubstitute;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
@@ -822,6 +823,89 @@ public class ServicesViewModelTests
         }
         throw new DirectoryNotFoundException("Could not locate the test project directory.");
     }
+
+    // ── Elevation gate on Start / Stop / Disable / Enable ────────────────────
+    //
+    // Four commands here refuse without administrator rights, and none of them was asserted (#2171).
+    // These tests state the condition with AdminHelper.ForceElevation instead of inheriting whatever the
+    // host happens to be: CI's runner IS elevated, this workstation is not, and a test that reads the
+    // real answer therefore exercises a different branch depending on where it runs — while looking
+    // identical either way.
+    //
+    // The elevated counterparts DECLINE the confirmation on purpose. Past the dialog these commands call
+    // ServiceManagerService against a real Windows service through a real PowerShellRunner, so a test
+    // that confirmed would start or stop a service on the machine running the suite. Declining proves
+    // the gate let the command through — which is the half the refusal test cannot show — and stops there.
+
+    /// <summary>A dialog that would say yes, installed so it can be asserted it was never asked.</summary>
+    private sealed class DialogScope : IDisposable
+    {
+        private readonly IDialogService _previous;
+
+        internal DialogScope(bool answer)
+        {
+            _previous = DialogService.Instance;
+            Dialog = Substitute.For<IDialogService>();
+            Dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(answer);
+            DialogService.Instance = Dialog;
+        }
+
+        internal IDialogService Dialog { get; }
+
+        public void Dispose() => DialogService.Instance = _previous;
+    }
+
+    private static ServiceEntry SafeEntry() => new()
+    {
+        Name = "XboxGipSvc",
+        DisplayName = "Xbox Accessory Management",
+        Status = "Stopped",
+        StartType = "Manual",
+        SafetyLevel = Models.SafetyLevel.Safe,
+    };
+
+    [Theory]
+    [InlineData("Start")]
+    [InlineData("Stop")]
+    [InlineData("Disable")]
+    [InlineData("Enable")]
+    public async Task ServiceCommand_WhenNotElevated_SaysSoAndNeverPromptsConfirm(string verb)
+    {
+        using var notElevated = AdminHelper.ForceElevation(false);
+        var vm = await CreateWithDataAsync();
+        using var dialog = new DialogScope(answer: true); // would say yes if it were asked
+
+        await ExecuteAsync(vm, verb, SafeEntry());
+
+        Assert.Contains("admin", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        dialog.Dialog.DidNotReceive().Confirm(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Theory]
+    [InlineData("Start")]
+    [InlineData("Stop")]
+    [InlineData("Disable")]
+    [InlineData("Enable")]
+    public async Task ServiceCommand_WhenElevated_AsksBeforeDoingAnything(string verb)
+    {
+        using var elevated = AdminHelper.ForceElevation(true);
+        var vm = await CreateWithDataAsync();
+        using var dialog = new DialogScope(answer: false); // decline, so nothing runs on this machine
+
+        await ExecuteAsync(vm, verb, SafeEntry());
+
+        dialog.Dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+        Assert.DoesNotContain("requires admin", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Task ExecuteAsync(ServicesViewModel vm, string verb, ServiceEntry entry) => verb switch
+    {
+        "Start" => vm.StartServiceCommand.ExecuteAsync(entry),
+        "Stop" => vm.StopServiceCommand.ExecuteAsync(entry),
+        "Disable" => vm.DisableServiceCommand.ExecuteAsync(entry),
+        "Enable" => vm.EnableServiceCommand.ExecuteAsync(entry),
+        _ => throw new ArgumentOutOfRangeException(nameof(verb), verb, "unknown service verb"),
+    };
 
     /// <summary>A throwaway ledger directory, so the developer's real %LOCALAPPDATA% file is untouched.</summary>
     private sealed class TempLedgerDir : IDisposable

--- a/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
@@ -3,11 +3,15 @@
 // License: MIT
 
 using System.Reflection;
+using SysManager.Helpers;
 using SysManager.Services;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
 
+// Serialized: the chkdsk gate tests replace AdminHelper.ElevationProbe, which is process-wide state.
+// Required by ArchitectureTests.ProcessWideStaticUsers_AreInTheSerializedCollection, which caught this.
+[Collection("ProcessWideStatics")]
 public class SystemHealthViewModelTests
 {
     private static SystemHealthViewModel NewVm() => new(new SystemInfoService(), new DiskHealthService(), new MemoryTestService(), new FixedDriveService(), new PowerShellRunner(), new BiosService());
@@ -255,5 +259,59 @@ public class SystemHealthViewModelTests
     {
         string[] lines = [];
         Assert.Equal("Exit 3", SystemHealthViewModel.ParseChkdskVerdict(lines, 3));
+    }
+
+    // ── Elevation gate on chkdsk ─────────────────────────────────────────────
+    //
+    // Both chkdsk entry points refuse without administrator rights, and neither refusal was asserted
+    // (#2171). Only the refusal is covered, deliberately: unlike the other gated commands in the app
+    // these have NO confirmation dialog to decline, so past the gate they start a real chkdsk scan on a
+    // real volume. There is nothing to substitute and nothing to stop it, so the elevated branch is not
+    // something a unit test may enter.
+    //
+    // The per-drive status is part of the assertion. Marking each selected drive "Needs admin" is what
+    // tells the user WHICH drives were skipped.
+
+    /// <summary>
+    /// The batch command refuses before it starts, so the tab never claims a scan finished.
+    /// </summary>
+    /// <remarks>
+    /// <c>ChkdskStatus</c> is the assertion that matters here, and the first draft did not have it. There
+    /// are TWO gates on this path — one in <c>RunChkdskOnSelectedAsync</c> and one in the per-drive
+    /// <c>RunChkdskCoreAsync</c> it calls — so asserting only the message and the drive's status passed
+    /// with the outer gate DELETED: the inner one set both. The mutation proving that is what found it.
+    /// <para>What the outer gate actually prevents is the report. Without it the command sets
+    /// <c>IsChkdskRunning</c>, walks the selection, has every drive refused one by one, and then writes
+    /// "All scans finished." — telling the user their disks were checked when nothing was read. The inner
+    /// gate cannot prevent that, because by then the loop is already running.</para>
+    /// </remarks>
+    [StaFact]
+    public async Task RunChkdskOnSelected_WhenNotElevated_RefusesWithoutClaimingAScanRan()
+    {
+        using var notElevated = AdminHelper.ForceElevation(false);
+        var vm = NewVm();
+        var drive = new DriveTarget { Letter = "C:", Label = "Windows", IsSelected = true };
+        vm.ChkdskDrives.Add(drive);
+
+        await vm.RunChkdskOnSelectedCommand.ExecuteAsync(null);
+
+        Assert.Contains("admin", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("Needs admin", drive.Status);
+        Assert.False(vm.IsChkdskRunning, "the refusal must not leave the tab looking busy");
+        Assert.Equal("", vm.ChkdskStatus);
+        Assert.DoesNotContain("finished", vm.ChkdskStatus, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [StaFact]
+    public async Task RunChkdsk_SingleDrive_WhenNotElevated_SaysSo()
+    {
+        using var notElevated = AdminHelper.ForceElevation(false);
+        var vm = NewVm();
+
+        await vm.RunChkdskCommand.ExecuteAsync("D:");
+
+        Assert.Contains("admin", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("D:", vm.StatusMessage);
+        Assert.False(vm.IsChkdskRunning);
     }
 }


### PR DESCRIPTION
Three view models refuse eight commands without administrator rights, and not one of those refusals was
asserted anywhere (#2171). They read elevation with `AdminHelper.IsElevated()` at call time, so whichever
branch runs is whichever branch the HOST is on — elevated on CI, not elevated in a developer's shell —
and neither run said anything about the refusal, because none of the existing tests drove a gated command
with a non-critical service or a selected drive.

    ServicesViewModel        Start / Stop / Disable / Enable
    NetworkRepairViewModel   Winsock reset / TCP-IP reset
    SystemHealthViewModel    chkdsk on selected drives / chkdsk on one drive

Each now has a refusal test that forces elevation OFF with `AdminHelper.ForceElevation` and asserts three
things: the message names administrator rights, the confirmation dialog is NOT reached, and the tab is not
left looking busy.

## Why the elevated counterparts decline the dialog

Services and Network Repair get an elevated test too, and both DECLINE the confirmation. That is not
timidity: past the dialog these commands call `ServiceManagerService` against a real Windows service
through a real `PowerShellRunner`, and `netsh` against the machine's real network stack. A test that
confirmed would start or stop a service, or reset Winsock, on whatever ran the suite. Declining proves the
gate let the command through — the half a refusal test cannot show — and stops there.

**SystemHealth gets no elevated counterpart, deliberately.** Its two chkdsk paths have no confirmation
dialog at all, so past the gate a real chkdsk scan starts with nothing to decline. There is no seam to
substitute, so the elevated branch is not something a unit test may enter, and saying so is more useful
than a test that pretends otherwise.

## What the mutation proof found in my own test

    baseline                                    GREEN
    M1  delete the Services Start gate          RED
    M2  delete the Services Stop gate           RED
    M3  delete the Services Disable gate        RED
    M4  delete the Services Enable gate         RED
    M5  delete the Winsock gate                 RED
    M6  delete the TCP/IP gate                  RED
    M7  delete the chkdsk selected-drives gate  RED  — only after the test was fixed
    M8  delete the chkdsk single-drive gate     RED
    restored, sha verified for all three        GREEN

**M7 was GREEN on the first attempt**, and that is the finding inside the finding. `RunChkdskOnSelected`
has TWO gates on its path: its own, and the one in the per-drive `RunChkdskCore` it calls. Asserting only
the status message and the drive's "Needs admin" marker passed with the outer gate deleted, because the
inner gate set both.

What the outer gate actually prevents is the report. Without it the command sets `IsChkdskRunning`, walks
the selection, has every drive refused one at a time, and then writes **"All scans finished."** — telling
the user their disks were checked when nothing was read. The inner gate cannot prevent that, because by
then the loop is already running. The test now asserts `ChkdskStatus`, which is the only assertion that
distinguishes the two gates, and it is red without the outer one.

Two identical gate messages also made this proof harder than it looks: Disable and Enable both say
"Changing startup type requires admin", so those two mutations have to keep the line after the gate to
stay unique. A needle that matches twice aborts rather than mutating the wrong one.

## A guard caught the thing I forgot

`ArchitectureTests.ProcessWideStaticUsers_AreInTheSerializedCollection` failed on
`SystemHealthViewModelTests.cs — touches AdminHelper.ElevationProbe`. `ForceElevation` replaces a
process-wide probe, so a class using it has to be in the serialized collection or it races the classes
that are. Services and Network Repair were already there; System Health was not, and now is. Exactly the
mechanical enforcement the repo prefers over remembering.

## Verification

The unit suite on this non-elevated machine, excluding only `DeepCleanupServiceTests`: 5146 tests, 0
failures. Every ArchitectureTests guard green at 114 of 114. Format clean; 43 leak patterns over 10,016
bytes of added lines, 0 hits.

Three of the ten view models in #2171 remain — Windows Update (whose gate at one point is INVERTED, since
PSWindowsUpdate must not be installed from an elevated session), Context Menu, and Standby Memory (whose
test opens with the host-dependent `if (vm.IsElevated)` skip that `ForceElevation` exists to replace).
The fitness check goes in with them, when its exception list can be empty.

Refs #2171.
