### PR TITLE
test: one thread-safe PropertyChanged recorder, and a guard that keeps it that way

### DIFF
--- a/SysManager/SysManager.IntegrationTests/DataModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DataModelTests.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.ComponentModel;
 using SysManager.Models;
 
 namespace SysManager.IntegrationTests;
@@ -82,8 +81,7 @@ public class TracerouteHopTests
     public void PropertyChanges_RaiseEvents()
     {
         var h = new TracerouteHop();
-        var raised = new List<string?>();
-        ((INotifyPropertyChanged)h).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        var raised = h.RecordPropertyChanges();
         h.HopNumber = 5;
         h.Address = "1.2.3.4";
         h.LatencyMs = 12;

--- a/SysManager/SysManager.IntegrationTests/DiskHealthReportTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DiskHealthReportTests.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.ComponentModel;
 using SysManager.Models;
 
 namespace SysManager.IntegrationTests;
@@ -26,11 +25,7 @@ public class DiskHealthReportTests
     public void PropertyChanged_FiresForAllFields()
     {
         var r = new DiskHealthReport();
-        var raised = new HashSet<string>();
-        ((INotifyPropertyChanged)r).PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName != null) raised.Add(e.PropertyName);
-        };
+        var raised = r.RecordPropertyChanges();
         r.FriendlyName = "NVMe";
         r.MediaType = "SSD";
         r.BusType = "NVMe";

--- a/SysManager/SysManager.IntegrationTests/HealthDiagnosticTests.cs
+++ b/SysManager/SysManager.IntegrationTests/HealthDiagnosticTests.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.ComponentModel;
 using SysManager.Helpers;
 using SysManager.Models;
 
@@ -27,11 +26,7 @@ public class HealthDiagnosticTests
     public void PropertyChanged_FiresForAllFields()
     {
         var d = new HealthDiagnostic();
-        var raised = new HashSet<string>();
-        ((INotifyPropertyChanged)d).PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName != null) raised.Add(e.PropertyName);
-        };
+        var raised = d.RecordPropertyChanges();
         d.Verdict = HealthVerdict.Good;
         d.Headline = "Healthy";
         d.Detail = "All good";

--- a/SysManager/SysManager.IntegrationTests/PingTargetTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PingTargetTests.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.ComponentModel;
 using SysManager.Models;
 
 namespace SysManager.IntegrationTests;
@@ -37,8 +36,7 @@ public class PingTargetTests
     public void IsEnabled_RaisesPropertyChanged()
     {
         var t = new PingTarget("x", "1.1.1.1", "#000000");
-        var raised = new List<string?>();
-        ((INotifyPropertyChanged)t).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        var raised = t.RecordPropertyChanges();
         t.IsEnabled = false;
         Assert.Contains(nameof(PingTarget.IsEnabled), raised);
     }

--- a/SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
+++ b/SysManager/SysManager.IntegrationTests/SysManager.IntegrationTests.csproj
@@ -23,7 +23,21 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Compiled in from the unit project rather than copied. Both suites record PropertyChanged names,
+         and the two other helpers this project shares by name with the unit one, StaHelper and
+         TestCollections, are separate files that have since DRIFTED apart (#2183) — StaHelper's copies are
+         now different designs. One source cannot. It stays in namespace SysManager.Tests, so a consumer
+         here needs `using SysManager.Tests;`, which is the visible price of not having two of them. -->
+    <Compile Include="..\SysManager.Tests\PropertyChangeRecorder.cs"
+             Link="PropertyChangeRecorder.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Xunit" />
+    <!-- For the linked PropertyChangeRecorder below, which keeps its own project's namespace. A global
+         using rather than one per file: it imports nothing else, because the only type compiled into THIS
+         assembly under SysManager.Tests is that one linked file. -->
+    <Using Include="SysManager.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SysManager/SysManager.IntegrationTests/ViewModelBaseTests.cs
+++ b/SysManager/SysManager.IntegrationTests/ViewModelBaseTests.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using SysManager.ViewModels;
 
@@ -26,8 +25,7 @@ public class ViewModelBaseTests
     public void IsBusy_RaisesPropertyChanged()
     {
         var vm = new Concrete();
-        var raised = new List<string?>();
-        ((INotifyPropertyChanged)vm).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        var raised = vm.RecordPropertyChanges();
         vm.IsBusy = true;
         Assert.Contains(nameof(ViewModelBase.IsBusy), raised);
     }
@@ -36,8 +34,7 @@ public class ViewModelBaseTests
     public void StatusMessage_RaisesPropertyChanged()
     {
         var vm = new Concrete();
-        var raised = new List<string?>();
-        ((INotifyPropertyChanged)vm).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        var raised = vm.RecordPropertyChanges();
         vm.StatusMessage = "hello";
         Assert.Contains(nameof(ViewModelBase.StatusMessage), raised);
     }

--- a/SysManager/SysManager.Tests/AppPackageTests.cs
+++ b/SysManager/SysManager.Tests/AppPackageTests.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.ComponentModel;
 using SysManager.Models;
 
 namespace SysManager.Tests;
@@ -26,8 +25,7 @@ public class AppPackageTests
     public void IsSelected_RaisesPropertyChanged()
     {
         var p = new AppPackage();
-        var raised = new List<string?>();
-        ((INotifyPropertyChanged)p).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        var raised = p.RecordPropertyChanges();
         p.IsSelected = false;
         Assert.Contains(nameof(AppPackage.IsSelected), raised);
     }
@@ -56,8 +54,7 @@ public class AppPackageTests
     public void NamePropertyChange_RaisesEvent()
     {
         var p = new AppPackage();
-        var raised = new List<string?>();
-        ((INotifyPropertyChanged)p).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        var raised = p.RecordPropertyChanges();
         p.Name = "Git";
         p.Id = "Git.Git";
         p.CurrentVersion = "2.47.0";

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -9237,4 +9237,109 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"\[(?:Fact|Theory|StaFact|StaTheory)\b", RegexOptions.CultureInvariant)]
     private static partial Regex TestMethodAttribute();
 
+    /// <summary>
+    /// A test may not record <c>PropertyChanged</c> into a collection that cannot take a concurrent write,
+    /// because whether that is safe depends on the source rather than on anything visible at the call site.
+    /// </summary>
+    /// <remarks>
+    /// <c>PropertyChanged += (_, e) =&gt; list.Add(e.PropertyName!)</c> was written sixty-one times, and each
+    /// one was safe or not depending on whether that particular source had a second, off-thread writer. A
+    /// view model whose constructor starts <c>InitializeAsync</c> does, because <c>ViewModelBase</c> awaits
+    /// it with <c>ConfigureAwait(false)</c> and the continuation resumes on the thread pool — #2169, an
+    /// <c>InvalidOperationException: Collection was modified; enumeration operation may not execute</c>
+    /// raised from inside an <c>Assert.Contains</c> on CI after roughly five thousand tests.
+    /// <para><b>Why a guard and not a sweep.</b> Identifying the exposed subset by pattern produced two
+    /// confidently wrong answers while #2169 was being fixed: keying the view model off
+    /// <c>new (\w+ViewModel)\(</c> missed every factory using target-typed <c>return new(...)</c>, including
+    /// the file that had actually failed, and deciding "does the factory wait for init" by looking for
+    /// <c>InitializationComplete</c> matched the phrase inside <c>NewVm</c>'s explanatory COMMENT. The
+    /// property this checks instead needs no per-file judgement: a recorder that survives a concurrent
+    /// writer is safe everywhere, and costs nothing where there is no concurrent writer.</para>
+    /// <para><b>The floor is on ADOPTION, not on the population this guard scans.</b> Counting raw
+    /// <c>PropertyChanged +=</c> sites would be a floor that every further conversion pushes DOWN, so
+    /// finishing the job would eventually read as a broken regex. The number that only grows is how many
+    /// call sites use the shared recorder — seventy when measured, counted with the same regex the guard
+    /// uses rather than a number arrived at some other way — so that is what has to stay above a floor for
+    /// a clean result to mean anything.</para>
+    /// <para>Twelve sites are legitimately left: they set a <c>bool</c> rather than appending, so there is
+    /// no collection to enumerate. <c>OperationLockServiceEdgeCaseTests</c> keeps a named handler because
+    /// its source is a process-wide singleton it must unsubscribe from, and uses a
+    /// <c>ConcurrentQueue</c> — which this guard accepts, deliberately. The helper is the easy path, not
+    /// the only legal one.</para>
+    /// </remarks>
+    [Fact]
+    public void NoTest_AppendsPropertyChangesToANonConcurrentCollection()
+    {
+        var root = Directory.GetParent(FindAppProjectDir())!.FullName;
+        var offenders = new List<string>();
+        var adoption = 0;
+        var filesRead = 0;
+
+        foreach (var project in new[] { "SysManager.Tests", "SysManager.IntegrationTests", "SysManager.UITests" })
+        {
+            var directory = Path.Combine(root, project);
+            Assert.True(Directory.Exists(directory), $"{project} was not found under {root}.");
+
+            foreach (var path in Directory.GetFiles(directory, "*.cs")
+                         .OrderBy(p => p, StringComparer.Ordinal))
+            {
+                var file = Path.GetFileName(path);
+                filesRead++;
+                var source = WithoutComments(File.ReadAllText(path));
+                adoption += SharedRecorderCall().Matches(source).Count;
+
+                // The helper's own file is the one place the banned shape is the implementation.
+                if (file == "PropertyChangeRecorder.cs") continue;
+
+                var lines = source.Replace("\r\n", "\n").Split('\n');
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    if (!PropertyChangedSubscription().IsMatch(lines[i])) continue;
+
+                    // The declaration usually sits just above the subscription and the append just below,
+                    // so the window spans both. A handler longer than this is not the shape being guarded.
+                    var window = string.Join('\n', lines[Math.Max(0, i - 3)..Math.Min(lines.Length, i + 5)]);
+                    if (NonConcurrentCollection().IsMatch(window) && CollectionAppend().IsMatch(window))
+                        offenders.Add($"{project}/{file}:{i + 1}  {lines[i].Trim()}");
+                }
+            }
+        }
+
+        Assert.True(filesRead >= 250,
+            $"only {filesRead} test files were read — this guard is looking at the wrong folders.");
+
+        // Seventy when measured, with this regex. Adoption only rises as more sites convert, so unlike a
+        // count of the remaining raw subscriptions this floor cannot be lowered by doing the right thing.
+        Assert.True(adoption >= 45,
+            $"only {adoption} call sites use the shared PropertyChangeRecorder, down from 70 — if it was "
+            + "replaced, this guard is now protecting a pattern nothing follows and must be revisited.");
+
+        Assert.True(offenders.Count == 0,
+            "These tests record PropertyChanged into a collection that throws if the source raises a "
+            + "notification while the assertion is enumerating it — which a view model does whenever its "
+            + "constructor started InitializeAsync, because that continuation resumes on the thread pool. "
+            + "Use source.RecordPropertyChanges() (or RecordChangesOf for a value), or a concurrent "
+            + "collection if the subscription has to be removed by hand:\n  "
+            + string.Join("\n  ", offenders)
+            + $"\n({adoption} call sites already use the shared recorder)");
+    }
+
+    /// <summary>A call to either of the shared recorder's entry points.</summary>
+    [GeneratedRegex(@"\.Record(?:PropertyChanges\(\)|ChangesOf\()", RegexOptions.CultureInvariant)]
+    private static partial Regex SharedRecorderCall();
+
+    /// <summary>A subscription to a <c>PropertyChanged</c> event.</summary>
+    [GeneratedRegex(@"PropertyChanged\s*\+=", RegexOptions.CultureInvariant)]
+    private static partial Regex PropertyChangedSubscription();
+
+    /// <summary>Construction of a collection with no concurrent-write guarantee.</summary>
+    [GeneratedRegex(@"new\s+(?:List|HashSet|Dictionary|SortedSet|SortedDictionary|Queue|Stack|Collection"
+                    + @"|ObservableCollection|BulkObservableCollection)\s*<",
+                    RegexOptions.CultureInvariant)]
+    private static partial Regex NonConcurrentCollection();
+
+    /// <summary>An append onto a collection, in any of the spellings those types use.</summary>
+    [GeneratedRegex(@"\.(?:Add|Push|Enqueue)\s*\(", RegexOptions.CultureInvariant)]
+    private static partial Regex CollectionAppend();
+
 }

--- a/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AudioMixerViewModelTests.cs
@@ -1157,11 +1157,7 @@ public class AudioMixerViewModelTests
         // flag would flash the bar on and off every second for as long as the tab is open.
         var vm = NewVm(ServiceWith(Session("s1")));
 
-        var seen = new List<bool>();
-        vm.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(vm.IsBusy)) seen.Add(vm.IsBusy);
-        };
+        var seen = vm.RecordChangesOf(nameof(vm.IsBusy), () => vm.IsBusy);
 
         await vm.ReconcileAsync();
 

--- a/SysManager/SysManager.Tests/BatteryHealthViewModelTests.cs
+++ b/SysManager/SysManager.Tests/BatteryHealthViewModelTests.cs
@@ -37,8 +37,7 @@ public class BatteryHealthViewModelTests
     public void Battery_CanBeReplaced()
     {
         var vm = new BatteryHealthViewModel(new Services.BatteryService());
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = vm.RecordPropertyChanges();
 
         vm.Battery = new Models.BatteryInfo { Name = "Test" };
         Assert.Contains("Battery", changed);
@@ -53,8 +52,7 @@ public class BatteryHealthViewModelTests
         // bound label silently freezing is the only regression this property realistically has.
         // Battery_CanBeReplaced two tests above already uses this pattern.
         var vm = new BatteryHealthViewModel(new Services.BatteryService());
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = vm.RecordPropertyChanges();
 
         vm.Summary = "Custom summary";
 

--- a/SysManager/SysManager.Tests/BatteryInfoEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/BatteryInfoEdgeCaseTests.cs
@@ -104,8 +104,7 @@ public class BatteryInfoEdgeCaseTests
     public void PropertyChanged_FiredOnChargePercentChange()
     {
         var info = new BatteryInfo();
-        var changes = new List<string>();
-        info.PropertyChanged += (_, e) => changes.Add(e.PropertyName!);
+        var changes = info.RecordPropertyChanges();
 
         info.ChargePercent = 75;
 
@@ -185,8 +184,7 @@ public class BatteryInfoEdgeCaseTests
     public void Display_RaisesPropertyChanged_WhenCapacityArrives()
     {
         var info = new BatteryInfo();
-        var changed = new List<string>();
-        info.PropertyChanged += (_, e) => changed.Add(e.PropertyName ?? "");
+        var changed = info.RecordPropertyChanges();
 
         info.FullChargeCapacityMWh = 45000;
 

--- a/SysManager/SysManager.Tests/BatteryServiceTests.cs
+++ b/SysManager/SysManager.Tests/BatteryServiceTests.cs
@@ -138,8 +138,7 @@ public class BatteryServiceTests
     public void BatteryInfo_PropertyChange_Notifies()
     {
         var info = new BatteryInfo();
-        var changed = new List<string>();
-        info.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = info.RecordPropertyChanges();
 
         info.HasBattery = true;
         info.Name = "Test Battery";

--- a/SysManager/SysManager.Tests/CleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CleanupViewModelTests.cs
@@ -108,12 +108,7 @@ public class CleanupViewModelTests
     public void IsAnyRunning_FiresPropertyChangedOnEveryFlag()
     {
         var vm = NewVm();
-        var seen = new HashSet<string>();
-        vm.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(vm.IsAnyRunning) && e.PropertyName != null)
-                seen.Add("IsAnyRunning");
-        };
+        var seen = vm.RecordPropertyChanges();
 
         vm.IsTempRunning = true;
         vm.IsBinRunning = true;

--- a/SysManager/SysManager.Tests/CpuAffinityViewModelTests.cs
+++ b/SysManager/SysManager.Tests/CpuAffinityViewModelTests.cs
@@ -249,11 +249,7 @@ public class CpuAffinityViewModelTests
         var service = FourCoreServiceWith(pid, 0b0001);
         var vm = NewVm(service);
 
-        var seen = new List<bool>();
-        vm.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(vm.IsBusy)) seen.Add(vm.IsBusy);
-        };
+        var seen = vm.RecordChangesOf(nameof(vm.IsBusy), () => vm.IsBusy);
 
         await vm.RefreshProcessesCommand.ExecuteAsync(null);
 
@@ -271,11 +267,7 @@ public class CpuAffinityViewModelTests
         const int pid = 4242;
         var vm = NewVm(FourCoreServiceWith(pid, 0b0001));
 
-        var seen = new List<bool>();
-        vm.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(vm.IsProgressIndeterminate)) seen.Add(vm.IsProgressIndeterminate);
-        };
+        var seen = vm.RecordChangesOf(nameof(vm.IsProgressIndeterminate), () => vm.IsProgressIndeterminate);
 
         await vm.RefreshProcessesCommand.ExecuteAsync(null);
 

--- a/SysManager/SysManager.Tests/DiskAnalyzerServiceTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerServiceTests.cs
@@ -247,8 +247,7 @@ public class DiskAnalyzerServiceTests : IDisposable
     public void DiskUsageEntry_PropertyChange_Notifies()
     {
         var entry = new DiskUsageEntry();
-        var changed = new List<string>();
-        entry.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = entry.RecordPropertyChanges();
 
         entry.Name = "test";
         entry.FullPath = @"C:\test";

--- a/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
@@ -170,8 +170,7 @@ public class DiskAnalyzerViewModelTests
         // The [NotifyPropertyChangedFor] attributes are what actually refresh the overlay; without
         // them the computed strings would change but the bound EmptyState would keep the old text.
         var vm = NewVm();
-        var raised = new List<string>();
-        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName ?? "");
+        var raised = vm.RecordPropertyChanges();
 
         vm.HasScanned = true;
 

--- a/SysManager/SysManager.Tests/DiskHealthReportEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/DiskHealthReportEdgeCaseTests.cs
@@ -241,8 +241,7 @@ public class DiskHealthReportEdgeCaseTests
     public void PropertyChanged_FiredOnWearPercentChange()
     {
         var report = new DiskHealthReport();
-        var changed = new List<string>();
-        report.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = report.RecordPropertyChanges();
 
         report.WearPercent = 50;
 

--- a/SysManager/SysManager.Tests/DiskHealthReportTests.cs
+++ b/SysManager/SysManager.Tests/DiskHealthReportTests.cs
@@ -36,8 +36,7 @@ public class DiskHealthReportTests
     public void PropertyChanged_FiresOnVerdictChange()
     {
         var r = new DiskHealthReport();
-        var changed = new List<string>();
-        r.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = r.RecordPropertyChanges();
         r.Verdict = "Healthy";
         Assert.Contains("Verdict", changed);
     }
@@ -46,8 +45,7 @@ public class DiskHealthReportTests
     public void PropertyChanged_FiresOnColorChange()
     {
         var r = new DiskHealthReport();
-        var changed = new List<string>();
-        r.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = r.RecordPropertyChanges();
         r.VerdictColorHex = StatusColors.Good;
         Assert.Contains("VerdictColorHex", changed);
     }

--- a/SysManager/SysManager.Tests/DuplicateFileGroupTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileGroupTests.cs
@@ -45,8 +45,7 @@ public class DuplicateFileGroupTests
     {
         var group = new DuplicateFileGroup();
         group.Count = 3;
-        var changed = new List<string>();
-        group.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = group.RecordPropertyChanges();
 
         group.FileSize = 2048;
 
@@ -58,8 +57,7 @@ public class DuplicateFileGroupTests
     {
         var group = new DuplicateFileGroup();
         group.FileSize = 1024;
-        var changed = new List<string>();
-        group.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = group.RecordPropertyChanges();
 
         group.Count = 5;
 
@@ -70,8 +68,7 @@ public class DuplicateFileGroupTests
     public void Hash_PropertyNotifies()
     {
         var group = new DuplicateFileGroup();
-        var changed = new List<string>();
-        group.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = group.RecordPropertyChanges();
 
         group.Hash = "abc123";
 
@@ -92,8 +89,7 @@ public class DuplicateFileGroupTests
     public void DuplicateFileEntry_Properties_Notify()
     {
         var entry = new DuplicateFileEntry();
-        var changed = new List<string>();
-        entry.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = entry.RecordPropertyChanges();
 
         entry.Path = @"C:\test\file.txt";
         entry.Name = "file.txt";
@@ -271,8 +267,7 @@ public class DuplicateFileGroupTests
     public void KeepLabel_NotifiesWhenTheMarkMoves()
     {
         var entry = new DuplicateFileEntry();
-        var changed = new List<string>();
-        entry.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = entry.RecordPropertyChanges();
 
         entry.IsSelected = true;
 

--- a/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
@@ -177,8 +177,7 @@ public class DuplicateFileViewModelTests
     public void DuplicateFileEntry_PropertyChange_Notifies()
     {
         var entry = new DuplicateFileEntry();
-        var changed = new List<string>();
-        entry.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = entry.RecordPropertyChanges();
 
         entry.Name = "test.bin";
         entry.Path = @"C:\test.bin";
@@ -197,8 +196,7 @@ public class DuplicateFileViewModelTests
     public void DuplicateFileGroup_PropertyChange_Notifies()
     {
         var group = new DuplicateFileGroup();
-        var changed = new List<string>();
-        group.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = group.RecordPropertyChanges();
 
         group.Hash = "ABC123";
         group.FileSize = 2048;

--- a/SysManager/SysManager.Tests/FriendlyEventEntryDisplayTests.cs
+++ b/SysManager/SysManager.Tests/FriendlyEventEntryDisplayTests.cs
@@ -54,8 +54,7 @@ public class FriendlyEventEntryDisplayTests
     public void Entry_SupportsPropertyChange()
     {
         var entry = new FriendlyEventEntry();
-        var changed = new List<string>();
-        entry.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = entry.RecordPropertyChanges();
 
         entry.Explanation = "Test explanation";
         entry.Recommendation = "Test recommendation";

--- a/SysManager/SysManager.Tests/FriendlyEventEntryExtendedTests.cs
+++ b/SysManager/SysManager.Tests/FriendlyEventEntryExtendedTests.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.ComponentModel;
 using SysManager.Helpers;
 using SysManager.Models;
 
@@ -14,11 +13,7 @@ public class FriendlyEventEntryExtendedTests
     public void PropertyChangedFires_ForAllFields()
     {
         var e = new FriendlyEventEntry();
-        var raised = new HashSet<string>();
-        ((INotifyPropertyChanged)e).PropertyChanged += (_, ev) =>
-        {
-            if (ev.PropertyName != null) raised.Add(ev.PropertyName);
-        };
+        var raised = e.RecordPropertyChanges();
         // A fixed date, not DateTime.Now: the generated setter skips PropertyChanged when the new
         // value equals the current one, so reading the wall clock made this assertion depend on
         // machine time rather than on a value the test controls.

--- a/SysManager/SysManager.Tests/HealthDiagnosticTests.cs
+++ b/SysManager/SysManager.Tests/HealthDiagnosticTests.cs
@@ -29,8 +29,7 @@ public class HealthDiagnosticTests
     public void PropertyChanged_FiresOnVerdictChange()
     {
         var h = new HealthDiagnostic();
-        var changed = new List<string>();
-        h.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = h.RecordPropertyChanges();
         h.Verdict = HealthVerdict.Good;
         Assert.Contains("Verdict", changed);
     }
@@ -39,8 +38,7 @@ public class HealthDiagnosticTests
     public void PropertyChanged_FiresOnHeadlineChange()
     {
         var h = new HealthDiagnostic();
-        var changed = new List<string>();
-        h.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = h.RecordPropertyChanges();
         h.Headline = "All good";
         Assert.Contains("Headline", changed);
     }

--- a/SysManager/SysManager.Tests/NavGroupTests.cs
+++ b/SysManager/SysManager.Tests/NavGroupTests.cs
@@ -122,8 +122,7 @@ public class NavGroupTests
     public void NavItem_IsSelected_UpdatesAutomationStatusAndRaisesChanges()
     {
         var item = CreateNavItem();
-        var changed = new List<string?>();
-        item.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+        var changed = item.RecordPropertyChanges();
 
         item.IsSelected = true;
 

--- a/SysManager/SysManager.Tests/NotificationBlockerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/NotificationBlockerViewModelTests.cs
@@ -270,11 +270,7 @@ public class NotificationBlockerViewModelTests
     {
         var vm = NewVm(NewService(App("a"), App("b")));
 
-        var seen = new List<bool>();
-        vm.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(vm.IsBusy)) seen.Add(vm.IsBusy);
-        };
+        var seen = vm.RecordChangesOf(nameof(vm.IsBusy), () => vm.IsBusy);
 
         await vm.RefreshCommand.ExecuteAsync(null);
 
@@ -291,11 +287,7 @@ public class NotificationBlockerViewModelTests
         // at 0 would read as "stalled".
         var vm = NewVm(NewService(App("a")));
 
-        var seen = new List<bool>();
-        vm.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(vm.IsProgressIndeterminate)) seen.Add(vm.IsProgressIndeterminate);
-        };
+        var seen = vm.RecordChangesOf(nameof(vm.IsProgressIndeterminate), () => vm.IsProgressIndeterminate);
 
         await vm.RefreshCommand.ExecuteAsync(null);
 

--- a/SysManager/SysManager.Tests/OperationLockServiceEdgeCaseTests.cs
+++ b/SysManager/SysManager.Tests/OperationLockServiceEdgeCaseTests.cs
@@ -1,6 +1,7 @@
 // SysManager · OperationLockServiceEdgeCaseTests
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
+using System.Collections.Concurrent;
 using SysManager.Services;
 
 namespace SysManager.Tests;
@@ -119,8 +120,13 @@ public class OperationLockServiceEdgeCaseTests
     [Fact]
     public void PropertyChanged_FiredOnAcquire()
     {
-        var changed = new List<string>();
-        void handler(object? _, System.ComponentModel.PropertyChangedEventArgs e) => changed.Add(e.PropertyName!);
+        // The one recorder in the suite that does NOT use PropertyChangeRecorder, because the source is a
+        // process-wide singleton that outlives the test: the helper never unsubscribes, which is correct for
+        // a source the test created and drops with it, and a leak here would keep every later acquire
+        // enqueueing into a finished test's collection. So the handler stays named and the `-=` below stays
+        // load-bearing — but the collection is concurrent, which is the property that actually matters.
+        var changed = new ConcurrentQueue<string>();
+        void handler(object? _, System.ComponentModel.PropertyChangedEventArgs e) => changed.Enqueue(e.PropertyName!);
         Service.PropertyChanged += handler;
 
         try

--- a/SysManager/SysManager.Tests/PerformanceProfileTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceProfileTests.cs
@@ -120,8 +120,7 @@ public class PerformanceProfileTests
     public void PropertyChange_Notifies()
     {
         var p = new PerformanceProfile();
-        var changed = new List<string>();
-        p.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = p.RecordPropertyChanges();
 
         p.ActivePlanName = "Test";
         p.VisualEffectsReduced = true;

--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Collections.Concurrent;
 using System.IO;
 using System.Reflection;
 using NSubstitute;
@@ -196,38 +195,20 @@ public class PerformanceViewModelTests
         Assert.False(vm.HasNvidiaGpu);
     }
 
-    /// <summary>
-    /// Records every property name this view model raises, safely enough to read while it is still
-    /// raising them.
-    /// </summary>
-    /// <remarks>
-    /// A plain <c>List&lt;string&gt;</c> here is a data race, and it fired on CI as
-    /// <c>InvalidOperationException: Collection was modified; enumeration operation may not execute</c>
-    /// from inside <c>Assert.Contains</c> (#2169). The second writer is the view model's own
-    /// initialization: the constructor calls <c>InitializeAsync</c>, whose continuations resume on the
-    /// thread pool because <c>ViewModelBase</c> awaits with <c>ConfigureAwait(false)</c>, and
-    /// <see cref="NewVm"/> deliberately does NOT wait for it — its <c>RunProcessAsync</c> returns a task
-    /// that never completes, which is what keeps these constructor-state tests independent of the host.
-    /// So the writer cannot be removed; the recorder has to tolerate it.
-    /// <para><c>ConcurrentQueue</c> rather than a snapshot: <c>changed.ToList()</c> would enumerate too,
-    /// and throw in exactly the same place. Its enumerator is a moment-in-time snapshot, so a concurrent
-    /// <c>Enqueue</c> cannot invalidate a read in progress.</para>
-    /// <para>It took ~5,000 concurrent tests to surface once and passes six for six in isolation, which
-    /// is precisely why it is worth fixing rather than watching: the next occurrence would read as a
-    /// one-off flake on an unrelated pull request.</para>
-    /// </remarks>
-    private static ConcurrentQueue<string> RecordPropertyChanges(PerformanceViewModel vm)
-    {
-        var changed = new ConcurrentQueue<string>();
-        vm.PropertyChanged += (_, e) => changed.Enqueue(e.PropertyName!);
-        return changed;
-    }
+    // This class is the reason PropertyChangeRecorder exists (#2169, #2175). Its local version of the
+    // helper lived here, and the concurrent writer that made it necessary is specific to this file: the
+    // constructor calls InitializeAsync, whose continuations resume on the thread pool because
+    // ViewModelBase awaits with ConfigureAwait(false), and NewVm deliberately does NOT wait for it — its
+    // RunProcessAsync returns a task that never completes, which is what keeps these constructor-state
+    // tests independent of the host. So the writer cannot be removed; the recorder has to tolerate it.
+    // It took ~5,000 concurrent tests to surface once and passed six for six in isolation, which is
+    // precisely why it was worth fixing rather than watching.
 
     [Fact]
     public void SelectedPlan_NotifiesPropertyChanged()
     {
         var vm = NewVm();
-        var changed = RecordPropertyChanges(vm);
+        var changed = vm.RecordPropertyChanges();
         vm.SelectedPlan = "high";
         Assert.Contains("SelectedPlan", changed);
     }
@@ -254,7 +235,7 @@ public class PerformanceViewModelTests
     public void IsProcessorStateLocked_NotifiesEditable()
     {
         var vm = NewVm();
-        var changed = RecordPropertyChanges(vm);
+        var changed = vm.RecordPropertyChanges();
         vm.IsProcessorStateLocked = true;
         Assert.Contains("IsProcessorStateLocked", changed);
         Assert.Contains("IsProcessorStateEditable", changed);

--- a/SysManager/SysManager.Tests/PingTargetTests.cs
+++ b/SysManager/SysManager.Tests/PingTargetTests.cs
@@ -43,8 +43,7 @@ public class PingTargetTests
     public void PropertyChanged_FiresOnNameChange()
     {
         var t = new PingTarget();
-        var changed = new List<string>();
-        t.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = t.RecordPropertyChanges();
         t.Name = "Test";
         Assert.Contains("Name", changed);
     }
@@ -53,8 +52,7 @@ public class PingTargetTests
     public void PropertyChanged_FiresOnLatencyChange()
     {
         var t = new PingTarget();
-        var changed = new List<string>();
-        t.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = t.RecordPropertyChanges();
         t.LastLatencyMs = 15.5;
         Assert.Contains("LastLatencyMs", changed);
     }
@@ -63,8 +61,7 @@ public class PingTargetTests
     public void PropertyChanged_FiresOnStatusChange()
     {
         var t = new PingTarget();
-        var changed = new List<string>();
-        t.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = t.RecordPropertyChanges();
         t.Status = "OK";
         Assert.Contains("Status", changed);
     }

--- a/SysManager/SysManager.Tests/PrivacyViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PrivacyViewModelTests.cs
@@ -234,11 +234,7 @@ public class PrivacyViewModelTests
     {
         var vm = NewVm();
 
-        var seen = new List<bool>();
-        vm.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(vm.IsBusy)) seen.Add(vm.IsBusy);
-        };
+        var seen = vm.RecordChangesOf(nameof(vm.IsBusy), () => vm.IsBusy);
 
         await vm.RefreshCommand.ExecuteAsync(null);
 
@@ -255,11 +251,7 @@ public class PrivacyViewModelTests
         // would read as "stalled".
         var vm = NewVm();
 
-        var seen = new List<bool>();
-        vm.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(vm.IsProgressIndeterminate)) seen.Add(vm.IsProgressIndeterminate);
-        };
+        var seen = vm.RecordChangesOf(nameof(vm.IsProgressIndeterminate), () => vm.IsProgressIndeterminate);
 
         await vm.RefreshCommand.ExecuteAsync(null);
 

--- a/SysManager/SysManager.Tests/ProcessManagerServiceTests.cs
+++ b/SysManager/SysManager.Tests/ProcessManagerServiceTests.cs
@@ -223,8 +223,7 @@ public class ProcessManagerServiceTests
     public void ProcessEntry_PropertyChange_Notifies()
     {
         var entry = new ProcessEntry();
-        var changed = new List<string>();
-        entry.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = entry.RecordPropertyChanges();
 
         entry.Pid = 1234;
         entry.Name = "test";

--- a/SysManager/SysManager.Tests/PropertyChangeRecorder.cs
+++ b/SysManager/SysManager.Tests/PropertyChangeRecorder.cs
@@ -13,7 +13,7 @@ namespace SysManager.Tests;
 /// </summary>
 /// <remarks>
 /// The shape this replaces — <c>PropertyChanged += (_, e) =&gt; list.Add(e.PropertyName!)</c> — was
-/// written about thirty times across the test projects, and whether each one was safe depended on
+/// written sixty-one times across the two test projects, and whether each one was safe depended on
 /// something no reader checked: whether that particular source had a second, off-thread writer. Most did
 /// not. A view model whose constructor starts <c>InitializeAsync</c> does, because
 /// <c>ViewModelBase</c> awaits it with <c>ConfigureAwait(false)</c> and the continuation resumes on the

--- a/SysManager/SysManager.Tests/PropertyChangeRecorder.cs
+++ b/SysManager/SysManager.Tests/PropertyChangeRecorder.cs
@@ -1,0 +1,79 @@
+// SysManager · PropertyChangeRecorder
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.Concurrent;
+using System.ComponentModel;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Records the property names an <see cref="INotifyPropertyChanged"/> raises, into a collection that
+/// stays safe to read while another thread is still raising them.
+/// </summary>
+/// <remarks>
+/// The shape this replaces — <c>PropertyChanged += (_, e) =&gt; list.Add(e.PropertyName!)</c> — was
+/// written about thirty times across the test projects, and whether each one was safe depended on
+/// something no reader checked: whether that particular source had a second, off-thread writer. Most did
+/// not. A view model whose constructor starts <c>InitializeAsync</c> does, because
+/// <c>ViewModelBase</c> awaits it with <c>ConfigureAwait(false)</c> and the continuation resumes on the
+/// thread pool — which is #2169, an <c>InvalidOperationException: Collection was modified; enumeration
+/// operation may not execute</c> raised from inside an <c>Assert.Contains</c> on CI.
+/// <para>Deciding the exposed subset by hand means reading thirty factories and re-reading them whenever
+/// one changes. A recorder that is safe under a concurrent writer removes the question instead of
+/// answering it thirty times, and costs nothing where there is no concurrent writer.</para>
+/// <para><b><see cref="ConcurrentQueue{T}"/> rather than a lock around a list, and rather than a
+/// snapshot.</b> <c>list.ToList()</c> enumerates too, and throws in exactly the same place. A queue's
+/// enumerator is a moment-in-time snapshot, so an <c>Enqueue</c> arriving mid-read cannot invalidate it.
+/// Enqueue order is preserved, so a test asserting a sequence of names keeps working.</para>
+/// <para>The subscription is never removed. Every caller records a source it created for that one test
+/// and drops both together, so there is nothing to leak — and taking an
+/// <see cref="IDisposable"/> instead would put a <c>using</c> on all sixty call sites to solve a problem
+/// none of them has.</para>
+/// </remarks>
+public static class PropertyChangeRecorder
+{
+    /// <summary>
+    /// Subscribes to <paramref name="source"/> and returns the queue its raised property names land in.
+    /// </summary>
+    /// <remarks>
+    /// <c>e.PropertyName</c> is forced non-null deliberately. The framework allows a null name, meaning
+    /// "every property changed", but nothing in this app raises one, and a null in the queue would fail
+    /// an assertion far from its cause. If a source ever does, this throws at the raise instead.
+    /// </remarks>
+    public static ConcurrentQueue<string> RecordPropertyChanges(this INotifyPropertyChanged source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var changed = new ConcurrentQueue<string>();
+        source.PropertyChanged += (_, e) => changed.Enqueue(e.PropertyName!);
+        return changed;
+    }
+
+    /// <summary>
+    /// Subscribes to <paramref name="source"/> and returns the sequence of values <paramref name="read"/>
+    /// produced each time <paramref name="propertyName"/> was raised.
+    /// </summary>
+    /// <remarks>
+    /// The other overload records WHICH property changed; this records what it changed TO, which is what a
+    /// busy-flag test needs: an operation that completes in microseconds cannot be sampled mid-flight, so
+    /// "the bar went up and then came down" is only observable as <c>[true, false]</c> in the notifications
+    /// themselves. Nine tests across seven tabs assert exactly that.
+    /// <para>A <see cref="Func{T}"/> rather than reading <c>e</c>, because the event carries only the name:
+    /// the value has to come from the source, at the moment it notified.</para>
+    /// </remarks>
+    public static ConcurrentQueue<T> RecordChangesOf<T>(
+        this INotifyPropertyChanged source, string propertyName, Func<T> read)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(propertyName);
+        ArgumentNullException.ThrowIfNull(read);
+
+        var seen = new ConcurrentQueue<T>();
+        source.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == propertyName) seen.Enqueue(read());
+        };
+        return seen;
+    }
+}

--- a/SysManager/SysManager.Tests/PropertyChangeRecorderTests.cs
+++ b/SysManager/SysManager.Tests/PropertyChangeRecorderTests.cs
@@ -1,0 +1,142 @@
+// SysManager · PropertyChangeRecorderTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.Concurrent;
+using System.ComponentModel;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for the shared recorder the rest of the suite records notifications through.
+/// </summary>
+/// <remarks>
+/// The one that matters is <see cref="RecordPropertyChanges_SurvivesAWriterOnAnotherThread"/>. Every other
+/// test here would pass just as happily against the plain <c>List&lt;string&gt;</c> this replaced, which is
+/// exactly why sixty-one hand-rolled copies of that list looked fine for as long as they did.
+/// </remarks>
+public class PropertyChangeRecorderTests
+{
+    /// <summary>Minimal notifier: this tests the recorder, not any particular view model.</summary>
+    private sealed class Notifier : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public int Value { get; private set; }
+
+        public void Raise(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+        public void SetValue(int value, string name)
+        {
+            Value = value;
+            Raise(name);
+        }
+    }
+
+    [Fact]
+    public void RecordPropertyChanges_CapturesEveryNameInOrder()
+    {
+        var source = new Notifier();
+        var changed = source.RecordPropertyChanges();
+
+        source.Raise("First");
+        source.Raise("Second");
+        source.Raise("First");
+
+        Assert.Equal(["First", "Second", "First"], changed);
+    }
+
+    [Fact]
+    public void RecordPropertyChanges_BeforeAnythingIsRaised_IsEmpty()
+    {
+        Assert.Empty(new Notifier().RecordPropertyChanges());
+    }
+
+    /// <summary>
+    /// The whole point: reading the record while the source is still notifying must not throw.
+    /// </summary>
+    /// <remarks>
+    /// This is the failure #2169 hit on CI — <c>InvalidOperationException: Collection was modified;
+    /// enumeration operation may not execute</c> from inside an <c>Assert.Contains</c>, once in about five
+    /// thousand tests, because a view model's <c>InitializeAsync</c> continuation was still raising
+    /// notifications on the thread pool while the assertion enumerated a plain <c>List</c>.
+    /// <para>Deterministic in the direction that counts: a <see cref="ConcurrentQueue{T}"/> enumerator is a
+    /// moment-in-time snapshot, so this CANNOT throw for a correct implementation however the two threads
+    /// interleave — there is no flake to inherit. Against a plain <c>List</c> the same loop throws nearly
+    /// every time, which is what makes it a real test rather than a restatement of the signature. No sleep
+    /// and no wall clock: the reader spins until the writer's fixed count is done.</para>
+    /// </remarks>
+    [Fact]
+    public async Task RecordPropertyChanges_SurvivesAWriterOnAnotherThread()
+    {
+        const int raises = 20_000;
+        var source = new Notifier();
+        var changed = source.RecordPropertyChanges();
+
+        var writer = Task.Run(() =>
+        {
+            for (var i = 0; i < raises; i++) source.Raise("Churn" + i);
+        });
+
+        var reads = 0;
+        while (!writer.IsCompleted)
+        {
+            // Enumerating is the operation that throws on a List being appended to concurrently.
+            foreach (var _ in changed) { }
+            reads++;
+        }
+
+        await writer;
+
+        Assert.True(reads > 0, "the writer finished before a single read — this proved nothing");
+        Assert.Equal(raises, changed.Count);
+    }
+
+    [Fact]
+    public void RecordChangesOf_CapturesTheValueAtEachNotification()
+    {
+        var source = new Notifier();
+        var seen = source.RecordChangesOf(nameof(Notifier.Value), () => source.Value);
+
+        source.SetValue(1, nameof(Notifier.Value));
+        source.SetValue(2, nameof(Notifier.Value));
+
+        Assert.Equal([1, 2], seen);
+    }
+
+    [Fact]
+    public void RecordChangesOf_IgnoresEveryOtherProperty()
+    {
+        var source = new Notifier();
+        var seen = source.RecordChangesOf(nameof(Notifier.Value), () => source.Value);
+
+        source.SetValue(7, "SomethingElse");
+
+        Assert.Empty(seen);
+    }
+
+    [Fact]
+    public void RecordPropertyChanges_NullSource_Throws()
+    {
+        INotifyPropertyChanged? source = null;
+        Assert.Throws<ArgumentNullException>(() => source!.RecordPropertyChanges());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RecordChangesOf_WithoutAPropertyName_Throws(string? name)
+    {
+        var source = new Notifier();
+        Assert.ThrowsAny<ArgumentException>(() => source.RecordChangesOf(name!, () => source.Value));
+    }
+
+    [Fact]
+    public void RecordChangesOf_WithoutAReader_Throws()
+    {
+        var source = new Notifier();
+        Assert.Throws<ArgumentNullException>(
+            () => source.RecordChangesOf<int>(nameof(Notifier.Value), null!));
+    }
+}

--- a/SysManager/SysManager.Tests/ServiceManagerServiceTests.cs
+++ b/SysManager/SysManager.Tests/ServiceManagerServiceTests.cs
@@ -100,8 +100,7 @@ public class ServiceManagerServiceTests
     public void ServiceEntry_ObservableProperties()
     {
         var entry = new ServiceEntry { Name = "Test" };
-        var changed = new List<string>();
-        entry.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = entry.RecordPropertyChanges();
         entry.Status = "Running";
         entry.StartType = "Automatic";
         Assert.Contains("Status", changed);

--- a/SysManager/SysManager.Tests/StandbyMemoryTests.cs
+++ b/SysManager/SysManager.Tests/StandbyMemoryTests.cs
@@ -113,11 +113,7 @@ public class StandbyMemoryTests
         var vm = NewVm(temp.Path);
         Assert.True(vm.IsElevated, "the scope must reach the view-model's constructor");
 
-        var seen = new List<bool>();
-        vm.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(vm.IsBusy)) seen.Add(vm.IsBusy);
-        };
+        var seen = vm.RecordChangesOf(nameof(vm.IsBusy), () => vm.IsBusy);
 
         await vm.PurgeCommand.ExecuteAsync(null);
 
@@ -140,11 +136,7 @@ public class StandbyMemoryTests
         var vm = NewVm(temp.Path);
         Assert.False(vm.IsElevated, "the scope must reach the view-model's constructor");
 
-        var seen = new List<bool>();
-        vm.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(vm.IsBusy)) seen.Add(vm.IsBusy);
-        };
+        var seen = vm.RecordChangesOf(nameof(vm.IsBusy), () => vm.IsBusy);
 
         await vm.PurgeCommand.ExecuteAsync(null);
 

--- a/SysManager/SysManager.Tests/TracerouteHopTests.cs
+++ b/SysManager/SysManager.Tests/TracerouteHopTests.cs
@@ -44,8 +44,7 @@ public class TracerouteHopTests
     public void PropertyChanged_FiresOnLatencyChange()
     {
         var h = new TracerouteHop();
-        var changed = new List<string>();
-        h.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = h.RecordPropertyChanges();
         h.LatencyMs = 10.0;
         Assert.Contains("LatencyMs", changed);
     }
@@ -54,8 +53,7 @@ public class TracerouteHopTests
     public void PropertyChanged_FiresOnHostNameChange()
     {
         var h = new TracerouteHop();
-        var changed = new List<string>();
-        h.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = h.RecordPropertyChanges();
         h.HostName = "resolved.host.com";
         Assert.Contains("HostName", changed);
     }

--- a/SysManager/SysManager.Tests/TracerouteViewModelTests.cs
+++ b/SysManager/SysManager.Tests/TracerouteViewModelTests.cs
@@ -108,8 +108,7 @@ public class TracerouteViewModelTests
         // rendering the old state even though the value changed.
         using var shared = NewShared();
         using var vm = new TracerouteViewModel(shared);
-        var raised = new List<string>();
-        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName ?? "");
+        var raised = vm.RecordPropertyChanges();
 
         shared.IsAutoTraceRunning = true;
 

--- a/SysManager/SysManager.Tests/UninstallerServiceTests.cs
+++ b/SysManager/SysManager.Tests/UninstallerServiceTests.cs
@@ -427,8 +427,7 @@ public class UninstallerServiceTests
     public void InstalledApp_PropertyChange_Notifies()
     {
         var app = new InstalledApp();
-        var changed = new List<string>();
-        app.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = app.RecordPropertyChanges();
 
         app.IsSelected = true;
         app.Name = "Test";

--- a/SysManager/SysManager.Tests/ViewModelBaseExtendedTests.cs
+++ b/SysManager/SysManager.Tests/ViewModelBaseExtendedTests.cs
@@ -68,8 +68,7 @@ public class ViewModelBaseExtendedTests
     public void IsBusy_RaisesPropertyChanged()
     {
         var vm = new TestViewModel();
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = vm.RecordPropertyChanges();
 
         vm.IsBusy = true;
 
@@ -80,8 +79,7 @@ public class ViewModelBaseExtendedTests
     public void StatusMessage_RaisesPropertyChanged()
     {
         var vm = new TestViewModel();
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = vm.RecordPropertyChanges();
 
         vm.StatusMessage = "Working...";
 
@@ -92,8 +90,7 @@ public class ViewModelBaseExtendedTests
     public void Progress_RaisesPropertyChanged()
     {
         var vm = new TestViewModel();
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = vm.RecordPropertyChanges();
 
         vm.Progress = 50;
 
@@ -104,8 +101,7 @@ public class ViewModelBaseExtendedTests
     public void IsProgressIndeterminate_RaisesPropertyChanged()
     {
         var vm = new TestViewModel();
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = vm.RecordPropertyChanges();
 
         vm.IsProgressIndeterminate = true;
 
@@ -117,8 +113,7 @@ public class ViewModelBaseExtendedTests
     {
         var vm = new TestViewModel();
         vm.Progress = 50;
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = vm.RecordPropertyChanges();
 
         vm.Progress = 50;
 
@@ -130,8 +125,7 @@ public class ViewModelBaseExtendedTests
     {
         var vm = new TestViewModel();
         vm.IsBusy = false;
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = vm.RecordPropertyChanges();
 
         vm.IsBusy = false;
 

--- a/SysManager/SysManager.Tests/ViewModelBaseTests.cs
+++ b/SysManager/SysManager.Tests/ViewModelBaseTests.cs
@@ -33,8 +33,7 @@ public class ViewModelBaseTests
     public void IsBusy_RaisesPropertyChanged()
     {
         var vm = new TestVm();
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = vm.RecordPropertyChanges();
         vm.IsBusy = true;
         Assert.Contains("IsBusy", changed);
     }
@@ -43,8 +42,7 @@ public class ViewModelBaseTests
     public void StatusMessage_RaisesPropertyChanged()
     {
         var vm = new TestVm();
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = vm.RecordPropertyChanges();
         vm.StatusMessage = "Loading...";
         Assert.Contains("StatusMessage", changed);
     }
@@ -53,8 +51,7 @@ public class ViewModelBaseTests
     public void Progress_RaisesPropertyChanged()
     {
         var vm = new TestVm();
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = vm.RecordPropertyChanges();
         vm.Progress = 50;
         Assert.Contains("Progress", changed);
     }
@@ -63,8 +60,7 @@ public class ViewModelBaseTests
     public void IsProgressIndeterminate_RaisesPropertyChanged()
     {
         var vm = new TestVm();
-        var changed = new List<string>();
-        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+        var changed = vm.RecordPropertyChanges();
         vm.IsProgressIndeterminate = true;
         Assert.Contains("IsProgressIndeterminate", changed);
     }

--- a/TESTING.md
+++ b/TESTING.md
@@ -174,6 +174,17 @@ collection definitions (all defined in `TestCollections.cs`, each with
   Requires `[Collection("ProcessWideStatics")]`.
 - `SyncProgress<T>` — a synchronous `IProgress<T>` that records reports on the calling thread, so
   progress assertions need no `Task.Delay`.
+- `PropertyChangeRecorder` — records what an `INotifyPropertyChanged` raises, into a collection that
+  is safe to read while it is still being written: `var changed = vm.RecordPropertyChanges();` for the
+  property NAMES, and `var seen = vm.RecordChangesOf(nameof(vm.IsBusy), () => vm.IsBusy);` for the
+  VALUES a named property took — which is the only way to assert "the bar went up and came down" on an
+  operation too fast to sample. **Never record into a plain `List`.** A view model whose constructor
+  started `InitializeAsync` is still raising notifications on the thread pool, so an `Assert.Contains`
+  can enumerate a collection being appended to (#2169). `ArchitectureTests`
+  `.NoTest_AppendsPropertyChangesToANonConcurrentCollection` fails the build on that shape; a
+  hand-written handler is still allowed where a subscription must be removed by hand, provided its
+  collection is concurrent. One file, compiled into both test projects rather than copied — the two
+  helpers that were copied instead have since drifted (#2183).
 - `StaHelper` — **`SysManager.IntegrationTests` only**, since it exists for tests that instantiate
   views. It queues a delegate onto **one** background STA thread shared by the whole suite and waits
   for it, rethrowing whatever the delegate threw. One thread rather than one per call because the


### PR DESCRIPTION
Closes #2175. One recorder, sixty-one call sites converted, and a guard whose floor cannot be lowered by finishing the job.

## The problem

`PropertyChanged += (_, e) => list.Add(e.PropertyName!)` was written **61 times** across the two test projects, and whether each one was safe depended on something no reader checked: whether that particular source had a second, off-thread writer.

Most did not. A view model whose constructor starts `InitializeAsync` does — `ViewModelBase` awaits it with `ConfigureAwait(false)`, so the continuation resumes on the thread pool and can append while the assertion enumerates. That is #2169: `InvalidOperationException: Collection was modified; enumeration operation may not execute`, raised from inside an `Assert.Contains` on CI, once in roughly five thousand tests.

## The recorder

`PropertyChangeRecorder`, one file, two entry points — because the call sites do two different things:

| entry point | returns | used by |
|---|---|---|
| `source.RecordPropertyChanges()` | the names raised | the 51 sites asserting *which* property notified |
| `source.RecordChangesOf(name, read)` | the values that property took | the 9 busy-flag tests asserting `[true, false]` |

51 name sites plus 9 value sites plus the one hand-written handler below accounts for all 61.

The second overload is not optional. An operation completing in microseconds cannot be sampled mid-flight, so "the progress bar went up and then came down" is only observable in the notifications themselves — nine tests across seven tabs assert exactly that sequence, and a name-only recorder cannot express it.

`ConcurrentQueue` rather than a lock or a snapshot: `list.ToList()` enumerates too, and throws in the same place. A queue's enumerator is a moment-in-time snapshot, and enqueue order is preserved so the order-asserting tests keep working unchanged.

## One file, compiled into both projects

```xml
<Compile Include="..\SysManager.Tests\PropertyChangeRecorder.cs" Link="PropertyChangeRecorder.cs" />
```

Not a copy each. The two helpers these projects already share by name, `StaHelper` and `TestCollections`, are separate files that have since drifted into genuinely different designs — #2183 found `StaHelper`'s unit-project copy still carrying the thread-per-call design that #2156 had to replace. One source cannot drift. The linked file keeps its own namespace, so the integration project takes a `<Using Include="SysManager.Tests" />`; that import brings in nothing else, because the only type compiled into that assembly under the namespace is the linked file.

## What was deliberately left alone

- **12 sites** set a `bool` (`fired = true`) rather than appending. No collection, nothing to enumerate, no race to have.
- **3 sites** assign a single `string` — they assert the *most recent* name, which the shared queue would not express more clearly.
- **`OperationLockServiceEdgeCaseTests.PropertyChanged_FiredOnAcquire`** keeps its named handler, because its source is `OperationLockService.Instance` — a process-wide singleton that outlives the test. The helper never unsubscribes, which is correct for a source the test creates and drops with it, but here it would leak a handler that every later acquire keeps enqueueing into. So the `-=` stays load-bearing and only the collection changes, to a `ConcurrentQueue`. The guard accepts that on purpose.
- **`PerformanceViewModelTests`** loses the local recorder #2169 added; the file-specific reasoning for why its writer cannot be removed stays as a comment where the tests are.

## The guard

`NoTest_AppendsPropertyChangesToANonConcurrentCollection` rejects a `PropertyChanged +=` whose surrounding window declares a `List`/`HashSet`/`Queue`/… and appends to it. The helper is the easy path; a concurrent collection is equally legal.

**Its floor is on adoption, not on the population it scans.** This matters more than it looks. A floor on "remaining raw subscriptions" is a floor that every further conversion pushes *down*, so completing the migration would eventually read as a broken regex — the trap that has bitten a guard in this repo before. The number of shared-recorder call sites only ever grows, so that is what has to stay above a floor (70 measured, floor 45) for a clean result to mean anything.

Why a guard rather than a one-time sweep is #2175's own argument, and it is worth repeating because both attempts to identify the exposed subset by pattern returned confident wrong answers: keying the view model off `new (\w+ViewModel)\(` missed every factory using target-typed `return new(...)` — including the file that had actually failed — and deciding "does the factory wait for init" by looking for `InitializationComplete` matched the phrase inside `NewVm`'s explanatory **comment**. A recorder that survives a concurrent writer needs none of that judgement.

## The recorder's own tests

`PropertyChangeRecorderTests`, 10 cases. One of them is the point:

```csharp
var writer = Task.Run(() => { for (var i = 0; i < 20_000; i++) source.Raise("Churn" + i); });
while (!writer.IsCompleted) { foreach (var _ in changed) { } reads++; }
```

Deterministic in the direction that counts: a `ConcurrentQueue` enumerator is a snapshot, so this **cannot** throw for a correct implementation however the threads interleave — there is no flake to inherit. Against the `List` it replaced it throws almost every time. No sleep and no wall clock; the reader spins until the writer's fixed count is done, and asserts it got at least one read in so the test cannot pass by never racing.

Every other test in that file would have passed against a plain `List` too. That is exactly why 61 copies of one looked fine for as long as they did.

## Verification

Five mutations, five reds, restore hash-checked byte-for-byte, final state green:

```
Q1  one converted site reverts to a plain List      RED  "DiskHealthReportTests.cs:40  r.PropertyChanged
                                                          += (_, e) => changed.Add(e.PropertyName!)"
Q2  the adoption floor raised to 999                RED  "only 70 call sites use the shared recorder"
Q3  the exempt handler drops its ConcurrentQueue    RED  the guard names it too — the exemption is the
                                                          concurrent collection, not the file
Q4  the helper itself uses a plain List             RED  "Collection was modified; enumeration
                                                          operation may not execute"
Q5  RecordChangesOf stops filtering by name         RED  its ignore-every-other-property test
```

Q3 is there because "this one file is allowed a hand-written handler" would be the wrong rule. Q2's first run also caught a stale number in the guard's own failure message — it said "down from 62", measured before the helper's tests added 8 more call sites — now re-derived with the guard's own regex.

All four projects: 0 errors, 0 warnings. Locally the 34 affected unit classes run green (697 cases) and the 5 affected integration classes green (16); the full suite is CI's blocking gate.

## Notes

- `test:` — no release, no version bump, no CHANGELOG entry.
- TESTING.md's shared-helpers list gains the recorder, with the rule stated plainly ("never record into a plain `List`") and the guard that enforces it named.

Closes #2175
