### PR TITLE
refactor: finish the corner-radius token migration, and make the guard require it

### DIFF
--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2476,11 +2476,20 @@ public partial class ArchitectureTests
     ///   exactly the same pixels, so the intent is stated and the arithmetic cannot go stale if the element is
     ///   resized.</item>
     /// </list>
-    /// <para>This guard deliberately does NOT require a token. Asking for one across 175 call sites is a
-    /// separate, purely mechanical migration; asking for an on-scale VALUE is the part that prevents a
-    /// regression, and it is checkable without touching a single view. <c>2</c> is on the list because it is
-    /// the accent stripe on the elevation and preview banners — a deliberate hairline, not a surface radius.
-    /// </para>
+    /// <para><b>It now requires the token as well, because the migration it deferred has happened.</b> This
+    /// used to say that asking for a token across 175 call sites was "a separate, purely mechanical
+    /// migration" and check only the VALUE. #1633 did that migration — 69 on-scale literals became token
+    /// references — so the weaker rule would leave the finished work free to unravel one literal at a time,
+    /// each new view looking locally reasonable.</para>
+    /// <para><b>The token values are read from App.xaml rather than hardcoded here.</b> Changing
+    /// <c>RadiusMd</c> from 8 to 10 must not leave this guard demanding a literal 8 — it would fail every
+    /// migrated view for using the very token it asks for. The allowed-value list stays literal, because
+    /// that is the scale's shape and a change to it should be deliberate.</para>
+    /// <para>Two values are allowed to stay raw, and they are not exceptions to the token rule — neither has
+    /// a token to use. <c>2</c> (20 uses) is the accent stripe on the elevation and preview banners, a
+    /// deliberate hairline rather than a surface radius; <c>16</c> (once) is ThemePopup's floating shell.
+    /// Both are documented at the token definitions in App.xaml. Any value the scale does not name is
+    /// silently accepted here, which is what makes adding one a deliberate act.</para>
     /// </remarks>
     [Fact]
     public void EveryCornerRadius_IsOnTheScale()
@@ -2489,39 +2498,106 @@ public partial class ArchitectureTests
         var allowed = new HashSet<string>(StringComparer.Ordinal) { "2", "4", "8", "12", "16", "999" };
 
         var appDir = FindAppProjectDir();
-        var offenders = new List<string>();
+        var appXaml = WithoutXamlComments(File.ReadAllText(Path.Combine(appDir, "App.xaml")));
+
+        // value -> token key, read from the definitions so the rule follows the scale rather than a copy.
+        var tokens = RadiusTokenDefinition().Matches(appXaml)
+            .ToDictionary(m => m.Groups[2].Value, m => m.Groups[1].Value, StringComparer.Ordinal);
+        Assert.True(tokens.Count >= 4,
+            $"only {tokens.Count} radius tokens were found in App.xaml — if the scale was renamed or moved, "
+            + "the token half of this guard is enforcing nothing.");
+
+        var offScale = new List<string>();
+        var untokenised = new List<string>();
+        var undefined = new List<string>();
         var literals = 0;
+        var references = 0;
 
         foreach (var file in Directory
                      .EnumerateFiles(appDir, "*.xaml", SearchOption.AllDirectories)
                      .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
                                              StringComparison.Ordinal)))
         {
-            var text = File.ReadAllText(file);
+            // Comments stripped, because App.xaml's own documentation QUOTES two of these values to explain
+            // why they stay raw — and without this the guard counted its own prose. That inflated the
+            // population by 2 and, worse, meant deleting the real ThemePopup 16 would leave the comment
+            // standing in for it. A guard must not be able to satisfy itself.
+            var text = WithoutXamlComments(File.ReadAllText(file));
+            foreach (var use in RadiusTokenUse().Matches(text).Cast<Match>())
+            {
+                references++;
+                var key = use.Groups[1].Value;
+                if (!tokens.ContainsValue(key))
+                    undefined.Add($"{Path.GetFileName(file)}: {key} is referenced but not defined");
+            }
             foreach (var hit in NumericCornerRadius().Matches(text).Cast<Match>())
             {
                 literals++;
                 var value = hit.Groups["value"].Value;
-                if (allowed.Contains(value)) continue;
-                offenders.Add($"{Path.GetFileName(file)}: CornerRadius=\"{value}\"");
+                if (tokens.TryGetValue(value, out var token))
+                    untokenised.Add($"{Path.GetFileName(file)}: a raw {value} — use {token}");
+                else if (!allowed.Contains(value))
+                    offScale.Add($"{Path.GetFileName(file)}: CornerRadius=\"{value}\"");
             }
         }
 
-        // Vacuity floor. RE-MEASURED at 90 on the same day it was written: 177 was the count before the
-        // elevation banner was extracted into one control, and that removed 60 banner Borders plus 27 of the
-        // stripe hairlines. The floor fired on the rebase, which is the floor working — a population is a
-        // measurement, and another change moved it. Current spread: 8 x39, 2 x20, 12 x19, 4 x9, 999 x2, 16 x1.
-        Assert.True(literals >= 80,
-            $"only {literals} numeric CornerRadius values were read, out of 90 measured — the pattern is out "
-            + "of date, so a pass proves nothing.");
+        // Vacuity floor, RE-MEASURED twice now, and both moves were real work rather than a broken pattern.
+        // 177 -> 90 when the elevation banner became one control (60 banner Borders and 27 hairlines gone).
+        // 90 -> 21 when #1633 replaced the 69 on-scale literals with token references. A population is a
+        // measurement; if a change moves it, re-measure and say why. Current spread: 2 x20, 16 x1.
+        //
+        // The floor is on literals PLUS references, because the two trade off: migrating one moves a count
+        // from the first to the second. A floor on literals alone would have fired on #1633 for doing
+        // exactly what this guard now asks for.
+        Assert.True(literals + references >= 100,
+            $"only {literals} numeric radii and {references} token references were read ({literals + references} "
+            + "against 120 measured) — the patterns are out of date, so a pass proves nothing.");
 
-        Assert.True(offenders.Count == 0,
+        // A StaticResource inside a DataTemplate resolves at RUNTIME, so deleting or renaming a key still
+        // compiles and the first symptom is a crash when the template inflates. That has happened here once
+        // with a Style, which is why the token half of this guard checks both directions.
+        Assert.True(undefined.Count == 0,
+            "these views reference a radius token that App.xaml does not define. It compiles either way — a "
+            + "StaticResource in a DataTemplate is resolved when the template inflates, not when it is "
+            + "built — so the first sign would be a crash in front of a user:\n  "
+            + string.Join("\n  ", undefined.Distinct())
+            + $"\n(defined: {string.Join(", ", tokens.Values.OrderBy(v => v, StringComparer.Ordinal))})");
+
+        Assert.True(offScale.Count == 0,
             "these corner radii are not on the scale. The tokens exist because the radii drifted once already "
             + "(5/6/8/10/999 scattered), and a number that is half of its element's own size is a pill or a "
             + "circle — say so with {StaticResource RadiusPill}, which clamps to the same pixels and cannot go "
             + "stale if the element is resized. Otherwise pick the nearest scale step (4, 8, 12, 16):\n  "
-            + string.Join("\n  ", offenders));
+            + string.Join("\n  ", offScale));
+
+        Assert.True(untokenised.Count == 0,
+            "these corner radii repeat a number the scale already names. #1633 migrated all 69 of them, so a "
+            + "literal here is that work unravelling one view at a time — each looking locally reasonable. "
+            + "Use the token; it is the same pixels:\n  "
+            + string.Join("\n  ", untokenised)
+            + $"\n({references} references to the scale, {tokens.Count} tokens defined)");
     }
+
+    /// <summary>XAML with its <c>&lt;!-- --&gt;</c> comments removed.</summary>
+    /// <remarks>
+    /// Needed wherever a check counts markup, because this repo's XAML comments quote the very values and
+    /// keys the checks look for — App.xaml's radius-token block explains two raw values by writing them out.
+    /// A guard that reads its own documentation reports a population that includes its own prose.
+    /// </remarks>
+    private static string WithoutXamlComments(string xaml) => XamlComment().Replace(xaml, "");
+
+    /// <summary>A XAML comment, including a multi-line one.</summary>
+    [GeneratedRegex(@"<!--.*?-->", RegexOptions.Compiled | RegexOptions.Singleline)]
+    private static partial Regex XamlComment();
+
+    /// <summary>A radius token definition in App.xaml, capturing its key and its value.</summary>
+    [GeneratedRegex(@"<CornerRadius\s+x:Key=""(Radius\w+)""\s*>\s*([0-9]+)\s*</CornerRadius>",
+                    RegexOptions.Compiled)]
+    private static partial Regex RadiusTokenDefinition();
+
+    /// <summary>A reference to one of the radius tokens, capturing the key.</summary>
+    [GeneratedRegex(@"(?:Static|Dynamic)Resource\s+(Radius\w+)", RegexOptions.Compiled)]
+    private static partial Regex RadiusTokenUse();
 
     /// <summary>A <c>CornerRadius</c> written as a plain number rather than a token.</summary>
     [GeneratedRegex(@"CornerRadius=""(?<value>\d+)""", RegexOptions.Compiled)]
@@ -9404,5 +9480,4 @@ public partial class ArchitectureTests
             + "as \"non-negative\":\n  "
             + string.Join("\n  ", offenders));
     }
-
 }

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -146,6 +146,14 @@
             <!-- the two layout strategies in the project docs. If a token scale  -->
             <!-- is wanted, land it WITH the view migration, not before it.       -->
             <!-- ============================================================ -->
+            <!-- MIGRATED: every on-scale raw value in the XAML now references one of these four   -->
+            <!-- (69 of them, #1633). Two values stay RAW on purpose, and are not misses:            -->
+            <!--   CornerRadius="2"  x20 — the hairline used for accent stripes and small chips. Off  -->
+            <!--                          the 4/8/12 scale deliberately; a 4 there reads as a bulge.  -->
+            <!--   CornerRadius="16" x1  — ThemePopup's outer shell, the only floating panel in the    -->
+            <!--                          app and deliberately rounder than a card.                    -->
+            <!-- Adding a token for either would extend a scale chosen as 4/8/12/999, so they are      -->
+            <!-- documented here instead. EveryOnScaleCornerRadius_UsesItsToken enforces the rest.     -->
             <CornerRadius x:Key="RadiusSm">4</CornerRadius>
             <CornerRadius x:Key="RadiusMd">8</CornerRadius>
             <CornerRadius x:Key="RadiusLg">12</CornerRadius>
@@ -235,7 +243,7 @@
                                             <Border x:Name="HeaderFocusBorder"
                                                     BorderBrush="Transparent"
                                                     BorderThickness="1"
-                                                    CornerRadius="8">
+                                                    CornerRadius="{StaticResource RadiusMd}">
                                                 <ContentPresenter HorizontalAlignment="Stretch"/>
                                             </Border>
                                             <ControlTemplate.Triggers>

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -37,7 +37,7 @@
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="8">
+                                CornerRadius="{StaticResource RadiusMd}">
                             <ContentPresenter
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
@@ -146,7 +146,7 @@
                                         AutomationProperties.AutomationId="{Binding Children[0].Id}"
                                         AutomationProperties.Name="{Binding Children[0].Label}"
                                         AutomationProperties.ItemStatus="{Binding Children[0].SelectionStatus}">
-                                    <Border CornerRadius="8" Padding="14,10"
+                                    <Border CornerRadius="{StaticResource RadiusMd}" Padding="14,10"
                                             DataContext="{Binding Children[0]}"
                                             Style="{StaticResource SidebarNavRow}">
                                         <Grid>
@@ -170,7 +170,7 @@
                                                            FontFamily="{StaticResource UiFont}"
                                                            FontSize="13"/>
                                                 <!-- PREVIEW pill: implemented but not yet QA-verified -->
-                                                <Border Background="{DynamicResource AccentSoft}" CornerRadius="4"
+                                                <Border Background="{DynamicResource AccentSoft}" CornerRadius="{StaticResource RadiusSm}"
                                                         Padding="5,1" Margin="7,0,0,0" VerticalAlignment="Center"
                                                         Visibility="{Binding IsInDevelopment, Converter={StaticResource BoolToVis}}">
                                                     <TextBlock Text="PREVIEW" FontSize="9" FontWeight="Bold"
@@ -188,7 +188,7 @@
                                           AutomationProperties.AutomationId="{Binding Id}"
                                           AutomationProperties.Name="{Binding Label}">
                                     <Expander.Header>
-                                        <Border CornerRadius="8" Padding="14,10" Cursor="Hand"
+                                        <Border CornerRadius="{StaticResource RadiusMd}" Padding="14,10" Cursor="Hand"
                                                 ToolTip="{Binding Tooltip}">
                                             <Border.Style>
                                                 <Style TargetType="Border">
@@ -303,7 +303,7 @@
                                                         AutomationProperties.AutomationId="{Binding Id}"
                                                         AutomationProperties.Name="{Binding Label}"
                                                         AutomationProperties.ItemStatus="{Binding SelectionStatus}">
-                                                    <Border CornerRadius="8" Padding="28,9,14,9"
+                                                    <Border CornerRadius="{StaticResource RadiusMd}" Padding="28,9,14,9"
                                                             Style="{StaticResource SidebarNavRow}">
                                                         <Grid>
                                                             <Rectangle x:Name="ActiveMark"
@@ -334,7 +334,7 @@
                                                                                    FontSize="13"
                                                                                    VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
                                                                         <!-- PREVIEW pill: implemented but not yet QA-verified -->
-                                                                        <Border Grid.Column="1" Background="{DynamicResource AccentSoft}" CornerRadius="4"
+                                                                        <Border Grid.Column="1" Background="{DynamicResource AccentSoft}" CornerRadius="{StaticResource RadiusSm}"
                                                                                 Padding="5,1" Margin="7,0,0,0" VerticalAlignment="Center"
                                                                                 Visibility="{Binding IsInDevelopment, Converter={StaticResource BoolToVis}}">
                                                                             <TextBlock Text="PREVIEW" FontSize="9" FontWeight="Bold"
@@ -361,7 +361,7 @@
 
                 <!-- Footer -->
                 <StackPanel Grid.Row="2" Margin="20,10,20,16">
-                    <Border Background="{DynamicResource Surface3}" CornerRadius="999"
+                    <Border Background="{DynamicResource Surface3}" CornerRadius="{StaticResource RadiusPill}"
                             Padding="10,3" HorizontalAlignment="Left"
                             AutomationProperties.AutomationId="ElevationBadge">
                         <StackPanel Orientation="Horizontal">
@@ -409,7 +409,7 @@
                              A Button would supply the peer and Space, but NOT Enter: ButtonBase
                              honours Enter only where KeyboardNavigation.AcceptsReturn is set, which
                              is why the nav rows set it explicitly. -->
-                        <Border Grid.Column="1" x:Name="ThemeBtn" Width="28" Height="28" CornerRadius="8"
+                        <Border Grid.Column="1" x:Name="ThemeBtn" Width="28" Height="28" CornerRadius="{StaticResource RadiusMd}"
                                 Background="{DynamicResource Surface3}" BorderBrush="{DynamicResource Border1}"
                                 BorderThickness="1" Cursor="Hand" MouseLeftButtonUp="ThemeBtn_Click"
                                 KeyDown="ThemeBtn_KeyDown"

--- a/SysManager/SysManager/Views/AdminBanner.xaml
+++ b/SysManager/SysManager/Views/AdminBanner.xaml
@@ -24,7 +24,7 @@
     <Grid>
         <!-- Not elevated: say what is locked, and offer the one button that unlocks it. -->
         <Border Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8"
+                BorderThickness="1" CornerRadius="{StaticResource RadiusLg}" Padding="12,8"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <!-- DockPanel, not a horizontal StackPanel: the message is the last child, so it fills the
                  remaining width and TextWrapping actually wraps. Inside a horizontal StackPanel the child
@@ -56,7 +56,7 @@
              through the parent's 12,8 padding to the border edge; it is tied to that padding, which is
              one more reason both live here rather than in 30 copies. -->
         <Border Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8"
+                BorderThickness="1" CornerRadius="{StaticResource RadiusLg}" Padding="12,8"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
             <Grid>
                 <Border Background="{DynamicResource WarningStripe}" Width="4" HorizontalAlignment="Left"

--- a/SysManager/SysManager/Views/BandwidthMonitorView.xaml
+++ b/SysManager/SysManager/Views/BandwidthMonitorView.xaml
@@ -94,7 +94,7 @@
 
         <!-- Alert strip -->
         <Border Grid.Row="3" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
-                BorderThickness="1" CornerRadius="12" Padding="12,10" Margin="28,12,28,0"
+                BorderThickness="1" CornerRadius="{StaticResource RadiusLg}" Padding="12,10" Margin="28,12,28,0"
                 Visibility="{Binding HasAlert, Converter={StaticResource FlexVis}}">
             <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width along
                  its orientation, so TextWrapping was inert and a long alert clipped (#1807). AlertMessage

--- a/SysManager/SysManager/Views/BrowserCleanerView.xaml
+++ b/SysManager/SysManager/Views/BrowserCleanerView.xaml
@@ -73,7 +73,7 @@
                                         <StackPanel Orientation="Horizontal">
                                             <TextBlock Text="{Binding Category}" FontWeight="SemiBold" FontSize="13"
                                                        Foreground="{DynamicResource TextPrimary}"/>
-                                            <Border Background="{DynamicResource Surface3}" CornerRadius="4" Padding="6,1" Margin="8,0,0,0"
+                                            <Border Background="{DynamicResource Surface3}" CornerRadius="{StaticResource RadiusSm}" Padding="6,1" Margin="8,0,0,0"
                                                     VerticalAlignment="Center"
                                                     Visibility="{Binding IsSensitive, Converter={StaticResource FlexVis}}">
                                                 <TextBlock Text="signs you out" FontSize="10" Foreground="{DynamicResource WarningText}"/>

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -108,7 +108,7 @@
                               Visibility="{Binding SearchResults.Count, Converter={StaticResource FlexVis}}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Border Padding="8,6" Margin="0,1" CornerRadius="8" Background="Transparent">
+                            <Border Padding="8,6" Margin="0,1" CornerRadius="{StaticResource RadiusMd}" Background="Transparent">
                                 <Border.Style>
                                     <Style TargetType="Border">
                                         <Style.Triggers>
@@ -184,7 +184,7 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Border Padding="16,10" Margin="4,1"
-                                    CornerRadius="8" Background="Transparent"
+                                    CornerRadius="{StaticResource RadiusMd}" Background="Transparent"
                                     ToolTip="{Binding WingetId}">
                                 <Border.Style>
                                     <Style TargetType="Border">
@@ -228,7 +228,7 @@
                                             <TextBlock Text="{Binding Name}"
                                                        FontWeight="SemiBold" FontSize="13"
                                                        Foreground="{DynamicResource TextPrimary}"/>
-                                            <Border CornerRadius="4" Padding="4,2" Margin="8,0,0,0" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Success}" BorderThickness="1"
+                                            <Border CornerRadius="{StaticResource RadiusSm}" Padding="4,2" Margin="8,0,0,0" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Success}" BorderThickness="1"
                                                     Visibility="{Binding IsInstalled, Converter={StaticResource BoolToVis}}">
                                                 <TextBlock Text="Installed" FontSize="9" Foreground="{DynamicResource Success}" FontWeight="SemiBold"/>
                                             </Border>
@@ -240,7 +240,7 @@
                                     </StackPanel>
 
                                     <!-- Status badge -->
-                                    <Border Grid.Column="3" CornerRadius="8" Padding="8,4"
+                                    <Border Grid.Column="3" CornerRadius="{StaticResource RadiusMd}" Padding="8,4"
                                             Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}" BorderThickness="1"
                                             VerticalAlignment="Center" Margin="12,0,0,0"
                                             Visibility="{Binding Status, Converter={StaticResource FlexVis}}">

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -92,7 +92,7 @@
                                Visibility="{Binding SfcEtaText, Converter={StaticResource FlexVis}}"/>
                 </StackPanel>
                 <!-- SFC verdict (shown after completion) -->
-                <Border Margin="0,8,0,0" Padding="12,10" CornerRadius="8"
+                <Border Margin="0,8,0,0" Padding="12,10" CornerRadius="{StaticResource RadiusMd}"
                         Background="{DynamicResource Surface1}"
                         Visibility="{Binding SfcVerdict, Converter={StaticResource FlexVis}}">
                     <!-- DockPanel, not a horizontal StackPanel: the verdict is a full sentence, and inside a
@@ -121,7 +121,7 @@
                                Visibility="{Binding DismEtaText, Converter={StaticResource FlexVis}}"/>
                 </StackPanel>
                 <!-- DISM verdict (shown after completion) -->
-                <Border Margin="0,8,0,0" Padding="12,10" CornerRadius="8"
+                <Border Margin="0,8,0,0" Padding="12,10" CornerRadius="{StaticResource RadiusMd}"
                         Background="{DynamicResource Surface1}"
                         Visibility="{Binding DismVerdict, Converter={StaticResource FlexVis}}">
                     <!-- DockPanel for the same reason as the SFC verdict above. -->

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -337,7 +337,7 @@
                                     Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
                                 <Button.Template>
                                     <ControlTemplate TargetType="Button">
-                                        <Border x:Name="Bd" CornerRadius="4" Padding="{TemplateBinding Padding}"
+                                        <Border x:Name="Bd" CornerRadius="{StaticResource RadiusSm}" Padding="{TemplateBinding Padding}"
                                                 Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningStripe}" BorderThickness="1">
                                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                         </Border>
@@ -369,7 +369,7 @@
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate DataType="{x:Type models:TemperatureReading}">
-                                <Border Background="{DynamicResource Surface2}" CornerRadius="8"
+                                <Border Background="{DynamicResource Surface2}" CornerRadius="{StaticResource RadiusMd}"
                                         Padding="14" Margin="0,0,10,10" MinWidth="200" MaxWidth="280">
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="{Binding DisplayValue}" Style="{StaticResource Metric}" FontWeight="SemiBold"

--- a/SysManager/SysManager/Views/DebloaterView.xaml
+++ b/SysManager/SysManager/Views/DebloaterView.xaml
@@ -90,12 +90,12 @@
                                         <StackPanel Orientation="Horizontal">
                                             <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" FontSize="13"
                                                        Foreground="{DynamicResource TextPrimary}"/>
-                                            <Border Background="{DynamicResource Surface3}" CornerRadius="4" Padding="6,1" Margin="8,0,0,0"
+                                            <Border Background="{DynamicResource Surface3}" CornerRadius="{StaticResource RadiusSm}" Padding="6,1" Margin="8,0,0,0"
                                                     VerticalAlignment="Center"
                                                     Visibility="{Binding IsProtected, Converter={StaticResource FlexVis}}">
                                                 <TextBlock Text="Protected" FontSize="10" Foreground="{DynamicResource TextMuted}"/>
                                             </Border>
-                                            <Border Background="{DynamicResource Surface3}" CornerRadius="4" Padding="6,1" Margin="8,0,0,0"
+                                            <Border Background="{DynamicResource Surface3}" CornerRadius="{StaticResource RadiusSm}" Padding="6,1" Margin="8,0,0,0"
                                                     VerticalAlignment="Center"
                                                     Visibility="{Binding IsCommonBloat, Converter={StaticResource FlexVis}}">
                                                 <TextBlock Text="Common bloat" FontSize="10" Foreground="{DynamicResource TextMuted}"/>

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -84,7 +84,7 @@
                                             <StackPanel Grid.Column="1">
                                                 <StackPanel Orientation="Horizontal">
                                                     <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource TextPrimary}"/>
-                                                    <Border Margin="10,0,0,0" Padding="8,2" CornerRadius="999"
+                                                    <Border Margin="10,0,0,0" Padding="8,2" CornerRadius="{StaticResource RadiusPill}"
                                                             Background="{DynamicResource DangerBgSubtle}" BorderBrush="{DynamicResource DangerBorder}" BorderThickness="1"
                                                             Visibility="{Binding IsDestructiveHint, Converter={StaticResource BoolToVis}}">
                                                         <TextBlock Text="Irreversible" Foreground="{DynamicResource DangerText}" FontSize="11" FontWeight="SemiBold"/>

--- a/SysManager/SysManager/Views/DefenderView.xaml
+++ b/SysManager/SysManager/Views/DefenderView.xaml
@@ -37,7 +37,7 @@
 
         <!-- Tamper Protection warning -->
         <Border Grid.Row="3" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
-                BorderThickness="1" CornerRadius="12" Padding="12,10" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="{StaticResource RadiusLg}" Padding="12,10" Margin="0,0,0,12"
                 Visibility="{Binding IsTamperProtected, Converter={StaticResource FlexVis}}">
             <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width along
                  its orientation, so TextWrapping was inert and this warning clipped (#1807). -->

--- a/SysManager/SysManager/Views/DevelopmentBanner.xaml
+++ b/SysManager/SysManager/Views/DevelopmentBanner.xaml
@@ -8,7 +8,7 @@
          status. Distinct from the WIP placeholder (which means "not built yet"):
          this means "built and working, pending verification". -->
     <Border Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Info}"
-            BorderThickness="1" CornerRadius="12" Padding="12,10">
+            BorderThickness="1" CornerRadius="{StaticResource RadiusLg}" Padding="12,10">
         <Grid>
             <!-- Left accent stripe, mirrors the elevated-admin banner pattern -->
             <Border Background="{DynamicResource Info}" Width="4" HorizontalAlignment="Left"

--- a/SysManager/SysManager/Views/DisplayProfileView.xaml
+++ b/SysManager/SysManager/Views/DisplayProfileView.xaml
@@ -58,7 +58,7 @@
 
         <!-- Auto-revert confirmation bar -->
         <Border Grid.Row="3" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
-                BorderThickness="1" CornerRadius="12" Padding="12,10" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="{StaticResource RadiusLg}" Padding="12,10" Margin="0,0,0,12"
                 Visibility="{Binding IsAwaitingConfirm, Converter={StaticResource FlexVis}}">
             <Grid>
                 <Grid.ColumnDefinitions>

--- a/SysManager/SysManager/Views/DuplicateFileView.xaml
+++ b/SysManager/SysManager/Views/DuplicateFileView.xaml
@@ -141,7 +141,7 @@
                                                 </StackPanel>
                                                 <!-- Keep badge: marks the one suggested copy. Uses the Success palette
                                                      ("this is the one to keep"), not a warning colour. -->
-                                                <Border DockPanel.Dock="Left" CornerRadius="8" Padding="6,2" Margin="0,0,8,0"
+                                                <Border DockPanel.Dock="Left" CornerRadius="{StaticResource RadiusMd}" Padding="6,2" Margin="0,0,8,0"
                                                         VerticalAlignment="Center"
                                                         Background="{DynamicResource SuccessBgSubtle}"
                                                         BorderBrush="{DynamicResource SuccessBorder}" BorderThickness="1"

--- a/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
+++ b/SysManager/SysManager/Views/EnvironmentVariablesView.xaml
@@ -185,7 +185,7 @@
                         <ItemsControl ItemsSource="{Binding PathEntries}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <Border Margin="0,2" Padding="8,6" CornerRadius="8" BorderThickness="1"
+                                    <Border Margin="0,2" Padding="8,6" CornerRadius="{StaticResource RadiusMd}" BorderThickness="1"
                                             Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}">
                                         <Grid>
                                             <Grid.ColumnDefinitions>

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -31,7 +31,7 @@
             <TextBlock Text="File Shredder" Style="{StaticResource Display}"/>
             <TextBlock Text="Securely delete files beyond recovery with multi-pass overwrite."
                        Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
-            <Border Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1" CornerRadius="8"
+            <Border Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1" CornerRadius="{StaticResource RadiusMd}"
                     Margin="0,10,0,0" Padding="10,8">
                 <!-- DockPanel, not a horizontal StackPanel: a StackPanel measures children with infinite
                      width along its orientation, so TextWrapping is inert there and this warning clips

--- a/SysManager/SysManager/Views/GamingProfileView.xaml
+++ b/SysManager/SysManager/Views/GamingProfileView.xaml
@@ -90,7 +90,7 @@
 
                         <!-- Per-game optimizations (only meaningful with a game selected) -->
                         <Border Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                                BorderThickness="1" CornerRadius="8" Padding="12,10" Margin="0,10,0,0"
+                                BorderThickness="1" CornerRadius="{StaticResource RadiusMd}" Padding="12,10" Margin="0,10,0,0"
                                 IsEnabled="{Binding HasSelectedGame}">
                             <StackPanel>
                                 <TextBlock Text="Applied to the selected game" Style="{StaticResource Caption}" Margin="0,0,0,6"/>

--- a/SysManager/SysManager/Views/LegacyPanelsView.xaml
+++ b/SysManager/SysManager/Views/LegacyPanelsView.xaml
@@ -44,7 +44,7 @@
                                     <ControlTemplate TargetType="Button">
                                         <Border x:Name="Bd" Background="{DynamicResource Surface2}"
                                                 BorderBrush="{DynamicResource Border1}" BorderThickness="1"
-                                                CornerRadius="8" Padding="14,12">
+                                                CornerRadius="{StaticResource RadiusMd}" Padding="14,12">
                                             <StackPanel>
                                                 <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"
                                                            Foreground="{DynamicResource TextPrimary}"/>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -444,7 +444,7 @@
                             </StackPanel>
 
                             <Expander Header="Full system message" Margin="0,16,0,0" Foreground="{DynamicResource TextSecondary}">
-                                <Border Padding="10" CornerRadius="8" Background="{DynamicResource Surface0}"
+                                <Border Padding="10" CornerRadius="{StaticResource RadiusMd}" Background="{DynamicResource Surface0}"
                                         BorderBrush="{DynamicResource Border1}" BorderThickness="1">
                                     <TextBox Text="{Binding SelectedEntry.FullMessage, Mode=OneWay}"
                                              AutomationProperties.Name="Full system message"
@@ -458,7 +458,7 @@
                             </Expander>
 
                             <Expander Header="Raw XML (for power users)" Margin="0,8,0,0" Foreground="{DynamicResource TextSecondary}">
-                                <Border Padding="10" CornerRadius="8" Background="{DynamicResource Surface0}"
+                                <Border Padding="10" CornerRadius="{StaticResource RadiusMd}" Background="{DynamicResource Surface0}"
                                         BorderBrush="{DynamicResource Border1}" BorderThickness="1">
                                     <TextBox Text="{Binding SelectedEntry.Xml, Mode=OneWay}"
                                              AutomationProperties.Name="Raw event XML"

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml
@@ -25,7 +25,7 @@
                 <TextBlock Text="Winsock and TCP/IP resets require admin and a reboot."
                            Style="{StaticResource Subtle}" Margin="0,0,0,16"/>
 
-                <Border Padding="16" Margin="0,0,0,12" CornerRadius="12" BorderThickness="1">
+                <Border Padding="16" Margin="0,0,0,12" CornerRadius="{StaticResource RadiusLg}" BorderThickness="1">
                     <Border.Style>
                         <Style TargetType="Border">
                             <Setter Property="Background" Value="{DynamicResource Surface1}"/>
@@ -52,7 +52,7 @@
                                 IsEnabled="{Binding IsRepairing, Converter={StaticResource BoolInvert}}"/>
                     </DockPanel>
                 </Border>
-                <Border Padding="16" Margin="0,0,0,12" CornerRadius="12" BorderThickness="1">
+                <Border Padding="16" Margin="0,0,0,12" CornerRadius="{StaticResource RadiusLg}" BorderThickness="1">
                     <Border.Style>
                         <Style TargetType="Border">
                             <Setter Property="Background" Value="{DynamicResource Surface1}"/>
@@ -79,7 +79,7 @@
                                 IsEnabled="{Binding IsRepairing, Converter={StaticResource BoolInvert}}"/>
                     </DockPanel>
                 </Border>
-                <Border Padding="16" Margin="0,0,0,12" CornerRadius="12" BorderThickness="1">
+                <Border Padding="16" Margin="0,0,0,12" CornerRadius="{StaticResource RadiusLg}" BorderThickness="1">
                     <Border.Style>
                         <Style TargetType="Border">
                             <Setter Property="Background" Value="{DynamicResource Surface1}"/>

--- a/SysManager/SysManager/Views/NotificationBlockerView.xaml
+++ b/SysManager/SysManager/Views/NotificationBlockerView.xaml
@@ -85,7 +85,7 @@
                               AutomationProperties.Name="Notification senders">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Border Margin="0,2" Padding="12,10" CornerRadius="8"
+                            <Border Margin="0,2" Padding="12,10" CornerRadius="{StaticResource RadiusMd}"
                                     BorderThickness="1">
                                 <Border.Style>
                                     <Style TargetType="Border">

--- a/SysManager/SysManager/Views/PingView.xaml
+++ b/SysManager/SysManager/Views/PingView.xaml
@@ -119,7 +119,7 @@
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Border Margin="0,0,10,10" Padding="14,12" CornerRadius="12"
+                            <Border Margin="0,0,10,10" Padding="14,12" CornerRadius="{StaticResource RadiusLg}"
                                     Background="{DynamicResource AccentSoft}" BorderBrush="{DynamicResource Border1}" BorderThickness="1">
                                 <Grid>
                                     <Border Background="{Binding ColorHex, Converter={StaticResource HexBrush}}"

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -64,7 +64,7 @@
                 <ItemsControl ItemsSource="{Binding FilteredToggles}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Border Margin="0,2" Padding="12,10" CornerRadius="8"
+                            <Border Margin="0,2" Padding="12,10" CornerRadius="{StaticResource RadiusMd}"
                                     BorderThickness="1">
                                 <Border.Style>
                                     <Style TargetType="Border">

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -176,7 +176,7 @@
                     <DataGridTemplateColumn Header="Status" Width="100" MinWidth="90" SortMemberPath="Status">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Border CornerRadius="8" Padding="8,4" VerticalAlignment="Center"
+                                <Border CornerRadius="{StaticResource RadiusMd}" Padding="8,4" VerticalAlignment="Center"
                                         Background="{DynamicResource Surface3}" BorderThickness="1" BorderBrush="{DynamicResource Border1}">
                                     <Grid>
                                         <Border Width="3" HorizontalAlignment="Left" CornerRadius="2"
@@ -202,7 +202,7 @@
                     <DataGridTemplateColumn Header="Safety" Width="110" MinWidth="100" SortMemberPath="SafetyLevel">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Border CornerRadius="8" Padding="6,3"
+                                <Border CornerRadius="{StaticResource RadiusMd}" Padding="6,3"
                                         Background="{Binding SafetyLevel, Converter={StaticResource ProcSafetyBg}}"
                                         BorderBrush="{Binding SafetyLevel, Converter={StaticResource ProcSafetyBg}}"
                                         BorderThickness="1" HorizontalAlignment="Left"

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -227,7 +227,7 @@
                 <DataGridTemplateColumn Header="Safety" Width="90" MinWidth="80" SortMemberPath="SafetyLevel">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <Border CornerRadius="8" Padding="6,3"
+                            <Border CornerRadius="{StaticResource RadiusMd}" Padding="6,3"
                                     Background="{Binding SafetyLevel, Converter={StaticResource SafetyBg}}"
                                     BorderBrush="{Binding SafetyLevel, Converter={StaticResource SafetyBg}}"
                                     BorderThickness="1" HorizontalAlignment="Left"

--- a/SysManager/SysManager/Views/SettingsWatchdogView.xaml
+++ b/SysManager/SysManager/Views/SettingsWatchdogView.xaml
@@ -67,7 +67,7 @@
 
         <!-- Drift summary banner (warning) -->
         <Border Grid.Row="4" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
-                BorderThickness="1" CornerRadius="12" Padding="12,10" Margin="28,12,28,0"
+                BorderThickness="1" CornerRadius="{StaticResource RadiusLg}" Padding="12,10" Margin="28,12,28,0"
                 Visibility="{Binding HasDrift, Converter={StaticResource FlexVis}}">
             <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width along
                  its orientation, so TextWrapping was inert and this drift notice clipped (#1807). -->

--- a/SysManager/SysManager/Views/SpeedTestView.xaml
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml
@@ -139,7 +139,7 @@
 
                 <!-- Info: Ookla vs HTTP explanation -->
                 <Border Grid.Row="1" Grid.ColumnSpan="2" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}" BorderThickness="1"
-                        CornerRadius="8" Padding="12,10" Margin="0,12,0,0">
+                        CornerRadius="{StaticResource RadiusMd}" Padding="12,10" Margin="0,12,0,0">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="&#xE946;" FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
                                    FontSize="14" Foreground="{DynamicResource Info}" VerticalAlignment="Top" Margin="0,0,10,0"/>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -136,7 +136,7 @@
                     <DataGridTemplateColumn Header="Safety" Width="120" MinWidth="100" SortMemberPath="Safety">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Border CornerRadius="8" Padding="6,3"
+                                <Border CornerRadius="{StaticResource RadiusMd}" Padding="6,3"
                                         Background="{Binding Safety, Converter={StaticResource ProcSafetyBg}}"
                                         BorderBrush="{Binding Safety, Converter={StaticResource ProcSafetyBg}}"
                                         BorderThickness="1" HorizontalAlignment="Left"
@@ -157,7 +157,7 @@
                     <DataGridTemplateColumn Header="Status" Width="100" MinWidth="90" SortMemberPath="StatusText">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Border CornerRadius="8" Padding="8,5" VerticalAlignment="Center" Margin="4,0"
+                                <Border CornerRadius="{StaticResource RadiusMd}" Padding="8,5" VerticalAlignment="Center" Margin="4,0"
                                         BorderThickness="1" BorderBrush="{DynamicResource Border1}">
                                     <Border.Style>
                                         <Style TargetType="Border">

--- a/SysManager/SysManager/Views/ThemePopup.xaml
+++ b/SysManager/SysManager/Views/ThemePopup.xaml
@@ -28,7 +28,7 @@
             <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" MaxHeight="480" Padding="20,14,20,18">
                 <StackPanel>
                     <!-- Mode switcher -->
-                    <Border Background="{DynamicResource Surface0}" CornerRadius="12" Padding="3"
+                    <Border Background="{DynamicResource Surface0}" CornerRadius="{StaticResource RadiusLg}" Padding="3"
                             BorderBrush="{DynamicResource Border1}" BorderThickness="1" Margin="0,0,0,16">
                         <UniformGrid Columns="3">
                             <RadioButton x:Name="DarkMode" Content="Dark" GroupName="Mode"
@@ -64,7 +64,7 @@
                         <TextBlock Text="CUSTOM COLORS" Style="{StaticResource SectionLabel}" Margin="0,0,0,10"/>
 
                         <!-- Accent picker -->
-                        <Border Background="{DynamicResource Surface0}" CornerRadius="12"
+                        <Border Background="{DynamicResource Surface0}" CornerRadius="{StaticResource RadiusLg}"
                                 BorderBrush="{DynamicResource Border1}" BorderThickness="1"
                                 Padding="12,8" Margin="0,0,0,8">
                             <Grid>
@@ -84,7 +84,7 @@
                                      EveryMouseClickableElement_IsAlsoKeyboardOperable lists them with this
                                      reason, so the exemption is visible rather than assumed. -->
                                 <Border Grid.Column="1" x:Name="CustomAccentPreview"
-                                        Width="24" Height="24" CornerRadius="8" Background="#6366F1"
+                                        Width="24" Height="24" CornerRadius="{StaticResource RadiusMd}" Background="#6366F1"
                                         Margin="0,0,10,0" Cursor="Hand"
                                         MouseLeftButtonUp="CustomAccent_Click"/>
                                 <TextBox Grid.Column="2" x:Name="CustomAccentHex" Text="#6366F1"
@@ -97,7 +97,7 @@
                         </Border>
 
                         <!-- Background picker -->
-                        <Border Background="{DynamicResource Surface0}" CornerRadius="12"
+                        <Border Background="{DynamicResource Surface0}" CornerRadius="{StaticResource RadiusLg}"
                                 BorderBrush="{DynamicResource Border1}" BorderThickness="1"
                                 Padding="12,8" Margin="0,0,0,8">
                             <Grid>
@@ -109,7 +109,7 @@
                                 <TextBlock Text="Background" Foreground="{DynamicResource TextSecondary}"
                                            FontSize="12" VerticalAlignment="Center"/>
                                 <Border Grid.Column="1" x:Name="CustomBgPreview"
-                                        Width="24" Height="24" CornerRadius="8" Background="#070A0F"
+                                        Width="24" Height="24" CornerRadius="{StaticResource RadiusMd}" Background="#070A0F"
                                         Margin="0,0,10,0" Cursor="Hand"
                                         MouseLeftButtonUp="CustomBg_Click"/>
                                 <TextBox Grid.Column="2" x:Name="CustomBgHex" Text="#070A0F"
@@ -122,7 +122,7 @@
                         </Border>
 
                         <!-- Surface picker -->
-                        <Border Background="{DynamicResource Surface0}" CornerRadius="12"
+                        <Border Background="{DynamicResource Surface0}" CornerRadius="{StaticResource RadiusLg}"
                                 BorderBrush="{DynamicResource Border1}" BorderThickness="1"
                                 Padding="12,8" Margin="0,0,0,8">
                             <Grid>
@@ -134,7 +134,7 @@
                                 <TextBlock Text="Surface" Foreground="{DynamicResource TextSecondary}"
                                            FontSize="12" VerticalAlignment="Center"/>
                                 <Border Grid.Column="1" x:Name="CustomSurfacePreview"
-                                        Width="24" Height="24" CornerRadius="8" Background="#0E1218"
+                                        Width="24" Height="24" CornerRadius="{StaticResource RadiusMd}" Background="#0E1218"
                                         Margin="0,0,10,0" Cursor="Hand"
                                         MouseLeftButtonUp="CustomSurface_Click"/>
                                 <TextBox Grid.Column="2" x:Name="CustomSurfaceHex" Text="#0E1218"
@@ -147,7 +147,7 @@
                         </Border>
 
                         <!-- Text picker -->
-                        <Border Background="{DynamicResource Surface0}" CornerRadius="12"
+                        <Border Background="{DynamicResource Surface0}" CornerRadius="{StaticResource RadiusLg}"
                                 BorderBrush="{DynamicResource Border1}" BorderThickness="1"
                                 Padding="12,8">
                             <Grid>
@@ -159,7 +159,7 @@
                                 <TextBlock Text="Text" Foreground="{DynamicResource TextSecondary}"
                                            FontSize="12" VerticalAlignment="Center"/>
                                 <Border Grid.Column="1" x:Name="CustomTextPreview"
-                                        Width="24" Height="24" CornerRadius="8" Background="#F1F3F7"
+                                        Width="24" Height="24" CornerRadius="{StaticResource RadiusMd}" Background="#F1F3F7"
                                         Margin="0,0,10,0" Cursor="Hand"
                                         MouseLeftButtonUp="CustomText_Click"/>
                                 <TextBox Grid.Column="2" x:Name="CustomTextHex" Text="#F1F3F7"

--- a/SysManager/SysManager/Views/TimerResolutionView.xaml
+++ b/SysManager/SysManager/Views/TimerResolutionView.xaml
@@ -36,7 +36,7 @@
                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0" VerticalAlignment="Center">
                     <TextBlock Text="{Binding CurrentDisplay}" FontSize="30" FontWeight="Bold"
                                Foreground="{DynamicResource TextPrimary}"/>
-                    <Border CornerRadius="8" Padding="8,3" Margin="14,0,0,0" VerticalAlignment="Center"
+                    <Border CornerRadius="{StaticResource RadiusMd}" Padding="8,3" Margin="14,0,0,0" VerticalAlignment="Center"
                             Background="{DynamicResource Surface3}"
                             Visibility="{Binding IsHighResolution, Converter={StaticResource FlexVis}}">
                         <TextBlock Text="HIGH RESOLUTION" FontSize="11" FontWeight="Bold"
@@ -68,7 +68,7 @@
 
         <!-- Power warning -->
         <Border Grid.Row="3" Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
-                BorderThickness="1" CornerRadius="12" Padding="12,10" Margin="0,0,0,16">
+                BorderThickness="1" CornerRadius="{StaticResource RadiusLg}" Padding="12,10" Margin="0,0,0,16">
             <!-- DockPanel, not a horizontal StackPanel: a StackPanel gives children infinite width along
                  its orientation, so TextWrapping was inert and this warning clipped (#1807). -->
             <DockPanel>

--- a/SysManager/SysManager/Views/TweaksHubView.xaml
+++ b/SysManager/SysManager/Views/TweaksHubView.xaml
@@ -13,7 +13,7 @@
     <UserControl.Resources>
         <!-- One reviewable tweak row: select checkbox + name/description + applied-state pill. -->
         <DataTemplate x:Key="TweakRow">
-            <Border Margin="0,2" Padding="12,10" CornerRadius="8" BorderThickness="1"
+            <Border Margin="0,2" Padding="12,10" CornerRadius="{StaticResource RadiusMd}" BorderThickness="1"
                     Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}">
                 <Grid>
                     <Grid.ColumnDefinitions>
@@ -28,7 +28,7 @@
                         <TextBlock Text="{Binding Description}" FontSize="11" Foreground="{DynamicResource TextMuted}"
                                    TextWrapping="Wrap" Margin="0,2,16,0"/>
                     </StackPanel>
-                    <Border Grid.Column="2" CornerRadius="4" Padding="8,2" VerticalAlignment="Center"
+                    <Border Grid.Column="2" CornerRadius="{StaticResource RadiusSm}" Padding="8,2" VerticalAlignment="Center"
                             Background="{DynamicResource Surface3}">
                         <TextBlock FontSize="10" FontWeight="Bold">
                             <TextBlock.Style>
@@ -93,7 +93,7 @@
                     <StackPanel>
                         <TextBlock Text="ADVANCED" Style="{StaticResource SectionLabel}" Margin="0,0,0,4"/>
                         <Border Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}"
-                                BorderThickness="1" CornerRadius="8" Padding="10,8" Margin="0,0,0,10">
+                                BorderThickness="1" CornerRadius="{StaticResource RadiusMd}" Padding="10,8" Margin="0,0,0,10">
                             <TextBlock Text="Higher-impact, machine-wide changes — review each one. Still fully reversible."
                                        Foreground="{DynamicResource WarningText}" FontSize="12" TextWrapping="Wrap"/>
                         </Border>

--- a/SysManager/SysManager/Views/UninstallerView.xaml
+++ b/SysManager/SysManager/Views/UninstallerView.xaml
@@ -29,7 +29,7 @@
 
         <!-- Elevation banner: not elevated -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="{StaticResource RadiusLg}" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}">
             <DockPanel>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
@@ -49,7 +49,7 @@
              the neutral Surface2/Border1 geometry of the not-elevated banner directly above instead, so
              the slot does not change appearance when the user elevates on another tab and arrives here. -->
         <Border Grid.Row="1" Background="{DynamicResource Surface2}" BorderBrush="{DynamicResource Border1}"
-                BorderThickness="1" CornerRadius="12" Padding="12,8" Margin="0,0,0,12"
+                BorderThickness="1" CornerRadius="{StaticResource RadiusLg}" Padding="12,8" Margin="0,0,0,12"
                 Visibility="{Binding IsElevated, Converter={StaticResource FlexVis}}">
             <!-- DockPanel, not the sibling banners' horizontal StackPanel: this message is the longest in
                  the app, and a StackPanel hands its children infinite width along its orientation, so
@@ -179,7 +179,7 @@
                     <DataGridTemplateColumn Header="Source" Width="90" MinWidth="70" SortMemberPath="Source">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Border CornerRadius="8" Padding="8,4" VerticalAlignment="Center"
+                                <Border CornerRadius="{StaticResource RadiusMd}" Padding="8,4" VerticalAlignment="Center"
                                         BorderThickness="1" BorderBrush="{DynamicResource Border1}"
                                         HorizontalAlignment="Center">
                                     <Border.Style>
@@ -245,7 +245,7 @@
                     <DataGridTemplateColumn Header="Status" Width="180" MinWidth="80" SortMemberPath="Status">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Border CornerRadius="8" Padding="8,4"
+                                <Border CornerRadius="{StaticResource RadiusMd}" Padding="8,4"
                                         Background="{DynamicResource Surface3}" BorderBrush="{DynamicResource Border1}" BorderThickness="1"
                                         VerticalAlignment="Center" Margin="4,0"
                                         Visibility="{Binding Status, Converter={StaticResource FlexVis}}"

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -45,7 +45,7 @@
                                VerticalAlignment="Center" FontSize="12"
                                Visibility="{Binding FilterText, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
                 </Grid>
-                <Border Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1" CornerRadius="4" Padding="6,2" Margin="4,0"
+                <Border Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1" CornerRadius="{StaticResource RadiusSm}" Padding="6,2" Margin="4,0"
                         Visibility="{Binding PendingReboot, Converter={StaticResource BoolToVis}}">
                     <TextBlock Text="⚠ Reboot pending" FontSize="11" Foreground="{DynamicResource Warning}"/>
                 </Border>
@@ -88,7 +88,7 @@
                     <DataGridTemplateColumn Header="Safety" Width="80" MinWidth="80" SortMemberPath="SafetyLevel">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Border CornerRadius="8" Padding="6,3"
+                                <Border CornerRadius="{StaticResource RadiusMd}" Padding="6,3"
                                         Background="{Binding SafetyLevel, Converter={StaticResource SafetyBg}}"
                                         HorizontalAlignment="Left"
                                         ToolTip="{Binding SafetyDescription}">
@@ -152,7 +152,7 @@
                     <DataGridTemplateColumn Header="Status" Width="130" MinWidth="80" SortMemberPath="Status">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Border CornerRadius="8" Padding="8,4" VerticalAlignment="Center"
+                                <Border CornerRadius="{StaticResource RadiusMd}" Padding="8,4" VerticalAlignment="Center"
                                         BorderThickness="1" BorderBrush="{DynamicResource Border1}"
                                         Visibility="{Binding Status, Converter={StaticResource FlexVis}}"
                                         ToolTip="{Binding Status}">

--- a/SysManager/SysManager/Views/WindowsUpdateView.xaml
+++ b/SysManager/SysManager/Views/WindowsUpdateView.xaml
@@ -259,7 +259,7 @@
                     <DataGridTemplateColumn Header="Category" Width="130" MinWidth="100" SortMemberPath="Category">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Border CornerRadius="8" Padding="8,3" HorizontalAlignment="Left"
+                                <Border CornerRadius="{StaticResource RadiusMd}" Padding="8,3" HorizontalAlignment="Left"
                                         BorderThickness="1">
                                     <Border.Style>
                                         <Style TargetType="Border">


### PR DESCRIPTION
Closes #1633. The radius scale existed and was bypassed; now the 69 on-scale literals reference it and the existing guard requires that they do.

**#1633's numbers were stale.** It reported 177 raw values against 1 token use; measured today it was **90 against 30** — partial migration had already happened. The 69 on-scale figure it implies is still right, so the work stands; the framing needed re-deriving first.

## The migration

| value | count | token |
|---:|---:|---|
| 8 | 39 | `RadiusMd` |
| 12 | 19 | `RadiusLg` |
| 4 | 9 | `RadiusSm` |
| 999 | 2 | `RadiusPill` |

**Pixel-for-pixel unchanged, proved from the diff rather than asserted:** 69 values removed, 69 token references added, and the two value spreads are equal — `{8:39, 12:19, 4:9, 999:2}` on both sides. A separate check confirms no added XAML line touches `Margin`, `Padding`, `FontSize`, `Background`, `Width` or `Height`. Nothing in this PR can move a pixel, which is also why it needs no mockup: the mockup-first rule is for iterating on appearance with you, and there is no appearance delta to iterate on.

## Two values stay raw, and they are documented rather than left looking like misses

- **`CornerRadius="2"`, 20 uses** — the accent-stripe hairline on the elevation and preview banners. Off the 4/8/12 scale deliberately; a 4 there reads as a bulge.
- **`CornerRadius="16"`, once** — ThemePopup's outer shell, the only floating panel in the app and deliberately rounder than a card.

Neither has a token, and inventing one would extend a scale chosen as 4/8/12/999. Both are now explained at the token definitions in App.xaml, so the next reader knows they are decisions.

## The guard is extended, not joined

`EveryCornerRadius_IsOnTheScale` already owned this. Its own comment said asking for a token across 175 call sites was *"a separate, purely mechanical migration"* and checked only the **value** — that migration is what this PR is, so leaving the weaker rule would let the finished work unravel one view at a time, each new view looking locally reasonable.

It now enforces three things:

1. an on-scale value must use its token — the new half
2. an off-scale value is still rejected — the original half, unchanged
3. **a referenced token must be defined** — a `StaticResource` inside a `DataTemplate` resolves at *runtime*, so deleting a key still compiles and the first symptom is a crash when the template inflates. That has already happened here once with a Style, so a check that only counted literals would be watching the wrong half.

Token values are **read from App.xaml**, not hardcoded. Changing `RadiusMd` from 8 to 10 must not leave the guard demanding a literal 8 — it would then fail every migrated view for using the very token it asks for.

## Two mistakes caught while writing it, both mine

**A parallel guard, nearly shipped.** I wrote a second radius check before grepping for the existing one. It is removed; the rule belongs in the guard that already owns the subject. What surfaced it was the old guard going red — its vacuity floor was a *measured* population of 90 literals, and migrating 69 of them dropped it to 23, which reads exactly like a broken regex.

That is also why **the floor is now on literals PLUS references**: migrating one moves a count from the first to the second, so a floor on literals alone fires on the correct change. 120 measured, floor 100.

**The guard counted its own documentation.** App.xaml's new comment *quotes* the two raw values to explain them, so the scan saw 23 literals where 21 exist — and worse, deleting the real ThemePopup `16` would have left the comment standing in for it, keeping the off-scale check quiet. XAML comments are stripped now, via a helper whose remarks say why.

## Verification

Five mutations, five reds, restore hash-checked byte-for-byte, final state green:

```
V1  a migrated view reverts to a raw on-scale value  RED  "PrivacyView.xaml: a raw 8 — use RadiusMd"
V2  an off-scale value appears                       RED  "PrivacyView.xaml: CornerRadius=\"10\""
V3  a view references an undefined token             RED  "RadiusHuge is referenced but not defined"
V4  the combined floor raised to 999                 RED  "only 21 numeric radii and 99 token
                                                           references were read (120 against 120)"
V5  the definitions move out of the regex's reach    RED  "only 3 radius tokens were found in App.xaml"
```

V5 changes nothing semantic — it adds a space inside the `<CornerRadius>` element — which is the point: the guard reads those definitions, so a formatting change that hides them must fail loudly rather than quietly enforcing nothing.

All four projects: 0 errors, 0 warnings. Guard suite green (121).

## Notes

- `refactor:` — no release, no version bump, no CHANGELOG entry.
- Nothing here needs verification on your laptop: there is no visual delta to look at. If you want a sanity check anyway, ThemePopup and the elevation banners are where the raw values that stayed live.

Closes #1633
