### PR TITLE
refactor: put Context Menu behind a seam so its two failure messages are asserted

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,9 +154,10 @@ QA-verified is marked with `IsInDevelopment` (surfaced as a PREVIEW badge) inste
 
 Thin wrappers around the underlying platform. Each service is designed to be
 unit-testable. Services that a view-model needs to substitute in tests sit behind
-an interface seam. Fourteen are registered against their implementation in `ServiceRegistration.cs` and
+an interface seam. Fifteen are registered against their implementation in `ServiceRegistration.cs` and
 constructor-injected: `IPowerShellRunner` (PowerShellRunner), `IWingetService` (WingetService),
-`IAppBlockerService` (AppBlockerService), `ICleanupPreScanService`, `ICpuAffinityService`,
+`IAppBlockerService` (AppBlockerService), `ICleanupPreScanService`, `IContextMenuService`,
+`ICpuAffinityService`,
 `IFileLockService`, `INotificationBlockerService`, `ISettingsWatchdogService`, `ITimerResolutionService`,
 `ITweaksHubService`, `IWindowsThemeService`, `IAudioMixerService`, `IGamingProfileService`, and
 `ISessionRestorePoint` (the last two via a factory).

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -8962,15 +8962,13 @@ public partial class ArchitectureTests
     public void EveryViewModelThatBranchesOnElevation_HasATestThatPinsIt()
     {
         // view model -> why no test pins its elevation branch yet, verified rather than deferred.
-        var cannotBePinnedYet = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            ["ContextMenuViewModel"] =
-                "takes a concrete ContextMenuService with no interface, so its toggle path cannot be "
-                + "driven at all: a test can neither make the registry write fail on purpose nor let it "
-                + "succeed, because a real toggle would change a shell key on the machine running the "
-                + "suite. Blocked on the seam in #2180, which is where its two failure messages get "
-                + "asserted",
-        };
+        // EMPTY, and that is the point. It held one entry — ContextMenuViewModel, whose concrete
+        // ContextMenuService could not be substituted, so a test could neither fail a toggle on purpose
+        // nor let it succeed without writing a real shell key. #2180 extracted IContextMenuService and
+        // both of its failure messages are now asserted, so the sweep #2171 asked for is complete.
+        // Anything added back needs a reason that has been VERIFIED, not deferred: an excuse nobody
+        // checked is a false claim sitting in the test suite.
+        var cannotBePinnedYet = new Dictionary<string, string>(StringComparer.Ordinal);
 
         var vmDir = Path.Combine(FindAppProjectDir(), "ViewModels");
         var testsDir = Path.Combine(

--- a/SysManager/SysManager.Tests/ContextMenuViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ContextMenuViewModelTests.cs
@@ -2,7 +2,9 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using NSubstitute;
 using SysManager.Helpers;
+using SysManager.Models;
 using SysManager.Services;
 using SysManager.ViewModels;
 
@@ -14,6 +16,10 @@ namespace SysManager.Tests;
 /// registry on construction; <see cref="NewVm"/> awaits <see cref="ViewModelBase.InitializationComplete"/>
 /// so assertions observe a settled state deterministically (no race with the scan).
 /// </summary>
+// Serialized: the toggle-failure tests pin elevation with AdminHelper.ForceElevation and swap
+// DialogService.Instance, both process-wide. Required by
+// ArchitectureTests.ProcessWideStaticUsers_AreInTheSerializedCollection.
+[Collection("ProcessWideStatics")]
 public class ContextMenuViewModelTests
 {
     private static ContextMenuViewModel NewVm()
@@ -115,5 +121,114 @@ public class ContextMenuViewModelTests
         Assert.True(vm.ScanCommand.CanExecute(null));
         Assert.True(vm.RefreshCommand.CanExecute(null));
         Assert.True(vm.ApplyPresetCommand.CanExecute(null));
+    }
+
+    // ── Toggling an entry ────────────────────────────────────────────────────
+    //
+    // None of this was assertable until IContextMenuService existed (#2180): a test could neither make a
+    // toggle fail on purpose nor let it succeed, because a real toggle writes a shell key on the machine
+    // running the suite — and on an elevated CI runner that write goes through. The substitute decides the
+    // outcome, so nothing here reaches the registry.
+    //
+    // The tests above deliberately keep the REAL service: they assert state derived from an actual scan,
+    // which a substitute returning nothing would make vacuous.
+
+    /// <summary>A view model whose toggles answer <paramref name="toggleSucceeds"/> and touch nothing.</summary>
+    private static ContextMenuViewModel NewVm(bool toggleSucceeds, out IContextMenuService service)
+    {
+        service = Substitute.For<IContextMenuService>();
+        service.ScanEntries().Returns([]);
+        service.EnableEntry(Arg.Any<ContextMenuEntry>()).Returns(toggleSucceeds);
+        service.DisableEntry(Arg.Any<ContextMenuEntry>()).Returns(toggleSucceeds);
+
+        var vm = new ContextMenuViewModel(service);
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
+
+    private static ContextMenuEntry NewEntry(bool enabled) => new()
+    {
+        Name = "Open with Example",
+        Command = @"C:\Program Files\Example\app.exe",
+        RegistryPath = @"HKCR\*\shell\Example",
+        Location = "Files",
+        IsEnabled = enabled,
+    };
+
+    /// <summary>
+    /// A failed toggle WITHOUT admin rights offers to restart elevated, and says why.
+    /// </summary>
+    [Fact]
+    public async Task ToggleEntry_WhenItFailsAndNotElevated_OffersToRestartAsAdministrator()
+    {
+        using var notElevated = AdminHelper.ForceElevation(false);
+        var vm = NewVm(toggleSucceeds: false, out _);
+        var entry = NewEntry(enabled: false);   // the user just clicked it off
+
+        using var dialog = new DialogAnswer(false);   // declined, so nothing relaunches
+        await vm.ToggleEntryCommand.ExecuteAsync(entry);
+
+        Assert.Equal(1, dialog.Calls);
+        Assert.Contains(dialog.Messages, m => m.Contains("administrator", StringComparison.OrdinalIgnoreCase));
+        Assert.True(entry.IsEnabled, "a failed toggle must put the switch back where it was");
+    }
+
+    /// <summary>
+    /// A failed toggle WITH admin rights says the entry is Windows-owned, and does not offer a restart.
+    /// </summary>
+    /// <remarks>
+    /// This is the branch worth having. Elevating again cannot help against a TrustedInstaller-owned key,
+    /// so offering it would send the user round a loop that ends where it started — and getting the two
+    /// messages the wrong way round would do exactly that for every user, with nothing failing.
+    /// </remarks>
+    [Fact]
+    public async Task ToggleEntry_WhenItFailsWhileElevated_SaysWindowsOwnsItAndOffersNoRestart()
+    {
+        using var elevated = AdminHelper.ForceElevation(true);
+        var vm = NewVm(toggleSucceeds: false, out _);
+        var entry = NewEntry(enabled: false);
+
+        using var dialog = new DialogAnswer(true);   // would say yes if it were ever asked
+        await vm.ToggleEntryCommand.ExecuteAsync(entry);
+
+        Assert.Equal(0, dialog.Calls);
+        Assert.Contains("TrustedInstaller", vm.StatusMessage);
+        Assert.True(entry.IsEnabled, "a failed toggle must put the switch back where it was");
+    }
+
+    [Theory]
+    [InlineData(true, "enabled")]
+    [InlineData(false, "disabled")]
+    public async Task ToggleEntry_WhenItSucceeds_ReportsItAndDropsThePresetToCustom(
+        bool desiredState, string expectedWord)
+    {
+        var vm = NewVm(toggleSucceeds: true, out var service);
+        var entry = NewEntry(enabled: desiredState);
+
+        using var dialog = new DialogAnswer(false);
+        await vm.ToggleEntryCommand.ExecuteAsync(entry);
+
+        Assert.Equal(0, dialog.Calls);
+        Assert.Equal("custom", vm.ActivePresetId);
+        Assert.Contains(expectedWord, vm.StatusMessage, StringComparison.Ordinal);
+        Assert.Equal(desiredState, entry.IsEnabled);
+
+        // The direction matters: the command reads the switch's NEW position and asks the service to
+        // match it, so an inverted call would disable what the user just turned on.
+        if (desiredState) service.Received(1).EnableEntry(entry);
+        else service.Received(1).DisableEntry(entry);
+    }
+
+    [Fact]
+    public async Task ToggleEntry_WithSomethingThatIsNotAnEntry_DoesNothing()
+    {
+        var vm = NewVm(toggleSucceeds: false, out var service);
+
+        using var dialog = new DialogAnswer(true);
+        await vm.ToggleEntryCommand.ExecuteAsync("not an entry");
+
+        Assert.Equal(0, dialog.Calls);
+        service.DidNotReceive().EnableEntry(Arg.Any<ContextMenuEntry>());
+        service.DidNotReceive().DisableEntry(Arg.Any<ContextMenuEntry>());
     }
 }

--- a/SysManager/SysManager.Tests/DialogAnswer.cs
+++ b/SysManager/SysManager.Tests/DialogAnswer.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Collections.Concurrent;
 using NSubstitute;
 using SysManager.Services;
 
@@ -19,10 +20,18 @@ namespace SysManager.Tests;
 /// <see cref="Calls"/> exists so a test can prove a dialog was NOT shown — asserting on the
 /// side effect alone cannot tell "the user said yes" apart from "no gate ran at all".
 /// </para>
+/// <para>
+/// <see cref="Messages"/> exists because for some gates the WORDING is the behaviour. Context Menu
+/// explains a failed toggle two different ways depending on elevation, and the elevated one is the
+/// valuable half — it says the entry is owned by TrustedInstaller and elevating will not help, which is
+/// what stops a user restarting as administrator for nothing (#2180). Swapped, every user would take the
+/// useless path and a test that counted calls would still pass.
+/// </para>
 /// </summary>
 public sealed class DialogAnswer : IDisposable
 {
     private readonly IDialogService _previous;
+    private readonly ConcurrentQueue<string> _messages = new();
 
     /// <summary>
     /// Swaps in a substitute dialog service that always answers <paramref name="confirm"/>, keeping the
@@ -33,12 +42,28 @@ public sealed class DialogAnswer : IDisposable
     {
         _previous = DialogService.Instance;
         var fake = Substitute.For<IDialogService>();
-        fake.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(_ => { Calls++; return confirm; });
+        fake.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(call =>
+        {
+            Calls++;
+            _messages.Enqueue($"{call.ArgAt<string>(1)}\n{call.ArgAt<string>(0)}");
+            return confirm;
+        });
         DialogService.Instance = fake;
     }
 
     /// <summary>How many times a confirmation was actually requested.</summary>
     public int Calls { get; private set; }
+
+    /// <summary>
+    /// Every confirmation shown, as <c>"title\nmessage"</c>, in the order they were requested.
+    /// </summary>
+    /// <remarks>
+    /// Title and body joined rather than kept apart, because a caller asserting on wording wants to know
+    /// the text reached the user and does not care which half carried it. A
+    /// <see cref="ConcurrentQueue{T}"/> because a gate reached from an <c>await</c> continuation raises
+    /// this on a thread-pool thread, not the test's.
+    /// </remarks>
+    public IReadOnlyCollection<string> Messages => _messages;
 
     public void Dispose() => DialogService.Instance = _previous;
 }

--- a/SysManager/SysManager/ServiceRegistration.cs
+++ b/SysManager/SysManager/ServiceRegistration.cs
@@ -62,7 +62,7 @@ public static class ServiceRegistration
         services.AddSingleton<PrivacyService>();
         services.AddSingleton<DnsService>();
         services.AddSingleton<HostsFileService>();
-        services.AddSingleton<ContextMenuService>();
+        services.AddSingleton<IContextMenuService, ContextMenuService>();
         services.AddSingleton<EnvironmentVariableService>();
         services.AddSingleton<RestorePointService>();
         // Singleton on purpose: "one restore point per session" has to mean the whole app, or two

--- a/SysManager/SysManager/Services/ContextMenuService.cs
+++ b/SysManager/SysManager/Services/ContextMenuService.cs
@@ -20,7 +20,7 @@ namespace SysManager.Services;
 /// Windows Explorer respects this value to hide the menu entry without
 /// removing the registration — safe and fully reversible.
 /// </summary>
-public sealed partial class ContextMenuService
+public sealed partial class ContextMenuService : IContextMenuService
 {
     // Registry locations that define context menu entries
     private static readonly (string SubKey, string Location)[] ShellLocations =

--- a/SysManager/SysManager/Services/IContextMenuService.cs
+++ b/SysManager/SysManager/Services/IContextMenuService.cs
@@ -1,0 +1,42 @@
+// SysManager · IContextMenuService
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// Reads and toggles Windows Explorer shell-extension entries. Extracted as an interface so the view
+/// model's toggle path can be driven at all: without it a test could neither make a toggle FAIL on
+/// purpose nor let it succeed, because a real toggle writes shell keys on the machine running the suite
+/// — and on an elevated CI runner that write goes through (#2180, Gate-ARCH).
+/// </summary>
+/// <remarks>
+/// What that blocked was not merely coverage. When a toggle fails, the view model explains it two
+/// different ways depending on elevation, and the elevated one is the valuable half: it says the entry is
+/// owned by TrustedInstaller and no amount of elevating will help, which is what stops a user relaunching
+/// as administrator for nothing. Swapped, every user would take the useless path and nothing would fail.
+/// <para>Only the three instance members the view model reaches are here. The classic-menu and
+/// restart-Explorer operations stay static on <see cref="ContextMenuService"/>: the view model calls them
+/// through the type rather than through an injected instance, so putting them behind this seam would
+/// widen it without making anything newly testable.</para>
+/// </remarks>
+public interface IContextMenuService
+{
+    /// <summary>Scans the known registry shell locations for context-menu entries.</summary>
+    List<ContextMenuEntry> ScanEntries();
+
+    /// <summary>
+    /// Hides an entry by writing <c>LegacyDisable</c>, without deleting any registration.
+    /// Returns false when the key is missing or not writable — a TrustedInstaller-owned entry
+    /// fails here even when elevated.
+    /// </summary>
+    bool DisableEntry(ContextMenuEntry entry);
+
+    /// <summary>
+    /// Restores an entry by removing <c>LegacyDisable</c>. Returns false on the same conditions
+    /// as <see cref="DisableEntry"/>.
+    /// </summary>
+    bool EnableEntry(ContextMenuEntry entry);
+}

--- a/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
@@ -21,7 +21,7 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class ContextMenuViewModel : ViewModelBase
 {
-    private readonly ContextMenuService _service;
+    private readonly IContextMenuService _service;
     private List<ContextMenuEntry> _allEntries = [];
 
     public BulkObservableCollection<ContextMenuEntry> Entries { get; } = new();
@@ -43,7 +43,7 @@ public sealed partial class ContextMenuViewModel : ViewModelBase
         "All", "Files", "Folders", "Directory Background", "Desktop"
     };
 
-    public ContextMenuViewModel(ContextMenuService service)
+    public ContextMenuViewModel(IContextMenuService service)
     {
         _service = service;
         IsElevated = AdminHelper.IsElevated();

--- a/TESTING.md
+++ b/TESTING.md
@@ -165,8 +165,12 @@ collection definitions (all defined in `TestCollections.cs`, each with
   the previous instance on dispose, so a confirmation gate can be driven without a UI:
   `using var _ = new DialogAnswer(false);`. Its `Calls` counter lets a test assert a dialog was
   *not* shown — asserting the side effect alone cannot distinguish "the user said yes" from
-  "no gate ran at all". Requires `[Collection("ProcessWideStatics")]` on the test class — a fitness
-  function in `ArchitectureTests` fails the build if a class swaps a process-wide static without it.
+  "no gate ran at all". Its `Messages` collection carries the wording shown, for the gates where the
+  wording IS the behaviour: Context Menu explains a failed toggle one way without admin rights and
+  another way with them, and swapping those two would send every user down a path that cannot help
+  while a call count stayed green (#2180). Requires `[Collection("ProcessWideStatics")]` on the test
+  class — a fitness function in `ArchitectureTests` fails the build if a class swaps a process-wide
+  static without it.
 - `AdminHelper.ForceElevation(bool)` — pins what `AdminHelper.IsElevated()` answers for the scope's
   lifetime and restores the previous probe on dispose: `using var notElevated =
   AdminHelper.ForceElevation(false);`. **Construct the view-model inside the scope** — view-models read


### PR DESCRIPTION
Closes #2180, and with it the elevation exception list in `ArchitectureTests` is **empty** — which is what #2171 was actually asking for.

## What could not be tested

```csharp
public ContextMenuViewModel(ContextMenuService service)   // concrete
```

`ToggleEntryAsync` calls `EnableEntry` / `DisableEntry`, which write shell-extension keys. With no interface a test could neither make the call **fail** on purpose nor let it **succeed** — a real toggle changes a context-menu entry on the machine running the suite, and on an elevated CI runner that write goes through.

So the branch that matters was asserted nowhere. A failed toggle is explained two different ways:

| elevation | what the user sees |
|---|---|
| not elevated | a confirmation offering to restart as administrator |
| elevated | *"protected by Windows (owned by TrustedInstaller)"* — and **no** restart offer |

The elevated message is the valuable half: elevating again cannot help against a TrustedInstaller-owned key, so it stops the user going round a loop that ends where it started. Swap the two and every user takes the useless path, with nothing failing.

## The seam

`IContextMenuService` carries **only the three instance members the view model reaches** — `ScanEntries`, `DisableEntry`, `EnableEntry`. The classic-menu and restart-Explorer operations stay `static` on `ContextMenuService`, because the view model calls them through the type rather than an injected instance; putting them behind the seam would widen it without making anything newly testable.

Registration becomes interface-first (`AddSingleton<IContextMenuService, ContextMenuService>`), matching the shape the other fifteen already use. The default wiring resolves the same implementation it always did, so behaviour is unchanged.

## `DialogAnswer` gains `Messages`

For these gates the **wording is the behaviour**, and `Calls` alone cannot tell the two explanations apart — a swap would keep the count identical. The shared helper now records each confirmation's `"title\nmessage"`, rather than this file hand-rolling a second dialog substitute beside the one TESTING.md documents.

A `ConcurrentQueue`, because a gate reached from an `await` continuation raises it on a thread-pool thread rather than the test's.

## The tests

Six new cases, none of which touch the registry — the substitute decides every outcome:

- failed toggle, **not** elevated → the confirmation IS shown and its text says administrator
- failed toggle, **elevated** → the status names TrustedInstaller and **no** dialog is shown at all
- successful toggle (×2, both directions) → the preset drops to `custom`, the status uses the right word, and **the service received the call matching the switch's new position** — an inverted call would disable what the user just turned on
- a parameter that is not an entry → nothing is called and nothing is asked

The pre-existing tests in that class deliberately keep the **real** service: they assert state derived from an actual scan, which a substitute returning an empty list would make vacuous.

## The exception list is empty now

```csharp
// EMPTY, and that is the point. It held one entry — ContextMenuViewModel, whose concrete
// ContextMenuService could not be substituted …
var cannotBePinnedYet = new Dictionary<string, string>(StringComparer.Ordinal);
```

#2171 asked for the guard to land with an empty list and I landed it with one entry, stated plainly at the time: holding the guard back for a single blocked row would have left the other nine unprotected while this waited. The entry is now gone rather than reworded, and R5 below proves the row it excused is genuinely under the guard.

## Verification

Five mutations, five reds, restore hash-checked byte-for-byte, final state green:

```
R1  the two failure branches swap places          RED  both failure tests
R2  the toggle asks for the wrong direction       RED  the success theory, on Received(1)
R3  a successful toggle stops dropping to custom  RED  the success theory
R4  a failed toggle stops restoring the switch    RED  both failure tests
R5  the tests stop pinning elevation              RED  "ContextMenuViewModel (1 cached + 0 call-time
                                                        branch(es)) — ContextMenuViewModelTests.cs"
```

Every mutation is safe to run under, which is the change being proved: with the seam in place no amount of inverting the toggle logic can reach the registry.

R5 has to remove **both** `ForceElevation` scopes, because the guard greps the whole comment-stripped file and one remaining use keeps the view model pinned. That also makes the elevated test host-dependent, so its red has two causes — which is itself the finding. The proof therefore requires the guard's own failure line in the output rather than accepting any red.

All four projects: 0 errors, 0 warnings. Locally green: the guard suite plus all four Context Menu classes (246 cases), and every class that uses `DialogAnswer` (281) since the helper changed. Full suite is CI's blocking gate.

## Docs

- ARCHITECTURE.md — the interface list gains `IContextMenuService`, and the count is re-derived from `ServiceRegistration.cs` (15, not "fourteen plus one").
- TESTING.md — `DialogAnswer`'s entry explains `Messages` and why wording needed its own assertion.

## Notes

- `refactor:` — behaviour identical, so no release, no version bump, no CHANGELOG entry.

Closes #2180
