### PR TITLE
test: point Deep Cleanup's shared scan at a temp tree, 183s to 0.25s

### DIFF
--- a/SysManager/SysManager.IntegrationTests/DeepCleanupRealRootsTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DeepCleanupRealRootsTests.cs
@@ -1,0 +1,91 @@
+// SysManager · DeepCleanupRealRootsTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.IntegrationTests;
+
+/// <summary>
+/// One scan of the real machine, shared by both tests below.
+/// </summary>
+/// <remarks>
+/// A full walk of this machine's caches took 45 seconds when measured, so two tests doing their own would
+/// add a minute and a half to a suite that already runs six. Shared and read-only, the same arrangement
+/// #2167 introduced in the unit project for the same reason.
+/// </remarks>
+public sealed class RealMachineScanFixture : IAsyncLifetime
+{
+    /// <summary>The one scan's categories. Read-only — both tests share this instance.</summary>
+    public IReadOnlyList<CleanupCategory> Categories { get; private set; } = [];
+
+    public async ValueTask InitializeAsync()
+        => Categories = await new DeepCleanupService().ScanAsync();
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}
+
+/// <summary>
+/// The one claim about Deep Cleanup's scan that only a live machine can make: the default roots really
+/// are this machine's folders, and a scan over them produces the same catalogue the unit tests describe.
+/// </summary>
+/// <remarks>
+/// Everything else moved the other way. Until #2176 the unit project scanned the real disk for all of it,
+/// which cost 183 seconds on a workstation with real caches and — worse — meant the assertions could only
+/// be shapes that hold anywhere. With <c>ICleanupRoots</c> the unit tests point at a tree they build and
+/// assert exact counts in 0.25 seconds; what is left over is this, and it belongs here, where a
+/// live-system dependency is the point of the project rather than a compromise.
+/// <para>Deliberately narrow. Neither test asserts that any particular folder EXISTS — a fresh runner has
+/// almost none of them — only that the definitions were built from the machine's own paths and that the
+/// walk completes. A test that required content would fail on CI and pass on a developer's machine for
+/// reasons neither chose, which is the state this replaced.</para>
+/// </remarks>
+public class DeepCleanupRealRootsTests(RealMachineScanFixture scan) : IClassFixture<RealMachineScanFixture>
+{
+    private readonly IReadOnlyList<CleanupCategory> _scanned = scan.Categories;
+
+    [Fact]
+    public void DefaultRoots_ProduceTheSameCatalogueOverTheRealMachine()
+    {
+        // The same floor the unit project's catalogue tests use, asserted here against real roots so a
+        // definition that only resolves on a temp tree cannot pass unnoticed.
+        Assert.True(_scanned.Count >= 10, $"expected >= 10 categories, got {_scanned.Count}");
+        Assert.All(_scanned, c => Assert.False(string.IsNullOrWhiteSpace(c.Name)));
+        Assert.Equal(_scanned.Count, _scanned.Select(c => c.Name).Distinct().Count());
+    }
+
+    /// <summary>
+    /// Every path the scan resolved is under one of this machine's own roots.
+    /// </summary>
+    /// <remarks>
+    /// All EIGHT roots are anchors, not just the seven folders. The first version of this test used only
+    /// the folders and failed on two legitimate paths — a Recycle Bin and a Steam shader cache on a second
+    /// drive — because those come from <c>FixedDriveRoots</c> and <c>RecycleBinPaths</c>. The failure was
+    /// the test's, not the scan's, and it is the reason this list is derived from the interface rather than
+    /// written out by hand.
+    /// <para>Asserted over the folders that DO exist, because that is the subset the scan reports at all.
+    /// <c>NotEmpty</c> first, so that an empty result says so instead of passing vacuously — which is what
+    /// pointing the seam's default somewhere else would look like.</para>
+    /// </remarks>
+    [Fact]
+    public void DefaultRoots_ResolveUnderTheMachinesOwnFolders()
+    {
+        var roots = new SystemCleanupRoots();
+        var anchors = new List<string>
+        {
+            roots.LocalAppData, roots.ProgramData, roots.SystemDrive,
+            roots.WindowsDirectory, roots.UserTemp, roots.ProgramFilesX86, roots.ProgramFiles,
+        };
+        anchors.AddRange(roots.FixedDriveRoots);
+        anchors.AddRange(roots.RecycleBinPaths);
+
+        var resolved = _scanned.SelectMany(c => c.Paths).ToList();
+
+        Assert.NotEmpty(resolved);
+        Assert.All(resolved, p => Assert.True(
+            anchors.Any(a => p.StartsWith(a, StringComparison.OrdinalIgnoreCase)),
+            $"a resolved cleanup path is under none of this machine's roots: {Path.GetFileName(p)}"));
+    }
+}

--- a/SysManager/SysManager.Tests/DeepCleanupScanLogicTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupScanLogicTests.cs
@@ -27,55 +27,12 @@ namespace SysManager.Tests;
 /// with "no category named X" rather than silently asserting over an empty list, which is the failure mode
 /// the shared-scan tests have by construction.</para>
 /// </remarks>
-public sealed class DeepCleanupScanLogicTests : IDisposable
+public sealed class DeepCleanupScanLogicTests
 {
-    private readonly string _root =
-        Path.Combine(Path.GetTempPath(), "SysManagerScanRoots", Guid.NewGuid().ToString("N"));
+    /// <summary>Fresh roots per test: an exact byte total cannot survive a tree another test planted in.</summary>
+    private static TempCleanupRoots Roots() => new();
 
-    public DeepCleanupScanLogicTests() => Directory.CreateDirectory(_root);
-
-    public void Dispose()
-    {
-        try { Directory.Delete(_root, recursive: true); }
-        catch (IOException) { /* a leftover temp tree under %TEMP% is harmless */ }
-        catch (UnauthorizedAccessException) { /* ditto */ }
-    }
-
-    /// <summary>
-    /// Every root pointed inside one temp tree, in its own subfolder so a category cannot pick up files
-    /// planted for another.
-    /// </summary>
-    private sealed class TempRoots(string root) : ICleanupRoots
-    {
-        public string LocalAppData { get; } = Sub(root, "LocalAppData");
-        public string ProgramData { get; } = Sub(root, "ProgramData");
-        public string SystemDrive { get; } = Sub(root, "SystemDrive");
-        public string WindowsDirectory { get; } = Sub(root, "Windows");
-        public string UserTemp { get; } = Sub(root, "Temp");
-        public string ProgramFilesX86 { get; } = Sub(root, "ProgramFilesX86");
-        public string ProgramFiles { get; } = Sub(root, "ProgramFiles");
-
-        /// <summary>Empty: a real drive root here would put the launcher probes back on the machine.</summary>
-        public IReadOnlyList<string> FixedDriveRoots { get; } = [];
-
-        /// <summary>Empty: the real bins are what made these tests take 48 seconds instead of one.</summary>
-        public IReadOnlyList<string> RecycleBinPaths { get; } = [];
-
-        private static string Sub(string root, string name)
-        {
-            var path = Path.Combine(root, name);
-            Directory.CreateDirectory(path);
-            return path;
-        }
-    }
-
-    private TempRoots Roots() => new(_root);
-
-    private static void WriteFile(string path, int bytes)
-    {
-        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-        File.WriteAllBytes(path, new byte[bytes]);
-    }
+    private static void WriteFile(string path, int bytes) => TempCleanupRoots.WriteFile(path, bytes);
 
     private static CleanupCategory Named(IReadOnlyList<CleanupCategory> categories, string name)
     {
@@ -89,7 +46,7 @@ public sealed class DeepCleanupScanLogicTests : IDisposable
     [Fact]
     public async Task Scan_ReportsTheExactFileCountAndByteTotal()
     {
-        var roots = Roots();
+        using var roots = Roots();
         var amd = Path.Combine(roots.SystemDrive, "AMD");
         WriteFile(Path.Combine(amd, "a.bin"), 10);
         WriteFile(Path.Combine(amd, "b.bin"), 10);
@@ -106,7 +63,7 @@ public sealed class DeepCleanupScanLogicTests : IDisposable
     [Fact]
     public async Task Scan_WithContent_PreSelectsTheCategory()
     {
-        var roots = Roots();
+        using var roots = Roots();
         WriteFile(Path.Combine(roots.SystemDrive, "AMD", "a.bin"), 1);
 
         var categories = await new DeepCleanupService(roots).ScanAsync();
@@ -121,7 +78,7 @@ public sealed class DeepCleanupScanLogicTests : IDisposable
     [Fact]
     public async Task Scan_WithAnEmptyFolder_ReportsZeroAndDoesNotSelectIt()
     {
-        var roots = Roots();
+        using var roots = Roots();
         Directory.CreateDirectory(Path.Combine(roots.SystemDrive, "Intel"));
 
         var categories = await new DeepCleanupService(roots).ScanAsync();
@@ -135,7 +92,8 @@ public sealed class DeepCleanupScanLogicTests : IDisposable
     [Fact]
     public async Task Scan_WithNoFolderAtAll_ReportsNoPaths()
     {
-        var categories = await new DeepCleanupService(Roots()).ScanAsync();
+        using var roots = Roots();
+        var categories = await new DeepCleanupService(roots).ScanAsync();
 
         Assert.Empty(Named(categories, "Intel driver extracts").Paths);
     }
@@ -156,7 +114,7 @@ public sealed class DeepCleanupScanLogicTests : IDisposable
     [Fact]
     public async Task Scan_WithAnAgeCutoff_CountsOnlyWhatIsOlderThanIt()
     {
-        var roots = Roots();
+        using var roots = Roots();
         var cbs = Path.Combine(roots.WindowsDirectory, "Logs", "CBS");
         var old = Path.Combine(cbs, "old.log");
         var young = Path.Combine(cbs, "young.log");
@@ -183,7 +141,7 @@ public sealed class DeepCleanupScanLogicTests : IDisposable
     [Fact]
     public async Task Scan_WithWindowsOld_OffersItButNeverPreSelectsIt()
     {
-        var roots = Roots();
+        using var roots = Roots();
         WriteFile(Path.Combine(roots.SystemDrive, "Windows.old", "big.bin"), 5000);
 
         var categories = await new DeepCleanupService(roots).ScanAsync();
@@ -197,7 +155,8 @@ public sealed class DeepCleanupScanLogicTests : IDisposable
     [Fact]
     public async Task Scan_WithoutWindowsOld_DoesNotOfferIt()
     {
-        var categories = await new DeepCleanupService(Roots()).ScanAsync();
+        using var roots = Roots();
+        var categories = await new DeepCleanupService(roots).ScanAsync();
 
         Assert.DoesNotContain(categories, c => c.Name.Contains("Windows.old", StringComparison.Ordinal));
     }
@@ -207,7 +166,7 @@ public sealed class DeepCleanupScanLogicTests : IDisposable
     [Fact]
     public async Task Scan_ReportsProgressForEveryCategoryAndFinishesOnDone()
     {
-        var roots = Roots();
+        using var roots = Roots();
         var progress = new SyncProgress<DeepCleanupService.ScanProgress>();
 
         var categories = await new DeepCleanupService(roots).ScanAsync(progress);
@@ -230,11 +189,12 @@ public sealed class DeepCleanupScanLogicTests : IDisposable
     [Fact]
     public async Task Scan_WhenCancelledBeforeItStarts_Throws()
     {
+        using var roots = Roots();
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => new DeepCleanupService(Roots()).ScanAsync(ct: cts.Token));
+            () => new DeepCleanupService(roots).ScanAsync(ct: cts.Token));
     }
 
     // ── Guarding the seam itself ─────────────────────────────────────────────

--- a/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupServiceTests.cs
@@ -9,38 +9,52 @@ using SysManager.Services;
 namespace SysManager.Tests;
 
 /// <summary>
-/// One real scan of this machine, shared by every test that only READS the result.
+/// One scan of a temp tree, shared by every test that only READS the catalogue.
 /// </summary>
 /// <remarks>
-/// <c>DeepCleanupService.ScanAsync</c> walks the machine: <c>LocalApplicationData</c>,
-/// <c>CommonApplicationData</c>, the Windows directory, both Program Files trees, and every drive root
-/// looking for Steam, Riot and shader caches. It reaches the filesystem through
-/// <c>Environment.GetFolderPath</c> and <c>Directory.EnumerateFiles</c> directly, so there is no seam to
-/// substitute and a test can only scan the real disk.
-/// <para>27 tests here assert properties of one scan's output — names are non-empty, sizes are
-/// non-negative, the list contains Recycle Bin — and each used to perform its own. The class carries no
-/// <c>[Collection]</c>, so it is its own collection and its tests run SEQUENTIALLY: 27 serial disk walks.
-/// On a fresh CI runner each is near-instant and the whole unit suite takes about 78 seconds. On a
-/// machine with real caches, 16 of these tests were measured at 31 to 52 seconds EACH, and the class
-/// alone did not finish inside a 20-minute budget while every other class in the suite had completed
-/// (#2167). The blocking suite's runtime was a function of how much junk was on the machine running it.
-/// </para>
-/// <para>Four tests still call <c>ScanAsync</c> themselves, and only two of those are a full walk. The
-/// two cancellation tests must drive it directly, because cancellation is the thing under test, and both
-/// stop almost immediately. <c>CleanAsync_NoneSelected_DoesNothing</c> MUTATES <c>IsSelected</c> on what
-/// it is given, and <c>CleanAsync_CancelledToken_ReturnsImmediately</c> hands its list to
-/// <c>CleanAsync</c>; neither may be given the shared instance, so each keeps its own scan. 27 walks
-/// down to 3.</para>
+/// <b>This used to scan the real machine, and it no longer does.</b> #2167 cut 27 serial disk walks to one
+/// — on a machine with real caches, 16 of these tests were measured at 31 to 52 seconds EACH, and the class
+/// alone did not finish inside a 20-minute budget while every other class had completed. That fixed the
+/// cost and left the non-determinism: 27 tests depending on one scan of one machine, so the blocking
+/// suite's result was still a function of what was on the disk running it.
+/// <para>#2176 added <c>ICleanupRoots</c>, and pointing the fixture at a temp tree turns out to cost these
+/// tests nothing, because almost all of them are CATALOGUE assertions — <c>ScanAsync_IncludesSteam</c>,
+/// unique names, the <c>&gt;= 10</c> floor — and a category is in the definitions whether or not its folder
+/// exists on this machine. The scan drops from about 180 seconds here to milliseconds and stops depending
+/// on the host at all.</para>
+/// <para>What that made redundant went with it. <c>ScanAsync_ReturnsNonNull</c> asserted a method returns
+/// something; <c>ScanAsync_WindowsOldNeverSelectedByDefault</c> opened with <c>if (wo != null)</c>, so on
+/// any machine without a previous Windows install — most of them, including CI — it asserted nothing at
+/// all; <c>ScanAsync_EmptyCategoriesAreNotSelected</c> could only check whatever happened to be empty.
+/// <c>DeepCleanupScanLogicTests</c> now asserts all three properly, over folders it creates.</para>
+/// <para>Three tests still scan for themselves, and none of them is a machine walk any more.
+/// The two cancellation tests must drive <c>ScanAsync</c> directly, because cancellation is the thing under
+/// test. <c>CleanAsync_NoneSelected_DoesNothing</c> MUTATES <c>IsSelected</c> on what it is given and
+/// <c>CleanAsync_CancelledToken_ReturnsImmediately</c> hands its list to <c>CleanAsync</c>, so neither may
+/// be given the shared instance.</para>
+/// <para>The tree is planted with a <c>Windows.old</c> folder, because that category is the one definition
+/// added conditionally — without it the catalogue this fixture describes would be one category short of
+/// what the app can show.</para>
 /// </remarks>
 public sealed class DeepCleanupScanFixture : IAsyncLifetime
 {
+    private readonly TempCleanupRoots _roots = new();
+
     /// <summary>The one scan's categories. Treat as read-only — every consumer shares this instance.</summary>
     public IReadOnlyList<CleanupCategory> Categories { get; private set; } = [];
 
     public async ValueTask InitializeAsync()
-        => Categories = await new DeepCleanupService().ScanAsync();
+    {
+        // Windows.old is the one conditional definition, so the catalogue is short one category without it.
+        TempCleanupRoots.WriteFile(Path.Combine(_roots.SystemDrive, "Windows.old", "leftover.bin"), 16);
+        Categories = await new DeepCleanupService(_roots).ScanAsync();
+    }
 
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync()
+    {
+        _roots.Dispose();
+        return ValueTask.CompletedTask;
+    }
 }
 
 public class DeepCleanupServiceTests(DeepCleanupScanFixture scan) : IClassFixture<DeepCleanupScanFixture>
@@ -53,12 +67,6 @@ public class DeepCleanupServiceTests(DeepCleanupScanFixture scan) : IClassFixtur
     {
         var s = new DeepCleanupService();
         Assert.NotNull(s);
-    }
-
-    [Fact]
-    public void ScanAsync_ReturnsNonNull()
-    {
-        Assert.NotNull(_scanned);
     }
 
     [Fact]
@@ -114,7 +122,8 @@ public class DeepCleanupServiceTests(DeepCleanupScanFixture scan) : IClassFixtur
         // OperationCanceledException instead. Deterministic (no wall-clock): the progress
         // callback fires synchronously inside the scan loop, so cancelling on the first
         // report cancels mid-scan reliably.
-        var s = new DeepCleanupService();
+        using var roots = new TempCleanupRoots();
+        var s = new DeepCleanupService(roots);
         using var cts = new CancellationTokenSource();
         var progress = new CancelOnFirstReport(cts);
 
@@ -252,26 +261,6 @@ public class DeepCleanupServiceTests(DeepCleanupScanFixture scan) : IClassFixtur
     }
 
     [Fact]
-    public void ScanAsync_WindowsOldNeverSelectedByDefault()
-    {
-        var wo = _scanned.FirstOrDefault(c => c.Name.Contains("Windows.old", StringComparison.OrdinalIgnoreCase));
-        if (wo != null)
-        {
-            Assert.False(wo.IsSelected, "Windows.old must never auto-select");
-            Assert.True(wo.IsDestructiveHint);
-        }
-    }
-
-    [Fact]
-    public void ScanAsync_EmptyCategoriesAreNotSelected()
-    {
-        Assert.All(_scanned, c =>
-        {
-            if (c.TotalSizeBytes == 0) Assert.False(c.IsSelected);
-        });
-    }
-
-    [Fact]
     public async Task CleanAsync_EmptyList_ReturnsZero()
     {
         var s = new DeepCleanupService();
@@ -285,8 +274,11 @@ public class DeepCleanupServiceTests(DeepCleanupScanFixture scan) : IClassFixtur
     public async Task CleanAsync_NoneSelected_DoesNothing()
     {
         // Its own scan, not the class fixture's: this test clears IsSelected on every category it is
-        // given, and the fixture's list is shared with 27 read-only tests in the same collection.
-        var s = new DeepCleanupService();
+        // given, and the fixture's list is shared with every read-only test in the same collection.
+        // Its own ROOTS too — this was one of the two remaining real machine walks in the class, and on a
+        // workstation with real caches it alone accounted for most of the runtime.
+        using var roots = new TempCleanupRoots();
+        var s = new DeepCleanupService(roots);
         var cats = await s.ScanAsync();
         foreach (var c in cats) c.IsSelected = false;
         var r = await s.CleanAsync(cats);
@@ -299,8 +291,9 @@ public class DeepCleanupServiceTests(DeepCleanupScanFixture scan) : IClassFixtur
     {
         // Its own scan for the same reason: the list is handed to CleanAsync, and a shared instance must
         // not be passed to something whose job is to act on it — even when a cancelled token means it
-        // will not.
-        var s = new DeepCleanupService();
+        // will not. Temp roots for the same reason as the test above.
+        using var roots = new TempCleanupRoots();
+        var s = new DeepCleanupService(roots);
         var cats = await s.ScanAsync();
         using var cts = new CancellationTokenSource();
         cts.Cancel();

--- a/SysManager/SysManager.Tests/TempCleanupRoots.cs
+++ b/SysManager/SysManager.Tests/TempCleanupRoots.cs
@@ -1,0 +1,79 @@
+// SysManager · TempCleanupRoots
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Deep Cleanup's scan roots, pointed at a temp tree the test owns and deletes.
+/// </summary>
+/// <remarks>
+/// Every root gets its own subfolder, so a category cannot pick up files planted for another — the
+/// definitions overlap heavily under <c>%LOCALAPPDATA%</c>, and a shared folder would make an exact
+/// count depend on which categories happen to look there.
+/// <para><c>FixedDriveRoots</c> and <c>RecycleBinPaths</c> are empty deliberately. A real drive root here
+/// would put the Steam, shader-cache and Riot probes back on the machine, and the real bins are what made
+/// the first version of these tests take 48 seconds instead of 0.2 (#2176).</para>
+/// <para>Shared rather than nested in one test class because two consumers need it: the deterministic
+/// scan-logic tests, and the class fixture that the catalogue tests share. Copying it would put the "which
+/// roots are redirected" decision in two places, which is the drift #2183 documents.</para>
+/// </remarks>
+public sealed class TempCleanupRoots : ICleanupRoots, IDisposable
+{
+    /// <summary>The tree everything below lives in — deleted on dispose.</summary>
+    public string Root { get; } =
+        Path.Combine(Path.GetTempPath(), "SysManagerScanRoots", Guid.NewGuid().ToString("N"));
+
+    public string LocalAppData { get; }
+    public string ProgramData { get; }
+    public string SystemDrive { get; }
+    public string WindowsDirectory { get; }
+    public string UserTemp { get; }
+    public string ProgramFilesX86 { get; }
+    public string ProgramFiles { get; }
+
+    /// <summary>Empty: a real drive root would put the launcher probes back on the machine.</summary>
+    public IReadOnlyList<string> FixedDriveRoots { get; } = [];
+
+    /// <summary>Empty: the real bins are what made these tests take 48 seconds instead of 0.2.</summary>
+    public IReadOnlyList<string> RecycleBinPaths { get; } = [];
+
+    public TempCleanupRoots()
+    {
+        LocalAppData = Sub("LocalAppData");
+        ProgramData = Sub("ProgramData");
+        SystemDrive = Sub("SystemDrive");
+        WindowsDirectory = Sub("Windows");
+        UserTemp = Sub("Temp");
+        ProgramFilesX86 = Sub("ProgramFilesX86");
+        ProgramFiles = Sub("ProgramFiles");
+    }
+
+    /// <summary>
+    /// Writes a file of <paramref name="bytes"/> zero bytes at <paramref name="path"/>, creating its
+    /// directory, and returns the path.
+    /// </summary>
+    public static string WriteFile(string path, int bytes)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllBytes(path, new byte[bytes]);
+        return path;
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(Root, recursive: true); }
+        catch (IOException) { /* a leftover tree under %TEMP% is harmless */ }
+        catch (UnauthorizedAccessException) { /* ditto */ }
+    }
+
+    private string Sub(string name)
+    {
+        var path = Path.Combine(Root, name);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}


### PR DESCRIPTION
Second half of #2176, and it closes it. #2187 gave `ScanAsync` its roots; this uses them for the rest of the class — which turned out to be a better move than the split the issue proposed.

## Why not the split the issue asked for

#2176 proposed moving the machine-dependent tests to `SysManager.IntegrationTests`. Having measured it, that would have been wrong:

- almost every test in `DeepCleanupServiceTests` is a **catalogue** assertion — `ScanAsync_IncludesSteam`, `…IncludesEpic`, `CategoriesHaveUniqueNames`, the `>= 10` floor — and a category is in the definitions whether or not its folder exists on the machine
- so none of them ever needed a real disk, and moving them to a non-blocking suite would have cost merge protection for nothing

Pointing the fixture at a temp tree gets the determinism **and** keeps the catalogue gating merges.

## The numbers

| | before | after |
|---|---:|---:|
| whole Deep Cleanup surface (unit) | **183.7s** | **0.250s** |
| tests depending on what is on the disk | all 44 | **none** |

735×, and the second row is the point: the blocking suite's result no longer varies with the machine running it.

## `TempCleanupRoots`, shared

Two consumers need it now — the deterministic scan-logic tests and the class fixture — so it is a shared helper rather than a nested double in one class. Copying it would put the "which roots are redirected" decision in two places, which is exactly the drift #2183 found in `StaHelper`.

`FixedDriveRoots` and `RecycleBinPaths` are empty deliberately: a real drive root would put the Steam, shader-cache and Riot probes back on the machine, and the real bins are what made the first version of the deterministic tests take 48 seconds instead of 0.2.

## Three tests deleted rather than moved

| test | why it went |
|---|---|
| `ScanAsync_ReturnsNonNull` | asserted that a method returns something |
| `ScanAsync_WindowsOldNeverSelectedByDefault` | opened with `if (wo != null)` — on any machine without a previous Windows install, which is most of them including CI, it asserted **nothing at all** |
| `ScanAsync_EmptyCategoriesAreNotSelected` | could only check whatever happened to be empty |

All three are now asserted properly in `DeepCleanupScanLogicTests`, over folders it creates — including a `Windows.old` with 5000 bytes in it, which is the case the conditional one could never reach.

The fixture plants a `Windows.old` folder, because that is the one definition added conditionally and the catalogue is a category short without it.

The last two real machine walks were `CleanAsync_NoneSelected_DoesNothing` and `CleanAsync_CancelledToken_ReturnsImmediately`. Both keep their own scan — one mutates `IsSelected` on the list, the other hands it to `CleanAsync`, so neither may be given the shared instance — and both now keep their own **roots** too.

## The one live-machine claim, in the right project

`DeepCleanupRealRootsTests` keeps what only a real machine can assert: the default roots are this machine's folders, and a scan over them yields the same catalogue. One shared scan for both tests, because a full walk measured 45 seconds and two would add a minute and a half to a six-minute suite.

Neither test requires any folder to **exist** — a fresh runner has almost none of them. A test that needed content would fail on CI and pass on a developer's machine for reasons neither chose, which is the state this whole change replaces.

**Its first version failed, and the failure was the test's.** It anchored on the seven folder roots, and two legitimate paths — a Recycle Bin and a Steam shader cache on a second drive — come from `FixedDriveRoots` and `RecycleBinPaths`:

```
D:\SteamLibrary\steamapps\shadercache is under none of this machine's cleanup roots
```

The anchor list is now built from all eight roots rather than written out by hand, and the assertion message no longer echoes a full path.

## Verification

No mutation proof here, deliberately: this PR moves and deletes tests rather than changing behaviour, and #2187's seven-mutation proof already pins the scan logic these tests assert. What is checked instead:

- all four projects build with 0 errors and 0 warnings
- the guard suite is green (121), including `TheSharedDeepCleanupScan_IsNeverMutatedOrCleaned` whose floor survives the three deletions, and `NoTestFile_ShadowsAHelperItsOwnProjectAlreadyShares` with the new shared helper
- `DeepCleanupServiceTests` + `DeepCleanupScanLogicTests`: 47 cases, 0 failures, 0.250s
- `DeepCleanupRealRootsTests`: 2 cases, 0 failures, 47.9s — run against this real machine
- the three deleted tests are each replaced by a named, stronger test in `DeepCleanupScanLogicTests`, which #2187's S4 and S5 mutations already proved go red

## Notes

- `test:` — no release, no version bump, no CHANGELOG entry.
- No `ArchitectureTests` change, so this does not collide with #2188.

Closes #2176
