### PR TITLE
refactor: give Deep Cleanup's scan its roots, so its logic can be asserted at all

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -162,7 +162,7 @@ constructor-injected: `IPowerShellRunner` (PowerShellRunner), `IWingetService` (
 `ITweaksHubService`, `IWindowsThemeService`, `IAudioMixerService`, `IGamingProfileService`, and
 `ISessionRestorePoint` (the last two via a factory).
 
-Two further seams exist but are reached differently, so grepping `ServiceRegistration.cs` for them
+Three further seams exist but are reached differently, so grepping `ServiceRegistration.cs` for them
 finds nothing:
 
 - `IDialogService` — consumed through the static `DialogService.Instance`, which tests swap for a
@@ -171,6 +171,13 @@ finds nothing:
 - `IBandwidthMonitorService` — the one seam with two shipping implementations
   (`ConnectionBandwidthSource` and `EtwBandwidthSource`), injected as factories so the Bandwidth
   Monitor can switch source at runtime. See the sources note further down.
+- `ICleanupRoots` — the directories Deep Cleanup's scan is built from, taken by
+  `DeepCleanupService`'s second constructor with `SystemCleanupRoots` as the parameterless default, so
+  `AddSingleton<DeepCleanupService>()` needs no change. It exists because the scan read
+  `Environment.GetFolderPath` and `DriveInfo.GetDrives()` inline, which left its logic assertable only
+  as "the size is non-negative"; with the roots injected a test points it at a tree it built and asserts
+  exact counts, the 30-day cutoff and which categories arrive pre-selected. A fitness function keeps the
+  machine reads out of the service.
 
 Key services:
 - `PingMonitorService` / `TracerouteService` / `TracerouteMonitorService` —

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -9340,4 +9340,60 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"\.(?:Add|Push|Enqueue)\s*\(", RegexOptions.CultureInvariant)]
     private static partial Regex CollectionAppend();
 
+    /// <summary>
+    /// Deep Cleanup's scan must take its roots from <c>ICleanupRoots</c> rather than asking the machine,
+    /// or its logic stops being assertable again.
+    /// </summary>
+    /// <remarks>
+    /// <c>ScanAsync</c> used to read <c>Environment.GetFolderPath</c> for five special folders and
+    /// <c>DriveInfo.GetDrives()</c> in three launcher probes, with no way to redirect any of it — so a test
+    /// could only check shapes that hold on any machine, and those pass for reasons nobody chose (#2176).
+    /// A single re-added call would quietly restore that, on one category, and every existing test would
+    /// stay green because none of them can see where the scan looked.
+    /// <para><b>This is the check that would have caught the gap the first attempt left.</b> The seam
+    /// covered the special folders and the drive probes but not <c>RecycleBinHelper.CurrentUserBinPaths()</c>,
+    /// which is also inside the definitions — so the eleven "deterministic" scan tests still walked the real
+    /// Recycle Bin on every drive and took 48 seconds instead of 0.2. Nothing failed; only the clock said
+    /// so.</para>
+    /// <para>Flat greps over the whole comment-stripped file rather than a slice of the scan methods,
+    /// because a guard that slices source between markers passes vacuously the moment a marker moves.
+    /// <c>RecycleBinHelper.EmptyAllDrives</c> is deliberately NOT banned: it is the shell call that empties
+    /// the bin, it lives on the clean side, and <c>CleanAsync</c> is already testable because it is handed
+    /// the paths it acts on.</para>
+    /// </remarks>
+    [Fact]
+    public void DeepCleanupsScan_TakesItsRootsFromTheSeam()
+    {
+        var path = Path.Combine(FindAppProjectDir(), "Services", "DeepCleanupService.cs");
+        Assert.True(File.Exists(path), $"DeepCleanupService.cs was not found at {path}");
+        var source = WithoutComments(File.ReadAllText(path));
+
+        // Floor: the file must still be the scanner this guard was written about. A rewrite that moved the
+        // definitions elsewhere would otherwise pass here while checking nothing.
+        Assert.True(source.Contains("ICleanupRoots", StringComparison.Ordinal),
+            "DeepCleanupService no longer mentions ICleanupRoots — if the seam was removed or renamed, "
+            + "this guard is checking nothing and must be updated with it.");
+
+        var banned = new (string Call, string Instead)[]
+        {
+            ("Environment.GetFolderPath", "one of ICleanupRoots' folder properties"),
+            ("Environment.SystemDirectory", "ICleanupRoots.SystemDrive"),
+            ("DriveInfo.GetDrives", "ICleanupRoots.FixedDriveRoots"),
+            ("RecycleBinHelper.CurrentUserBinPaths", "ICleanupRoots.RecycleBinPaths"),
+            ("Path.GetTempPath", "ICleanupRoots.UserTemp"),
+        };
+
+        var offenders = banned
+            .Where(b => source.Contains(b.Call, StringComparison.Ordinal))
+            .Select(b => $"{b.Call} — use {b.Instead}")
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "DeepCleanupService's scan reads the machine directly again. Every one of these has a property "
+            + "on ICleanupRoots, and using the property is what lets a test point the scan at a tree it "
+            + "built — without it the scan's file counts, byte totals and age cutoff can only be asserted "
+            + "as \"non-negative\":\n  "
+            + string.Join("\n  ", offenders));
+    }
+
 }

--- a/SysManager/SysManager.Tests/DeepCleanupScanLogicTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupScanLogicTests.cs
@@ -1,0 +1,278 @@
+// SysManager · DeepCleanupScanLogicTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// What Deep Cleanup's scan DECIDES, asserted against a tree the test builds — exact file counts, exact
+/// byte totals, the age cutoff, which categories arrive pre-selected.
+/// </summary>
+/// <remarks>
+/// None of this was assertable before <see cref="ICleanupRoots"/> (#2176). The scan read
+/// <c>Environment.GetFolderPath</c> and <c>DriveInfo.GetDrives()</c> directly, so a test could only check
+/// shapes that hold on any machine — the name is non-empty, the size is non-negative — which pass for
+/// reasons nobody chose, and pass over almost-empty caches on a fresh CI runner while a real workstation
+/// has unpredictable content in them.
+/// <para>Everything below a root is still the real filesystem. The seam redirects WHERE the scan looks,
+/// not HOW it reads, so size aggregation, the age cutoff and reparse-point skipping are exercised against
+/// real directories rather than a fake — which is the whole reason the seam is the roots and not an
+/// <c>IFileSystem</c>.</para>
+/// <para>Category names are quoted from the definitions on purpose. If one is renamed, these fail loudly
+/// with "no category named X" rather than silently asserting over an empty list, which is the failure mode
+/// the shared-scan tests have by construction.</para>
+/// </remarks>
+public sealed class DeepCleanupScanLogicTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "SysManagerScanRoots", Guid.NewGuid().ToString("N"));
+
+    public DeepCleanupScanLogicTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); }
+        catch (IOException) { /* a leftover temp tree under %TEMP% is harmless */ }
+        catch (UnauthorizedAccessException) { /* ditto */ }
+    }
+
+    /// <summary>
+    /// Every root pointed inside one temp tree, in its own subfolder so a category cannot pick up files
+    /// planted for another.
+    /// </summary>
+    private sealed class TempRoots(string root) : ICleanupRoots
+    {
+        public string LocalAppData { get; } = Sub(root, "LocalAppData");
+        public string ProgramData { get; } = Sub(root, "ProgramData");
+        public string SystemDrive { get; } = Sub(root, "SystemDrive");
+        public string WindowsDirectory { get; } = Sub(root, "Windows");
+        public string UserTemp { get; } = Sub(root, "Temp");
+        public string ProgramFilesX86 { get; } = Sub(root, "ProgramFilesX86");
+        public string ProgramFiles { get; } = Sub(root, "ProgramFiles");
+
+        /// <summary>Empty: a real drive root here would put the launcher probes back on the machine.</summary>
+        public IReadOnlyList<string> FixedDriveRoots { get; } = [];
+
+        /// <summary>Empty: the real bins are what made these tests take 48 seconds instead of one.</summary>
+        public IReadOnlyList<string> RecycleBinPaths { get; } = [];
+
+        private static string Sub(string root, string name)
+        {
+            var path = Path.Combine(root, name);
+            Directory.CreateDirectory(path);
+            return path;
+        }
+    }
+
+    private TempRoots Roots() => new(_root);
+
+    private static void WriteFile(string path, int bytes)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllBytes(path, new byte[bytes]);
+    }
+
+    private static CleanupCategory Named(IReadOnlyList<CleanupCategory> categories, string name)
+    {
+        var found = categories.FirstOrDefault(c => c.Name == name);
+        Assert.NotNull(found);   // renamed or removed — fix this test rather than letting it assert nothing
+        return found!;
+    }
+
+    // ── Sizes and counts ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Scan_ReportsTheExactFileCountAndByteTotal()
+    {
+        var roots = Roots();
+        var amd = Path.Combine(roots.SystemDrive, "AMD");
+        WriteFile(Path.Combine(amd, "a.bin"), 10);
+        WriteFile(Path.Combine(amd, "b.bin"), 10);
+        WriteFile(Path.Combine(amd, "nested", "c.bin"), 10);
+
+        var categories = await new DeepCleanupService(roots).ScanAsync();
+
+        var category = Named(categories, "AMD installer leftovers");
+        Assert.Equal(3, category.FileCount);
+        Assert.Equal(30, category.TotalSizeBytes);
+        Assert.Equal(0, category.SkippedCount);
+    }
+
+    [Fact]
+    public async Task Scan_WithContent_PreSelectsTheCategory()
+    {
+        var roots = Roots();
+        WriteFile(Path.Combine(roots.SystemDrive, "AMD", "a.bin"), 1);
+
+        var categories = await new DeepCleanupService(roots).ScanAsync();
+
+        Assert.True(Named(categories, "AMD installer leftovers").IsSelected);
+    }
+
+    /// <summary>
+    /// An empty folder is still reported, and must NOT arrive ticked — a "clean 0 bytes" run tells the
+    /// user nothing happened for a reason they cannot see.
+    /// </summary>
+    [Fact]
+    public async Task Scan_WithAnEmptyFolder_ReportsZeroAndDoesNotSelectIt()
+    {
+        var roots = Roots();
+        Directory.CreateDirectory(Path.Combine(roots.SystemDrive, "Intel"));
+
+        var categories = await new DeepCleanupService(roots).ScanAsync();
+
+        var category = Named(categories, "Intel driver extracts");
+        Assert.Equal(0, category.FileCount);
+        Assert.Equal(0, category.TotalSizeBytes);
+        Assert.False(category.IsSelected);
+    }
+
+    [Fact]
+    public async Task Scan_WithNoFolderAtAll_ReportsNoPaths()
+    {
+        var categories = await new DeepCleanupService(Roots()).ScanAsync();
+
+        Assert.Empty(Named(categories, "Intel driver extracts").Paths);
+    }
+
+    // ── The age cutoff ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The servicing-logs category counts only files older than thirty days, and the boundary is what a
+    /// test has to pin: an off-by-one in the comparison would either keep everything or delete a log
+    /// Windows is still rolling.
+    /// </summary>
+    /// <remarks>
+    /// <b>The two files are deliberately different sizes.</b> With both at 100 bytes this test passed
+    /// against an INVERTED comparison — one file either way, 100 bytes either way — so it asserted that
+    /// exactly one file was counted without asserting which. Distinct sizes make the byte total name the
+    /// file, and the mutation that swapped the comparison then fails. Found by the proof, not by review.
+    /// </remarks>
+    [Fact]
+    public async Task Scan_WithAnAgeCutoff_CountsOnlyWhatIsOlderThanIt()
+    {
+        var roots = Roots();
+        var cbs = Path.Combine(roots.WindowsDirectory, "Logs", "CBS");
+        var old = Path.Combine(cbs, "old.log");
+        var young = Path.Combine(cbs, "young.log");
+        WriteFile(old, 100);
+        WriteFile(young, 7);
+        File.SetLastWriteTimeUtc(old, DateTime.UtcNow - TimeSpan.FromDays(31));
+        File.SetLastWriteTimeUtc(young, DateTime.UtcNow - TimeSpan.FromDays(29));
+
+        var categories = await new DeepCleanupService(roots).ScanAsync();
+
+        var category = Named(categories, "Old Windows servicing logs (> 30 days)");
+        Assert.Equal(1, category.FileCount);
+        Assert.Equal(100, category.TotalSizeBytes);   // 7 would mean it kept the young one instead
+        Assert.Equal(TimeSpan.FromDays(30), category.OlderThan);
+    }
+
+    // ── Windows.old ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Windows.old appears only when it exists, and never arrives ticked however much it holds — it is
+    /// the user's way back to their previous Windows, so pre-selecting it would let one click destroy
+    /// the rollback.
+    /// </summary>
+    [Fact]
+    public async Task Scan_WithWindowsOld_OffersItButNeverPreSelectsIt()
+    {
+        var roots = Roots();
+        WriteFile(Path.Combine(roots.SystemDrive, "Windows.old", "big.bin"), 5000);
+
+        var categories = await new DeepCleanupService(roots).ScanAsync();
+
+        var category = Named(categories, "Windows.old (previous Windows installation)");
+        Assert.Equal(5000, category.TotalSizeBytes);
+        Assert.True(category.IsDestructiveHint);
+        Assert.False(category.IsSelected, "pre-ticking this would let one click destroy the rollback");
+    }
+
+    [Fact]
+    public async Task Scan_WithoutWindowsOld_DoesNotOfferIt()
+    {
+        var categories = await new DeepCleanupService(Roots()).ScanAsync();
+
+        Assert.DoesNotContain(categories, c => c.Name.Contains("Windows.old", StringComparison.Ordinal));
+    }
+
+    // ── Progress ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Scan_ReportsProgressForEveryCategoryAndFinishesOnDone()
+    {
+        var roots = Roots();
+        var progress = new SyncProgress<DeepCleanupService.ScanProgress>();
+
+        var categories = await new DeepCleanupService(roots).ScanAsync(progress);
+
+        Assert.NotEmpty(progress.Reports);
+        Assert.Equal("Done", progress.Reports[^1].CategoryName);
+        Assert.Equal(progress.Reports[^1].Total, progress.Reports[^1].Current);
+
+        // One report per category plus the final "Done": a bar that stops short of its own total reads
+        // as a stalled scan.
+        Assert.Equal(categories.Count + 1, progress.Reports.Count);
+    }
+
+    // ── Cancellation ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A cancelled scan throws rather than returning what it had. Returning partial results would let the
+    /// caller show a success toast for a scan the user stopped.
+    /// </summary>
+    [Fact]
+    public async Task Scan_WhenCancelledBeforeItStarts_Throws()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => new DeepCleanupService(Roots()).ScanAsync(ct: cts.Token));
+    }
+
+    // ── Guarding the seam itself ─────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithoutRoots_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new DeepCleanupService(null!));
+
+    /// <summary>
+    /// The default roots are the values the scan read inline before the seam existed, so production
+    /// behaviour is unchanged by construction rather than by inspection.
+    /// </summary>
+    /// <remarks>
+    /// <c>FixedDriveRoots</c> is asserted to be read FRESH rather than cached, because
+    /// <c>DeepCleanupService</c> is a DI singleton built once at startup: caching would freeze the drive
+    /// list for the whole session, so a drive plugged in afterwards would silently stop being scanned.
+    /// That is the one member where the obvious implementation is the wrong one.
+    /// </remarks>
+    [Fact]
+    public void SystemCleanupRoots_MatchesWhatTheScanUsedToReadInline()
+    {
+        var roots = new SystemCleanupRoots();
+
+        Assert.Equal(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), roots.LocalAppData);
+        Assert.Equal(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), roots.ProgramData);
+        Assert.Equal(Path.GetPathRoot(Environment.SystemDirectory) ?? @"C:\", roots.SystemDrive);
+        Assert.Equal(Environment.GetFolderPath(Environment.SpecialFolder.Windows), roots.WindowsDirectory);
+        Assert.Equal(Path.GetTempPath(), roots.UserTemp);
+        Assert.Equal(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), roots.ProgramFilesX86);
+        Assert.Equal(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), roots.ProgramFiles);
+
+        var expected = DriveInfo.GetDrives()
+            .Where(d => d.DriveType == DriveType.Fixed && d.IsReady)
+            .Select(d => d.RootDirectory.FullName);
+        Assert.Equal(expected, roots.FixedDriveRoots);
+        Assert.Equal(RecycleBinHelper.CurrentUserBinPaths(), roots.RecycleBinPaths);
+
+        Assert.NotSame(roots.FixedDriveRoots, roots.FixedDriveRoots);
+        Assert.NotSame(roots.RecycleBinPaths, roots.RecycleBinPaths);
+    }
+}

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -19,12 +19,32 @@ namespace SysManager.Services;
 /// </summary>
 public sealed class DeepCleanupService
 {
+    private readonly ICleanupRoots _roots;
+
+    /// <summary>
+    /// Builds a service that scans the real machine.
+    /// </summary>
+    public DeepCleanupService() : this(new SystemCleanupRoots())
+    {
+    }
+
+    /// <summary>
+    /// Builds a service that scans <paramref name="roots"/>, so a test can supply a tree it owns.
+    /// </summary>
+    /// <remarks>
+    /// The parameterless overload above is what production uses, and it passes the same roots the service
+    /// read inline before this seam existed — so the default behaviour is unchanged by construction
+    /// rather than by inspection (#2176).
+    /// </remarks>
+    public DeepCleanupService(ICleanupRoots roots)
+        => _roots = roots ?? throw new ArgumentNullException(nameof(roots));
+
     public sealed record ScanProgress(int Current, int Total, string CategoryName);
 
     public Task<IReadOnlyList<CleanupCategory>> ScanAsync(
         IProgress<ScanProgress>? progress = null,
         CancellationToken ct = default)
-        => Task.Run(() => Scan(progress, ct), ct);
+        => Task.Run(() => Scan(_roots, progress, ct), ct);
 
     public Task<CleanupResult> CleanAsync(
         IReadOnlyList<CleanupCategory> categories,
@@ -42,15 +62,15 @@ public sealed class DeepCleanupService
         bool IsDestructiveHint = false,
         bool IsRecycleBin = false);
 
-    private static List<Def> BuildDefinitions()
+    private static List<Def> BuildDefinitions(ICleanupRoots roots)
     {
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-        var systemDrive = Path.GetPathRoot(Environment.SystemDirectory) ?? @"C:\";
-        var windowsDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
-        var tempUser = Path.GetTempPath();
-        var pfx86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
-        var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        var localAppData = roots.LocalAppData;
+        var programData = roots.ProgramData;
+        var systemDrive = roots.SystemDrive;
+        var windowsDir = roots.WindowsDirectory;
+        var tempUser = roots.UserTemp;
+        var pfx86 = roots.ProgramFilesX86;
+        var pf = roots.ProgramFiles;
 
         var defs = new List<Def>
         {
@@ -116,16 +136,16 @@ public sealed class DeepCleanupService
 
             new("Recycle Bin (all drives)",
                 "Emptying the recycle bin on every fixed drive.",
-                RecycleBinHelper.CurrentUserBinPaths(),
+                [.. roots.RecycleBinPaths],
                 IsRecycleBin: true),
 
             new("Steam — browser & depot cache",
                 "Steam web browser cache, HTML cache, app cache and depot lookup cache. Doesn't touch game files, downloads or logins.",
-                SteamCacheDirs(pfx86, pf, localAppData)),
+                SteamCacheDirs(roots)),
 
             new("Steam — shader cache",
                 "Per-game shader cache under steamapps\\shadercache. Rebuilt on next launch — clearing can fix stutter or shader corruption.",
-                SteamShaderCacheDirs(pfx86, pf)),
+                SteamShaderCacheDirs(roots)),
 
             new("Epic Games Launcher — webcache & logs",
                 "Epic Launcher browser webcache and log files. Doesn't affect your Epic login or installed games.",
@@ -147,7 +167,7 @@ public sealed class DeepCleanupService
 
             new("Riot Client / League of Legends — logs",
                 "Riot Client and League client logs only. No game files or credentials.",
-                RiotLogDirs(localAppData, pfx86, pf)),
+                RiotLogDirs(roots)),
 
             new("GOG Galaxy — cache",
                 "GOG Galaxy launcher webcache and redists installer cache.",
@@ -182,9 +202,10 @@ public sealed class DeepCleanupService
 
     // ---------- scanning ----------
 
-    private static IReadOnlyList<CleanupCategory> Scan(IProgress<ScanProgress>? progress, CancellationToken ct)
+    private static IReadOnlyList<CleanupCategory> Scan(
+        ICleanupRoots roots, IProgress<ScanProgress>? progress, CancellationToken ct)
     {
-        var defs = BuildDefinitions();
+        var defs = BuildDefinitions(roots);
         var results = new List<CleanupCategory>(defs.Count);
         var total = defs.Count;
 
@@ -253,43 +274,43 @@ public sealed class DeepCleanupService
 
     // ---------- launcher roots ----------
 
-    private static string[] SteamRoots(string pfx86, string pf)
+    private static string[] SteamRoots(ICleanupRoots roots)
     {
-        List<string> roots =
+        List<string> found =
         [
-            Path.Combine(pfx86, "Steam"),
-            Path.Combine(pf, "Steam"),
+            Path.Combine(roots.ProgramFilesX86, "Steam"),
+            Path.Combine(roots.ProgramFiles, "Steam"),
         ];
-        foreach (var drive in DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.Fixed && d.IsReady))
+        foreach (var driveRoot in roots.FixedDriveRoots)
         {
-            var candidate = Path.Combine(drive.RootDirectory.FullName, "Steam");
-            if (Directory.Exists(candidate)) roots.Add(candidate);
+            var candidate = Path.Combine(driveRoot, "Steam");
+            if (Directory.Exists(candidate)) found.Add(candidate);
         }
-        return roots.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        return found.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
     }
 
-    private static string[] SteamCacheDirs(string pfx86, string pf, string localAppData)
+    private static string[] SteamCacheDirs(ICleanupRoots roots)
     {
         List<string> result = [];
-        foreach (var root in SteamRoots(pfx86, pf))
+        foreach (var root in SteamRoots(roots))
         {
             result.Add(Path.Combine(root, "appcache"));
             result.Add(Path.Combine(root, "htmlcache"));
             result.Add(Path.Combine(root, "depotcache"));
             result.Add(Path.Combine(root, "logs"));
         }
-        result.Add(Path.Combine(localAppData, "Steam", "htmlcache"));
+        result.Add(Path.Combine(roots.LocalAppData, "Steam", "htmlcache"));
         return result.ToArray();
     }
 
-    private static string[] SteamShaderCacheDirs(string pfx86, string pf)
+    private static string[] SteamShaderCacheDirs(ICleanupRoots roots)
     {
         List<string> result = [];
-        foreach (var root in SteamRoots(pfx86, pf))
+        foreach (var root in SteamRoots(roots))
             result.Add(Path.Combine(root, "steamapps", "shadercache"));
-        foreach (var drive in DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.Fixed && d.IsReady))
+        foreach (var driveRoot in roots.FixedDriveRoots)
         {
-            var candidate = Path.Combine(drive.RootDirectory.FullName, "SteamLibrary", "steamapps", "shadercache");
+            var candidate = Path.Combine(driveRoot, "SteamLibrary", "steamapps", "shadercache");
             if (Directory.Exists(candidate)) result.Add(candidate);
         }
         return result.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
@@ -299,17 +320,17 @@ public sealed class DeepCleanupService
     /// Riot Client logs are in %LOCALAPPDATA%, but League of Legends can be
     /// installed on any drive. Scan all fixed drives for Riot Games folders.
     /// </summary>
-    private static string[] RiotLogDirs(string localAppData, string pfx86, string pf)
+    private static string[] RiotLogDirs(ICleanupRoots roots)
     {
         var result = new List<string>
         {
-            Path.Join(localAppData, "Riot Games", "Riot Client", "Logs"),
-            Path.Join(pfx86, "Riot Games", "League of Legends", "Logs"),
-            Path.Join(pf, "Riot Games", "League of Legends", "Logs"),
+            Path.Join(roots.LocalAppData, "Riot Games", "Riot Client", "Logs"),
+            Path.Join(roots.ProgramFilesX86, "Riot Games", "League of Legends", "Logs"),
+            Path.Join(roots.ProgramFiles, "Riot Games", "League of Legends", "Logs"),
         };
-        foreach (var drive in DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.Fixed && d.IsReady))
+        foreach (var driveRoot in roots.FixedDriveRoots)
         {
-            var candidate = Path.Join(drive.RootDirectory.FullName, "Riot Games", "League of Legends", "Logs");
+            var candidate = Path.Join(driveRoot, "Riot Games", "League of Legends", "Logs");
             result.Add(candidate);
         }
         return result.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();

--- a/SysManager/SysManager/Services/ICleanupRoots.cs
+++ b/SysManager/SysManager/Services/ICleanupRoots.cs
@@ -1,0 +1,121 @@
+// SysManager · ICleanupRoots
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Helpers;
+
+namespace SysManager.Services;
+
+/// <summary>
+/// The directories Deep Cleanup's scan is built from. Injected so a test can point the scan at a tree
+/// it created itself, instead of at whatever happens to be on the machine running the suite (#2176).
+/// </summary>
+/// <remarks>
+/// <see cref="DeepCleanupService"/> asked the machine directly — <c>Environment.GetFolderPath</c> for
+/// five special folders and <c>DriveInfo.GetDrives()</c> for the launcher probes — with no parameter to
+/// redirect any of it. So its LOGIC was unassertable: a test could not say "a category over a folder
+/// holding 3 files of 10 bytes reports 3 files and 30 bytes", because it could not create that folder
+/// anywhere the scan would look. What was left were shapes that hold on any machine (the name is
+/// non-empty, the size is non-negative), which pass for reasons nobody chose — and pass differently on a
+/// fresh CI runner, where those caches are nearly all empty, than on a real workstation.
+/// <para>Deliberately the ROOTS and not a filesystem abstraction. <c>CleanAsync</c> already takes the
+/// paths it operates on, which is why its tests build real temp trees today and are the strongest in the
+/// file. This gives <c>ScanAsync</c> the same property with the smallest possible seam: everything below
+/// a root is still the real <see cref="System.IO.Directory"/>, so junction skipping, permission failures
+/// and size aggregation are exercised for real rather than against a fake.</para>
+/// </remarks>
+public interface ICleanupRoots
+{
+    /// <summary><c>%LOCALAPPDATA%</c>.</summary>
+    string LocalAppData { get; }
+
+    /// <summary><c>%PROGRAMDATA%</c>.</summary>
+    string ProgramData { get; }
+
+    /// <summary>The drive the OS is installed on, with a trailing separator — e.g. <c>C:\</c>.</summary>
+    string SystemDrive { get; }
+
+    /// <summary>The Windows directory.</summary>
+    string WindowsDirectory { get; }
+
+    /// <summary>The per-user temp directory.</summary>
+    string UserTemp { get; }
+
+    /// <summary><c>%PROGRAMFILES(X86)%</c>.</summary>
+    string ProgramFilesX86 { get; }
+
+    /// <summary><c>%PROGRAMFILES%</c>.</summary>
+    string ProgramFiles { get; }
+
+    /// <summary>
+    /// Roots of the fixed, ready drives, used to find game launchers installed off the system drive.
+    /// </summary>
+    /// <remarks>
+    /// A property rather than a call to <c>DriveInfo.GetDrives()</c> at each use site: the Steam,
+    /// shader-cache and Riot probes each enumerated drives separately, so a test that redirected only the
+    /// special folders would still have walked the machine's real drive roots three times.
+    /// <para>Read fresh each time by the real implementation, because the service that consumes it is a
+    /// DI singleton — see <see cref="SystemCleanupRoots.FixedDriveRoots"/>.</para>
+    /// </remarks>
+    IReadOnlyList<string> FixedDriveRoots { get; }
+
+    /// <summary>
+    /// The current user's Recycle Bin folders, one per fixed drive.
+    /// </summary>
+    /// <remarks>
+    /// Behind the seam for the same reason as the rest, and the omission was measurable rather than
+    /// theoretical: with only the special folders redirected, the eleven deterministic scan tests took 48
+    /// seconds, because every one of them still walked the real Recycle Bin on every drive of the machine
+    /// running them. A "deterministic" test whose result depends on what is in the bin is not one.
+    /// </remarks>
+    IReadOnlyList<string> RecycleBinPaths { get; }
+}
+
+/// <summary>
+/// The real machine's roots — exactly what <see cref="DeepCleanupService"/> read inline before the seam
+/// existed, so the parameterless constructor behaves identically.
+/// </summary>
+public sealed class SystemCleanupRoots : ICleanupRoots
+{
+    public string LocalAppData { get; } =
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+    public string ProgramData { get; } =
+        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+
+    /// <summary>The drive the OS is installed on, with a trailing separator.</summary>
+    /// <remarks>
+    /// Derived from <c>Environment.SystemDirectory</c> rather than from <c>%SYSTEMDRIVE%</c>, and the
+    /// <c>C:\</c> fallback is kept: <see cref="Path.GetPathRoot(string)"/> is documented as nullable and a
+    /// null here would put every driver-leftover path at a relative location.
+    /// </remarks>
+    public string SystemDrive { get; } = Path.GetPathRoot(Environment.SystemDirectory) ?? @"C:\";
+
+    public string WindowsDirectory { get; } =
+        Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+
+    public string UserTemp { get; } = Path.GetTempPath();
+
+    public string ProgramFilesX86 { get; } =
+        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+
+    public string ProgramFiles { get; } =
+        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+
+    /// <summary>Roots of the fixed, ready drives, read from the machine.</summary>
+    /// <remarks>
+    /// Enumerated on every read, NOT cached in the constructor. <c>DeepCleanupService</c> is a DI
+    /// singleton built once at startup, so caching here would freeze the drive list for the whole
+    /// session — a drive plugged in or made ready afterwards would stop being scanned until restart.
+    /// Every other member is a genuine constant for the process lifetime and is cached; this one is not.
+    /// </remarks>
+    public IReadOnlyList<string> FixedDriveRoots =>
+        [.. DriveInfo.GetDrives()
+            .Where(d => d.DriveType == DriveType.Fixed && d.IsReady)
+            .Select(d => d.RootDirectory.FullName)];
+
+    /// <summary>The current user's Recycle Bin folders, read from the machine.</summary>
+    /// <remarks>Read fresh for the same reason as <see cref="FixedDriveRoots"/> — it enumerates drives.</remarks>
+    public IReadOnlyList<string> RecycleBinPaths => RecycleBinHelper.CurrentUserBinPaths();
+}


### PR DESCRIPTION
First half of #2176: the seam and the tests it makes possible. The second half — what to do with the 39-case class that still performs one real machine scan — is left open deliberately, with the measurements to decide it. See the last section.

## What could not be tested

`ScanAsync` decided what to clean by asking the machine:

| what it read | for |
|---|---|
| `Environment.GetFolderPath` ×5 | LocalAppData, ProgramData, Windows, ProgramFiles, ProgramFiles(x86) |
| `Environment.SystemDirectory` | the system drive, for the driver-leftover folders |
| `Path.GetTempPath` | the user temp category |
| `DriveInfo.GetDrives()` ×3 | Steam, shader-cache and Riot probes, separately |
| `RecycleBinHelper.CurrentUserBinPaths()` | the Recycle Bin category |

No parameter, interface or constructor argument redirected any of it. So the assertions could only be shapes that hold on any machine — *the name is non-empty, the size is non-negative, the list contains something matching "Recycle"* — and those pass for reasons nobody chose. A fresh `windows-latest` runner has almost nothing in those caches; a real workstation has content, but unpredictable content. Neither asserted much and they asserted different things.

A test could not say *"a category over a folder holding 3 files of 10 bytes reports 3 files and 30 bytes"*, because it could not create that folder anywhere the scan would look.

## The seam

`ICleanupRoots`, taken by a second constructor with `SystemCleanupRoots` as the parameterless default — so `AddSingleton<DeepCleanupService>()` and the design-time graph are untouched, and the default behaviour is unchanged **by construction** rather than by inspection.

**Deliberately the roots, not a filesystem abstraction.** Everything below a root is still the real `Directory`, so size aggregation, the 30-day cutoff and reparse-point skipping are exercised against real directories rather than a fake. `CleanAsync` already takes the paths it operates on — which is exactly why its tests build real temp trees and are the strongest in the file. This gives `ScanAsync` the same property.

## The tests

Eleven cases in `SysManager.Tests`, each over a tree the test builds:

- exact file count **and** byte total, including from a nested folder
- the age cutoff keeps the file 31 days old and drops the one 29 days old
- `Windows.old` is offered only when it exists, and never pre-selected however large — pre-ticking it would let one click destroy the user's rollback
- an empty category is reported with zero and **not** pre-selected
- a category whose folder does not exist reports no paths
- one progress report per category, ending on `Done` with `Current == Total`
- a cancelled scan throws rather than returning partial results
- `SystemCleanupRoots` returns what the scan used to read inline, member by member

Category names are quoted from the definitions on purpose: a rename fails with *"no category named X"* rather than silently asserting over an empty list.

## Two things the work turned up

**The recycle bin escaped the first version of the seam, and the clock is what caught it.** With only the special folders and drive probes redirected, the eleven tests took **48.594s** — because every one of them still walked the real Recycle Bin on every drive of the machine. Behind the seam they take **0.204s**, a 238× difference. Nothing failed; only the timing said so. That is why the guard below exists.

**`FixedDriveRoots` must be read fresh, not cached in the constructor.** `DeepCleanupService` is registered `AddSingleton`, built once at startup — so caching the drive list would freeze it for the whole session, and a drive plugged in or made ready afterwards would silently stop being scanned. Every other member is a genuine process-lifetime constant and is cached; these two are not. My first version cached it, and a remark claiming "the service is constructed per scan" was simply wrong.

## The guard

`DeepCleanupsScan_TakesItsRootsFromTheSeam` fails the build if any of those five machine reads reappears in `DeepCleanupService.cs`. A single re-added call would quietly undo this for one category, and every existing test would stay green because none of them can see where the scan looked.

Flat greps over the comment-stripped file rather than a slice of the scan methods — a guard that slices between markers passes vacuously the moment a marker moves. `RecycleBinHelper.EmptyAllDrives` is **not** banned: it is the shell call that empties the bin, it lives on the clean side, and `CleanAsync` is already testable.

## Verification

Seven mutations, restore hash-checked byte-for-byte, final state green:

```
S1  a special folder is read directly again     RED  "Environment.GetFolderPath — use one of
                                                      ICleanupRoots' folder properties"
S2  the recycle-bin paths escape the seam       RED  "RecycleBinHelper.CurrentUserBinPaths — use
                                                      ICleanupRoots.RecycleBinPaths"
S3  the age cutoff comparison inverts           RED  the cutoff test — see below
S4  Windows.old arrives pre-selected            RED  its never-pre-selected test
S5  an empty category arrives pre-selected      RED  the empty-category test
S6  sizes stop aggregating from nested folders  RED  the exact-count test
S7  FixedDriveRoots is cached                   RED  the default-roots test, on NotSame
```

**S3 went GREEN on the first run**, and that is the most useful thing in this PR. Both fixture files were 100 bytes, so inverting the comparison still counted one file totalling 100 bytes — the test asserted that exactly one file was counted without asserting *which*. Distinct sizes (100 and 7) fixed it, and the assertion now names the file by its total. Found by the proof, not by review.

All four projects: 0 errors, 0 warnings. Locally green: the guard suite (121) and all Deep Cleanup classes (114). One `<remarks>` I wrote without a `<summary>` was caught by an existing guard rather than by me.

## What is left of #2176, and why it is not here

The issue also asked to split the existing `DeepCleanupServiceTests` — 39 cases sharing one real machine scan — between the two projects. Not done here, because the measurement says the obvious split is the wrong one:

- that class still costs **~180s** locally, all of it the one real scan
- but most of its cases are **catalogue** assertions (`ScanAsync_IncludesSteam`, `…IncludesEpic`, unique names, the >= 10 floor) that do not depend on the machine at all — a category is in the definitions whether or not its folder exists

So the likely right answer is to point that whole class at deterministic roots and delete the handful of shape-only cases the eleven new tests now cover properly — not to move it to `SysManager.IntegrationTests`. That is a separate change with its own reasoning and its own diff, so this PR says **Refs**, not Closes, and #2176 stays open for it.

## Notes

- `refactor:` — behaviour identical, no release, no version bump, no CHANGELOG entry.
- ARCHITECTURE.md gains `ICleanupRoots` in the "seams reached differently" list, which is where it belongs — it is not DI-registered.

Refs #2176
