### PR TITLE
refactor: route Windows Update's fourth admin gate through the seam the other three use

### DIFF
--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -8944,13 +8944,21 @@ public partial class ArchitectureTests
     /// host, and the result was that "the elevation gate on SFC, DISM, Windows Update and nine privileged
     /// tabs asserted nothing anywhere". The seam was added; the sweep it was added for stopped at
     /// <c>CleanupViewModel</c>. This is what keeps it swept.</para>
-    /// <para><b>Two pinning mechanisms count, and missing one is how the first measurement of this went
-    /// wrong.</b> <c>AdminHelper.ForceElevation</c> replaces the process-wide probe and reaches both an
-    /// <c>if (!AdminHelper.IsElevated())</c> read and a cached one. Assigning <c>vm.IsElevated</c> pins it
-    /// per instance and is equally valid — <c>DnsHostsViewModelTests</c> and <c>WindowsFeaturesTests</c> do
-    /// that — but only for a view model that caches the answer in the property; it cannot reach a call-time
-    /// read. Counting only the first mechanism reported the two files that already did it right as the
-    /// biggest gaps.</para>
+    /// <para><b>Three pinning mechanisms count, and missing one is how the first measurement of this went
+    /// wrong — twice.</b> <c>AdminHelper.ForceElevation</c> replaces the process-wide probe and reaches
+    /// both an <c>if (!AdminHelper.IsElevated())</c> read and a cached one. Assigning <c>vm.IsElevated</c>
+    /// pins it per instance and is equally valid — <c>DnsHostsViewModelTests</c> and
+    /// <c>WindowsFeaturesTests</c> do that — but only for a view model that caches the answer in the
+    /// property; it cannot reach a call-time read. Counting only the first mechanism reported the two files
+    /// that already did it right as the biggest gaps.</para>
+    /// <para>The third is an INJECTED probe: a view model taking <c>Func&lt;bool&gt; isElevated</c> is
+    /// pinned by a test that supplies it, and that is strictly better than the other two because it needs
+    /// no process-wide state at all. <c>WindowsUpdateViewModel</c> is the one that has it, and it went from
+    /// pinned to unpinned in this guard's eyes the moment #2181 routed its fourth gate through that seam
+    /// instead of <c>AdminHelper.IsElevated()</c> — the change that made it MORE testable read here as
+    /// less. The marker is the named argument <c>isElevated:</c>, which mirrors the parameter's own name, so
+    /// renaming the parameter breaks the test and this guard together rather than silently loosening it.
+    /// Comments are stripped first, so a passing mention of <c>isElevated:</c> in prose does not count.</para>
     /// <para>Test files are matched to a view model by NAMING it, not by filename and not by
     /// constructing it. Filename matching made <c>WindowsFeaturesTests.cs</c> invisible, because its name
     /// carries no "ViewModel". Construction matching then missed <c>StandbyMemoryTests</c> and
@@ -9007,6 +9015,7 @@ public partial class ArchitectureTests
 
             var pinned = covering.Any(kv =>
                 kv.Value.Contains("ForceElevation", StringComparison.Ordinal)
+                || kv.Value.Contains("isElevated:", StringComparison.Ordinal)
                 || (callTime == 0 && ElevationAssignment().IsMatch(kv.Value)));
 
             if (!pinned)

--- a/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
+++ b/SysManager/SysManager.Tests/WindowsUpdateViewModelTests.cs
@@ -760,7 +760,8 @@ public class WindowsUpdateViewModelTests
     {
         runner = Substitute.For<IPowerShellRunner>();
         return new WindowsUpdateViewModel(runner, new WindowsUpdateService(),
-                                         new WindowsUpdatePolicyService(), () => elevated);
+                                         new WindowsUpdatePolicyService(),
+                                         isElevated: () => elevated);
     }
 
     private static void ExecutePolicy(WindowsUpdateViewModel vm, string which)
@@ -886,10 +887,16 @@ public class WindowsUpdateViewModelTests
     /// what makes the relaunch worth doing. <c>RelaunchAsAdmin</c> returns false when
     /// <c>Application.Current</c> is null, which it is under the test runner, so nothing is spawned.</para>
     /// </remarks>
+    /// <remarks>
+    /// This used to open with <c>AdminHelper.ForceElevation(false)</c>, because the gate read
+    /// <c>AdminHelper.IsElevated()</c> at call time and the injected value could not reach it — one test
+    /// pinning elevation a different way from its eight neighbours, and a reason for the whole class to
+    /// swap a process-wide static. #2181 routed that gate through the same seam, so this now says what it
+    /// means with the constructor argument.
+    /// </remarks>
     [Fact]
     public async Task InstallUpdates_WhenNotElevated_OffersToRelaunchAndInstallsNothing()
     {
-        using var notElevated = AdminHelper.ForceElevation(false);
         var vm = NewVm(elevated: false, out var runner);
         vm.Updates.Add(new UpdateEntry { Title = "KB0000001", IsSelected = true });
 
@@ -911,6 +918,53 @@ public class WindowsUpdateViewModelTests
             DialogService.Instance = prevDialog;
         }
     }
+
+    /// <summary>
+    /// The install gate ASKS the injected probe, rather than reading the process behind its back.
+    /// </summary>
+    /// <remarks>
+    /// A mutation cannot prove this by outcome. On a non-elevated host the injected value and
+    /// <c>AdminHelper.IsElevated()</c> both answer false, so reverting the gate to the static call leaves
+    /// every assertion above green — and the elevated direction is not open to a test, because past the
+    /// gate the command hands real updates to a real <c>WindowsUpdateService</c>.
+    /// <para>Counting the calls decides it instead. The constructor reads the probe once to seed
+    /// <see cref="WindowsUpdateViewModel.IsElevated"/>; the gate reading it too makes two. One means the
+    /// gate went around the seam, which is the state #2181 describes.</para>
+    /// </remarks>
+    [Fact]
+    public async Task InstallUpdates_AsksTheInjectedProbeRatherThanTheProcess()
+    {
+        var asked = 0;
+        var runner = Substitute.For<IPowerShellRunner>();
+        var vm = new WindowsUpdateViewModel(runner, new WindowsUpdateService(),
+                                            new WindowsUpdatePolicyService(),
+                                            isElevated: () => { asked++; return false; });
+        Assert.Equal(1, asked);   // the constructor's read, seeding the property
+
+        vm.Updates.Add(new UpdateEntry { Title = "KB0000001", IsSelected = true });
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.InstallUpdatesCommand.ExecuteAsync(null);
+
+            Assert.Equal(2, asked);
+            Assert.Contains("Admin required", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DialogService.Instance = prevDialog;
+        }
+    }
+
+    [Fact]
+    public void Constructor_WithoutAnElevationProbe_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new WindowsUpdateViewModel(
+            Substitute.For<IPowerShellRunner>(), new WindowsUpdateService(),
+            new WindowsUpdatePolicyService(), isElevated: null!));
 
 }
 

--- a/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsUpdateViewModel.cs
@@ -101,6 +101,22 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
     {
     }
 
+    /// <summary>
+    /// The elevation probe every gate on this tab answers to, kept rather than only cached into
+    /// <see cref="IsElevated"/>. Named for what it IS rather than <c>_isElevated</c>, which is the
+    /// toolkit's backing field for the property.
+    /// </summary>
+    /// <remarks>
+    /// The property still exists and the view still binds it; what changed is that
+    /// <c>InstallUpdatesAsync</c> no longer reaches past this seam to <c>AdminHelper.IsElevated()</c>.
+    /// Three of the tab's four gates read the injected value and the fourth read the process directly, so
+    /// a test could decide elevation for three of them and had to swap the process-wide probe for the
+    /// fourth — two mechanisms for one question, in one file, which is how the next person picks the wrong
+    /// one (#2181). Behaviour is unchanged: a Windows process is elevated or not for its whole lifetime,
+    /// so the cached answer and a call-time read could never disagree.
+    /// </remarks>
+    private readonly Func<bool> _isElevatedProbe;
+
     internal WindowsUpdateViewModel(
         IPowerShellRunner runner,
         WindowsUpdateService wu,
@@ -117,7 +133,8 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
         // long-running commands' CanExecute (disabling them while one runs prevents
         // a second command disposing the shared CTS the first is still awaiting).
         PropertyChanged += OnVmPropertyChanged;
-        IsElevated = (isElevated ?? throw new ArgumentNullException(nameof(isElevated)))();
+        _isElevatedProbe = isElevated ?? throw new ArgumentNullException(nameof(isElevated));
+        IsElevated = _isElevatedProbe();
         // PSWindowsUpdate is only needed for the History view, so we don't
         // probe for it at startup — the History command checks itself if
         // the module is missing. This keeps the constructor side-effect-free
@@ -511,7 +528,7 @@ public sealed partial class WindowsUpdateViewModel : ViewModelBase
                 "Confirm Windows Update"))
             return;
 
-        if (!AdminHelper.IsElevated())
+        if (!_isElevatedProbe())
         {
             StatusMessage = "Admin required. Relaunching elevated...";
             if (AdminHelper.RelaunchAsAdmin()) App.RequestShutdown();


### PR DESCRIPTION
Closes #2181. Three of Windows Update's four admin gates answered to the injected elevation seam; the fourth read the process directly. Now all four use the same one.

## What was inconsistent

```csharp
// before
IsElevated = (isElevated ?? throw new ArgumentNullException(nameof(isElevated)))();
```

The delegate's *result* was cached and the delegate itself thrown away, so `InstallUpdatesAsync` had nothing to call and reached for `AdminHelper.IsElevated()` instead:

| gate | read |
|---|---|
| `RequireAdminForPolicy` (all three policy commands) | cached `IsElevated` ✓ |
| `InstallModule`'s inverted gate | cached `IsElevated` ✓ |
| `InstallUpdatesAsync` | `AdminHelper.IsElevated()` ✗ |

**Not a user-visible defect.** A Windows process is elevated or it is not for its whole lifetime, so the two could never disagree at run time. What it cost was one mechanism per question: seven of the tab's elevation tests decided elevation with the constructor argument, and the eighth had to swap the process-wide probe and drag the class into `ProcessWideStatics` for it. Two ways to say one thing, in one file, is how the next person picks the wrong one — and picking the seam for a call-time gate produces a test that silently asserts whatever the host happens to be, which is exactly the defect class #2171 existed to remove.

The fix stores the delegate. `IsElevated` still exists and the view still binds it; `_isElevatedProbe` is named for what it is, because `_isElevated` is the toolkit's backing field for the property.

## A mutation cannot prove this by outcome

This is the interesting part. On a non-elevated host the injected value and `AdminHelper.IsElevated()` **both answer false**, so reverting the gate to the static call leaves every existing assertion green. And the elevated direction is not open to a test: past that gate the command hands real updates to a real `WindowsUpdateService`, with no substitute available.

So the test counts the calls instead:

```csharp
var vm = new WindowsUpdateViewModel(runner, …, isElevated: () => { asked++; return false; });
Assert.Equal(1, asked);          // the constructor's read, seeding the property
await vm.InstallUpdatesCommand.ExecuteAsync(null);
Assert.Equal(2, asked);          // the gate asked too — one would mean it went around the seam
```

Plus `Constructor_WithoutAnElevationProbe_Throws`, since the null guard moved from the call to the assignment.

## The guard needed a third mechanism, and how that surfaced is the point

`EveryViewModelThatBranchesOnElevation_HasATestThatPinsIt` knew two ways to pin elevation: `ForceElevation`, and assigning `vm.IsElevated` when the view model has no call-time read. This change made the view model **more** testable and the guard immediately reported it as **unpinned** — the call-time pattern it recognised was gone, the test no longer used `ForceElevation`, and it knew nothing about an injected probe. Caught locally, before CI.

The third marker is the named argument `isElevated:`, which mirrors the parameter's own name — so renaming the parameter breaks the tests and the guard together rather than quietly loosening it. Comments are stripped first, so the passing mention of `isElevated: true` in a comment elsewhere in that file does not count.

## Verification

Four mutations, four reds, restore hash-checked byte-for-byte, final state green:

```
T1  the gate reads the process behind the seam again  RED  the call-counting test
T2  the constructor stops guarding a null probe       RED  the null-probe test
T3  the isElevated: markers all disappear             RED  "WindowsUpdateViewModel (2 cached + 0
                                                            call-time branch(es))"
T4  the constructor stops seeding IsElevated          RED  the counting test's first assertion,
                                                            plus five neighbours
```

T3 had to remove **all three** call sites. The guard asks whether the FILE pins elevation, so one surviving marker satisfied it and the first version of that mutation stayed green — a reminder that a file-scoped guard needs a file-scoped mutation. Dropping the named argument still compiles and still passes every test, so the guard is the only thing that can object to it, which is what makes T3 a test of the guard rather than of the tests.

Every mutation stays on the refusal side of the gate; none of them lets an install start.

All four projects: 0 errors, 0 warnings. Locally green: Windows Update in both projects (200 unit + 37 integration) and the guard suite (121). Full suite is CI's blocking gate.

## Notes

- `refactor:` — behaviour identical, no release, no version bump, no CHANGELOG entry.
- The class keeps `[Collection("ProcessWideStatics")]`: it no longer pins elevation through a static, but it still swaps `DialogService.Instance`, which is process-wide.

Closes #2181
