### PR TITLE
test: pin the last two elevation branches, then guard the sweep mechanically

### DIFF
--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -8913,6 +8913,133 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Every view model that behaves differently when elevated must have a test that DECIDES the answer,
+    /// rather than inheriting whatever the machine running the suite happens to be.
+    /// </summary>
+    /// <remarks>
+    /// CI's runner is elevated and a developer's shell is not, so a test that reads the real answer
+    /// exercises a different branch depending on where it runs — while looking identical either way. Ten
+    /// view models have an elevation branch and six of them were in exactly that state (#2171): App
+    /// Blocker's six confirmation tests failed on a developer machine and a seventh passed there for the
+    /// wrong reason, and Standby Memory's test asserted one contract on an elevated host and a different
+    /// one otherwise, inside an <c>if (vm.IsElevated)</c>.
+    /// <para><c>AdminHelper</c>'s own documentation says this has happened before: sixteen test cases once
+    /// opened with <c>if (IsElevated) return;</c> so they would not report a false failure on an elevated
+    /// host, and the result was that "the elevation gate on SFC, DISM, Windows Update and nine privileged
+    /// tabs asserted nothing anywhere". The seam was added; the sweep it was added for stopped at
+    /// <c>CleanupViewModel</c>. This is what keeps it swept.</para>
+    /// <para><b>Two pinning mechanisms count, and missing one is how the first measurement of this went
+    /// wrong.</b> <c>AdminHelper.ForceElevation</c> replaces the process-wide probe and reaches both an
+    /// <c>if (!AdminHelper.IsElevated())</c> read and a cached one. Assigning <c>vm.IsElevated</c> pins it
+    /// per instance and is equally valid — <c>DnsHostsViewModelTests</c> and <c>WindowsFeaturesTests</c> do
+    /// that — but only for a view model that caches the answer in the property; it cannot reach a call-time
+    /// read. Counting only the first mechanism reported the two files that already did it right as the
+    /// biggest gaps.</para>
+    /// <para>Test files are matched to a view model by NAMING it, not by filename and not by
+    /// constructing it. Filename matching made <c>WindowsFeaturesTests.cs</c> invisible, because its name
+    /// carries no "ViewModel". Construction matching then missed <c>StandbyMemoryTests</c> and
+    /// <c>SystemHealthViewModelTests</c>, whose factories use target-typed <c>new(...)</c> and never write
+    /// the type name after <c>new</c> — this guard reported both as uncovered on its first run while both
+    /// pin elevation correctly. Comments are stripped first, so a mention is a mention in code.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryViewModelThatBranchesOnElevation_HasATestThatPinsIt()
+    {
+        // view model -> why no test pins its elevation branch yet, verified rather than deferred.
+        var cannotBePinnedYet = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["ContextMenuViewModel"] =
+                "takes a concrete ContextMenuService with no interface, so its toggle path cannot be "
+                + "driven at all: a test can neither make the registry write fail on purpose nor let it "
+                + "succeed, because a real toggle would change a shell key on the machine running the "
+                + "suite. Blocked on the seam in #2180, which is where its two failure messages get "
+                + "asserted",
+        };
+
+        var vmDir = Path.Combine(FindAppProjectDir(), "ViewModels");
+        var testsDir = Path.Combine(
+            Directory.GetParent(FindAppProjectDir())!.FullName, "SysManager.Tests");
+
+        var testSources = Directory.GetFiles(testsDir, "*.cs")
+            .ToDictionary(p => Path.GetFileName(p)!, p => WithoutComments(File.ReadAllText(p)),
+                          StringComparer.Ordinal);
+        Assert.True(testSources.Count >= 100,
+            $"only {testSources.Count} test files were read — this guard is looking at the wrong folder");
+
+        var branching = 0;
+        var offenders = new List<string>();
+
+        foreach (var path in Directory.GetFiles(vmDir, "*ViewModel.cs")
+                     .OrderBy(p => p, StringComparer.Ordinal))
+        {
+            var name = Path.GetFileNameWithoutExtension(path);
+            var source = WithoutComments(File.ReadAllText(path));
+
+            var cached = CachedElevationBranch().Matches(source).Count;
+            var callTime = CallTimeElevationBranch().Matches(source).Count;
+            if (cached + callTime == 0) continue;
+            branching++;
+
+            if (cannotBePinnedYet.ContainsKey(name)) continue;
+
+            // Files that NAME this view model, not files that write `new <Name>(`. Matching the
+            // construction misses every factory using target-typed `new(...)`, which is how both
+            // StandbyMemoryTests and SystemHealthViewModelTests build theirs — and this guard reported
+            // exactly those two as uncovered on its first run, while both do pin elevation. Comments are
+            // already stripped, so a mention here is a mention in code.
+            var covering = testSources
+                .Where(kv => kv.Value.Contains(name, StringComparison.Ordinal))
+                .ToList();
+
+            var pinned = covering.Any(kv =>
+                kv.Value.Contains("ForceElevation", StringComparison.Ordinal)
+                || (callTime == 0 && ElevationAssignment().IsMatch(kv.Value)));
+
+            if (!pinned)
+            {
+                var where = covering.Count == 0
+                    ? "no test file mentions it"
+                    : string.Join(", ", covering.Select(kv => kv.Key));
+                offenders.Add($"{name} ({cached} cached + {callTime} call-time branch(es)) — {where}");
+            }
+        }
+
+        // Ten when measured. A collapse means the branch patterns stopped matching and a clean result
+        // would prove nothing at all.
+        Assert.True(branching >= 8,
+            $"only {branching} view models were seen to branch on elevation — the patterns are out of "
+            + "date, so this guard is checking almost nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "These view models behave differently when elevated and no test decides which branch runs, so "
+            + "each one asserts whatever the host happens to be: the elevated path on CI, the other one on "
+            + "a developer machine, and neither verified on both. Pin it with "
+            + "AdminHelper.ForceElevation(bool) — or, for a cached IsElevated, by assigning the property — "
+            + "or name the view model in the exception list in this test WITH the reason it cannot be "
+            + "pinned yet:\n  "
+            + string.Join("\n  ", offenders)
+            + $"\n({branching} view models branch on elevation)");
+
+        // The exception list must not outlive what it excuses.
+        var stale = cannotBePinnedYet.Keys
+            .Where(n => !File.Exists(Path.Combine(vmDir, n + ".cs")))
+            .OrderBy(n => n, StringComparer.Ordinal);
+        Assert.Empty(stale);
+    }
+
+    /// <summary>A branch on the cached <c>IsElevated</c> property, in either polarity.</summary>
+    [GeneratedRegex(@"if\s*\(\s*!?\s*IsElevated\s*\)", RegexOptions.CultureInvariant)]
+    private static partial Regex CachedElevationBranch();
+
+    /// <summary>A branch on <c>AdminHelper.IsElevated()</c>, read at call time, in either polarity.</summary>
+    [GeneratedRegex(@"if\s*\(\s*!?\s*AdminHelper\.IsElevated\(\)\s*\)", RegexOptions.CultureInvariant)]
+    private static partial Regex CallTimeElevationBranch();
+
+    /// <summary>A test pinning a cached answer per instance, as <c>vm.IsElevated = false</c> or in an initializer.</summary>
+    [GeneratedRegex(@"\bIsElevated\s*=\s*(?:true|false)\b", RegexOptions.CultureInvariant)]
+    private static partial Regex ElevationAssignment();
+
+    /// <summary>
     /// The one shared Deep Cleanup scan must stay read-only: no test may iterate it with a view to
     /// changing an item, and it must never be handed to <c>CleanAsync</c>.
     /// </summary>

--- a/SysManager/SysManager.Tests/StandbyMemoryTests.cs
+++ b/SysManager/SysManager.Tests/StandbyMemoryTests.cs
@@ -2,11 +2,14 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
 
+// Serialized: the purge gate tests replace AdminHelper.ElevationProbe, which is process-wide state.
+[Collection("ProcessWideStatics")]
 public class StandbyMemoryTests
 {
     [Theory]
@@ -89,11 +92,26 @@ public class StandbyMemoryTests
     private static StandbyMemoryViewModel NewVm(string configDir) =>
         new(new Services.StandbyMemoryService(), new Services.StandbyPreferenceService(configDir));
 
+    /// <summary>
+    /// Elevated, the manual purge raises the busy flag and clears it, so the bar can appear.
+    /// </summary>
+    /// <remarks>
+    /// This was one test with an <c>if (vm.IsElevated)</c> inside it, asserting one contract on an
+    /// elevated host and a different one otherwise (#2171). It always passed and never verified either
+    /// branch on both, which is the pattern <c>AdminHelper.ForceElevation</c> exists to replace — its own
+    /// documentation names it as the reason the seam was added.
+    /// <para>Forcing elevation ON is safe here whatever the host actually is. Past the gate the purge
+    /// calls <c>NtSetSystemInformation</c>, which drops a cache and destroys nothing; on a host that is
+    /// not really elevated the call simply fails, and either way the flag goes up and comes back down,
+    /// which is what this asserts.</para>
+    /// </remarks>
     [Fact]
-    public async Task ManualPurge_RaisesIsBusyThenClearsIt()
+    public async Task ManualPurge_WhenElevated_RaisesIsBusyThenClearsIt()
     {
+        using var elevated = AdminHelper.ForceElevation(true);
         using var temp = new TempConfigDir();
         var vm = NewVm(temp.Path);
+        Assert.True(vm.IsElevated, "the scope must reach the view-model's constructor");
 
         var seen = new List<bool>();
         vm.PropertyChanged += (_, e) =>
@@ -103,18 +121,35 @@ public class StandbyMemoryTests
 
         await vm.PurgeCommand.ExecuteAsync(null);
 
-        if (vm.IsElevated)
+        Assert.Equal([true, false], seen);
+        Assert.False(vm.IsBusy);
+    }
+
+    /// <summary>
+    /// Without administrator rights the purge refuses, says why, and never shows the bar.
+    /// </summary>
+    /// <remarks>
+    /// Flashing a progress bar for an operation that was refused would be its own bug, so the absence of
+    /// any <c>IsBusy</c> notification is as much the point as the message.
+    /// </remarks>
+    [Fact]
+    public async Task ManualPurge_WhenNotElevated_SaysSoAndNeverShowsTheBar()
+    {
+        using var notElevated = AdminHelper.ForceElevation(false);
+        using var temp = new TempConfigDir();
+        var vm = NewVm(temp.Path);
+        Assert.False(vm.IsElevated, "the scope must reach the view-model's constructor");
+
+        var seen = new List<bool>();
+        vm.PropertyChanged += (_, e) =>
         {
-            // Elevated: the purge ran, so the flag went up and came back down.
-            Assert.Equal([true, false], seen);
-        }
-        else
-        {
-            // Not elevated: the command short-circuits before any work, so the bar must never appear
-            // — flashing it for an operation that was refused would be its own bug.
-            Assert.Empty(seen);
-            Assert.Contains("administrator", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
-        }
+            if (e.PropertyName == nameof(vm.IsBusy)) seen.Add(vm.IsBusy);
+        };
+
+        await vm.PurgeCommand.ExecuteAsync(null);
+
+        Assert.Empty(seen);
+        Assert.Contains("administrator", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
         Assert.False(vm.IsBusy);
     }
 
@@ -122,6 +157,10 @@ public class StandbyMemoryTests
     public async Task ManualPurge_LeavesTheBarIndeterminateThenClear()
     {
         // There is no percentage to report for a native purge call, so the bar must be marquee.
+        // Elevation forced ON so the command actually enters the body: on a non-elevated host it
+        // returns at the gate, and the assertion below would then hold without the purge ever setting
+        // the flag it is about.
+        using var elevated = AdminHelper.ForceElevation(true);
         using var temp = new TempConfigDir();
         var vm = NewVm(temp.Path);
 

--- a/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
@@ -4,6 +4,7 @@
 
 using System.Reflection;
 using NSubstitute;
+using SysManager.Helpers;
 using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
@@ -740,6 +741,177 @@ public class WindowsUpdateViewModelTests
         => typeof(WindowsUpdateViewModel)
             .GetMethod("OnRunnerProgressChanged", BindingFlags.NonPublic | BindingFlags.Instance)!
             .Invoke(vm, [percent]);
+
+    // ── Elevation gates ──────────────────────────────────────────────────────
+    //
+    // Four gated paths in three shapes, and none was asserted (#2171). Elevation was read from whatever
+    // host ran the suite: CI's runner IS elevated, a developer's shell is not, so each of these exercised
+    // a different branch depending on where it ran while looking identical either way.
+    //
+    // Three of them use the view model's OWN seam — the internal constructor takes a Func<bool>, so the
+    // answer is decided per instance with no process-wide state and no serialized collection needed. The
+    // fourth, InstallUpdates, reads AdminHelper.IsElevated() directly and bypasses that seam, so its test
+    // is the only one here that has to replace the static probe. That inconsistency is filed separately.
+    //
+    // The runner is substituted throughout: past these gates the real one installs a PowerShell module or
+    // Windows updates, and a test must not be one gate away from doing that.
+
+    private static WindowsUpdateViewModel NewVm(bool elevated, out IPowerShellRunner runner)
+    {
+        runner = Substitute.For<IPowerShellRunner>();
+        return new WindowsUpdateViewModel(runner, new WindowsUpdateService(),
+                                         new WindowsUpdatePolicyService(), () => elevated);
+    }
+
+    private static void ExecutePolicy(WindowsUpdateViewModel vm, string which)
+    {
+        switch (which)
+        {
+            case "Defer": vm.DeferFeatureUpdatesCommand.Execute(null); break;
+            case "Pause": vm.PauseUpdatesCommand.Execute(null); break;
+            case "Restore": vm.RestoreUpdatePolicyCommand.Execute(null); break;
+            default: throw new ArgumentOutOfRangeException(nameof(which), which, "unknown policy command");
+        }
+    }
+
+    [Theory]
+    [InlineData("Defer")]
+    [InlineData("Pause")]
+    [InlineData("Restore")]
+    public void PolicyCommand_WhenNotElevated_SaysSoAndNeverPromptsConfirm(string which)
+    {
+        var vm = NewVm(elevated: false, out _);
+        Assert.False(vm.IsElevated, "the injected answer must reach the view model");
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true); // would say yes if asked
+        DialogService.Instance = dialog;
+        try
+        {
+            ExecutePolicy(vm, which);
+
+            Assert.Contains("administrator", vm.PolicySummary, StringComparison.OrdinalIgnoreCase);
+            dialog.DidNotReceive().Confirm(Arg.Any<string>(), Arg.Any<string>());
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    /// <summary>
+    /// Elevated, the policy commands get as far as asking — the half a refusal test cannot show. They
+    /// decline, because past the dialog these write real Windows Update policy keys.
+    /// </summary>
+    [Theory]
+    [InlineData("Defer")]
+    [InlineData("Pause")]
+    [InlineData("Restore")]
+    public void PolicyCommand_WhenElevated_AsksBeforeChangingPolicy(string which)
+    {
+        var vm = NewVm(elevated: true, out _);
+        Assert.True(vm.IsElevated, "the injected answer must reach the view model");
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false); // decline, so nothing is written
+        DialogService.Instance = dialog;
+        try
+        {
+            ExecutePolicy(vm, which);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.DoesNotContain("Changing update policy requires", vm.PolicySummary);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    /// <summary>
+    /// Installing PSWindowsUpdate is refused when SysManager IS elevated — the one gate in the app whose
+    /// refusal is on the ELEVATED side.
+    /// </summary>
+    /// <remarks>
+    /// The module installs per user, so an elevated session would put it under the administrator's profile
+    /// where the user's normal session cannot see it. Hence the inverted check, and hence a test that
+    /// decides elevation is ON rather than off.
+    /// </remarks>
+    [Fact]
+    public async Task InstallModule_WhenElevated_RefusesBecauseTheModuleIsPerUser()
+    {
+        var vm = NewVm(elevated: true, out var runner);
+
+        await vm.InstallModuleCommand.ExecuteAsync(null);
+
+        Assert.Contains("non-administrator", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.False(vm.IsBusy, "the refusal must not leave the tab looking busy");
+        await runner.DidNotReceiveWithAnyArgs().RunScriptViaPwshAsync(default!);
+    }
+
+    /// <summary>
+    /// Not elevated, installing PSWindowsUpdate is allowed and the install script reaches the runner —
+    /// the branch the inverted gate exists to permit.
+    /// </summary>
+    /// <remarks>
+    /// Asserted on the script rather than on a call count. A count of one was the first attempt and it
+    /// failed at TWO: the command installs the module and then probes for it, so the runner is used twice.
+    /// Naming the install script says what has to happen and does not break when the probe changes.
+    /// </remarks>
+    [Fact]
+    public async Task InstallModule_WhenNotElevated_ReachesTheRunner()
+    {
+        var vm = NewVm(elevated: false, out var runner);
+
+        await vm.InstallModuleCommand.ExecuteAsync(null);
+
+        Assert.DoesNotContain("non-administrator", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        await runner.Received(1).RunScriptViaPwshAsync(
+            Arg.Is<string>(s => s.Contains("Install-Module -Name PSWindowsUpdate", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Installing updates without elevation offers to relaunch rather than failing, and installs nothing.
+    /// </summary>
+    /// <remarks>
+    /// The only test here that has to replace the process-wide probe, because <c>InstallUpdatesAsync</c>
+    /// calls <c>AdminHelper.IsElevated()</c> directly instead of reading the injected answer its three
+    /// siblings use. Filed as an inconsistency rather than changed inside a test-only change.
+    /// <para>This gate also sits AFTER the confirmation, unlike the refusals elsewhere in the app, and
+    /// that is coherent rather than an oversight: the non-elevated path is not a refusal but a
+    /// continuation — it relaunches elevated and carries the user's intent across — so asking first is
+    /// what makes the relaunch worth doing. <c>RelaunchAsAdmin</c> returns false when
+    /// <c>Application.Current</c> is null, which it is under the test runner, so nothing is spawned.</para>
+    /// </remarks>
+    [Fact]
+    public async Task InstallUpdates_WhenNotElevated_OffersToRelaunchAndInstallsNothing()
+    {
+        using var notElevated = AdminHelper.ForceElevation(false);
+        var vm = NewVm(elevated: false, out var runner);
+        vm.Updates.Add(new UpdateEntry { Title = "KB0000001", IsSelected = true });
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true); // the user agrees to install
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.InstallUpdatesCommand.ExecuteAsync(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            Assert.Contains("Admin required", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.False(vm.IsBusy, "the install never started, so the tab must not look busy");
+            Assert.Equal("", vm.Updates[0].Status);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
 }
 
 // ---------- UpdateEntry model ----------


### PR DESCRIPTION
Finishes the elevation sweep #2171 asked for and puts a fitness guard behind it so this cannot be a third round.

## What was wrong

Two view models were left asserting whichever branch the host happened to be on:

- **Windows Update** has four admin gates (three policy commands through a shared `RequireAdminForPolicy`, `InstallModule`'s inverted gate, and `InstallUpdates`) and no test decided elevation for any of them.
- **Standby Memory** had one purge test whose body was `if (vm.IsElevated) { … } else { … }` — a different contract asserted on CI than on a developer machine, and neither verified on both.

## What this adds

**Windows Update — eight tests through the view model's own `Func<bool> isElevated` seam**, with a substituted `IPowerShellRunner` so the elevated path is entered without installing anything:

| test | pins |
|---|---|
| `PolicyCommand_WhenNotElevated_SaysSoAndNeverPromptsConfirm` ×3 | the refusal message, and that `Confirm` is never reached |
| `PolicyCommand_WhenElevated_AsksBeforeChangingPolicy` ×3 | the gate lets it through and it asks first |
| `InstallModule_WhenElevated_RefusesBecauseTheModuleIsPerUser` | the inverted gate — elevated is the refusing side here |
| `InstallModule_WhenNotElevated_ReachesTheRunner` | the install script actually reaches PowerShell |
| `InstallUpdates_WhenNotElevated_OffersToRelaunchAndInstallsNothing` | the relaunch offer, and that no update status changes |

The elevated policy tests decline the confirmation on purpose: past the dialog those commands write real Windows Update policy on whatever runs the suite. Declining proves the gate opened and stops there.

**Standby Memory** — the host-dependent test is split into `ManualPurge_WhenElevated_RaisesIsBusyThenClearsIt` and `ManualPurge_WhenNotElevated_SaysSoAndNeverShowsTheBar`, and the existing indeterminate-bar test is pinned to elevated so it stops changing meaning by machine.

**`ArchitectureTests.EveryViewModelThatBranchesOnElevation_HasATestThatPinsIt`** — counts both spellings and both polarities of the branch across `ViewModels/`, and accepts either pinning mechanism: `ForceElevation` always, or an `IsElevated` assignment when the view model has no call-time read for that assignment to miss.

## Two measurement traps this guard is written around

Both produced confident wrong answers while the issue was being measured, and one of them reached the issue body itself (corrected in a comment there):

1. **Matching test files to a view model by filename** makes `WindowsFeaturesTests.cs` invisible — its name carries no "ViewModel".
2. **Matching by `new <Name>(`** misses every factory using target-typed `new(...)`. That is how `StandbyMemoryTests` and `SystemHealthViewModelTests` build theirs, and the guard's first run reported exactly those two as uncovered while both pin elevation correctly.

The guard matches the type **name** in comment-stripped source instead. A floor of eight branching view models (ten when measured) means a pattern that stops matching fails loudly rather than passing on an empty set — M7 below is that check.

## The one exception, and why the guard lands anyway

`ContextMenuViewModel` takes a concrete `ContextMenuService` with no interface, so its toggle path cannot be driven at all: a test can neither make the registry write fail on purpose nor let it succeed, because a real toggle changes a shell key on the machine running the suite. Blocked on the seam in #2180.

#2171 asked for the guard to land with an **empty** exception list, on the grounds that an exception list carrying unverified reasons is a false claim sitting in the test suite. That reasoning is about eight "not done yet" excuses. This is one entry, with a verified reason and a filed blocker, and holding the guard back for it would leave the other nine rows unprotected for the sake of a formality. Stated here rather than quietly diverging.

## Verification

Seven mutations, seven reds, restore hash-checked byte-for-byte, final state green:

```
M1  the policy gate reports but does not stop     RED  the 3 refusal tests, on DidNotReceive(Confirm)
M2  the policy gate always refuses                RED  both sides of the policy pair
M3  InstallModule loses its inverted gate         RED  its elevated refusal test
M4  InstallUpdates loses its gate                 RED  its relaunch test
M5  the standby purge loses its gate              RED  ManualPurge_WhenNotElevated
M6  Windows Update stops deciding elevation       RED  the guard alone, naming it
M7  the guard's floor raised to 99                RED  "only 10 view models were seen to branch"
```

Every mutation is safe to run under: the Windows Update tests use a substituted runner, so no module and no update can install even with a gate removed. Two of them also corrected the tests they were aimed at — `InstallModule_WhenNotElevated_ReachesTheRunner` originally expected one runner call and got two (install plus probe), so it now asserts the install script by content.

All four projects build in Release with 0 errors and 0 warnings. Locally the three affected classes and the whole of `ArchitectureTests` run green; the full unit suite is CI's blocking gate, since running forty privileged-tab classes on this workstation risks exactly the prompts that policy avoids.

## Notes for the reviewer

- `InstallUpdates`' gate reads `AdminHelper.IsElevated()` at call time rather than the `IsElevated` the constructor caches from the injected seam, so its test uses `ForceElevation` while the other seven use the seam. Recorded in that test's remarks and filed as #2181 — not a user-visible defect, since elevation cannot change inside a process lifetime, but it does mean one of four gates ignores the seam that exists to control it, and it leaves two mechanisms for one question in one file.
- `test:` — no release, no version bump, no CHANGELOG entry.

Refs #2171
