### PR TITLE
feat: the Drivers tab now says whether Windows signed each driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.79.0] - 2026-09-09
+
+The Drivers tab now shows whether Windows reports each driver as digitally signed. Until now the only clue
+about where a driver came from was the Manufacturer column, and that name is a string the driver package
+supplies about itself, so anyone can write anything in it. The new Signature column comes from Windows
+instead. It stays blank when Windows reports nothing, because "Unsigned" is the kind of word someone acts
+on and it must not stand in for "we do not know".
+
+### Added
+
+- **Drivers — a Signature column, read from Windows rather than from the driver.** `Win32_PnPSignedDriver`,
+  the Windows source this tab already queried, is named for exactly this property, and the query selected
+  four others and dropped it. So the one tab that could answer "is this driver from who it claims?" was
+  answering it with `Manufacturer`, which the driver package fills in about itself. The column says "Signed"
+  or "Unsigned" and deliberately not "Safe": a signature identifies the publisher and nothing more, and
+  Windows will load a signed driver from anyone holding a valid certificate. There are three states rather
+  than two. A driver Windows says nothing about shows blank, and a test pins that absent never renders as
+  unsigned, because on this tab that reads as an accusation and sends someone hunting for a driver to remove.
+
+### Changed
+
+- **A query that fetches a property nothing reads now fails the build.** The dropped `IsSigned` broke
+  nothing and failed nothing: the query worked, the parse worked, and the column that should have existed
+  simply did not exist. `EveryPropertyACimQueryFetches_IsReadBackOut` compares both directions over the
+  queries that return JSON — every property selected has to be parsed, and every property parsed has to be
+  selected — so deleting a value from a query fails as loudly as never reading one. The reverse direction is
+  the one that matters most: parse tests supply their own JSON, so they keep passing while the real query
+  quietly stops asking for the value.
+
 ## [1.78.8] - 2026-09-08
 
 App Blocker's Unblock button asked you to confirm even when it could not do the job. Without

--- a/README.md
+++ b/README.md
@@ -961,7 +961,12 @@ offers, "rate us" prompts:
 
 ### Drivers
 - Sortable DataGrid table of all installed system drivers
-- Columns: Device Name, Manufacturer, Version, Date — click headers to sort
+- Columns: Device Name, Manufacturer, Version, Date, Signature — click headers to sort
+- **Signature** — whether Windows reports the driver as digitally signed. Manufacturer
+  is a name the driver package supplies about itself, so it proves nothing; this column
+  comes from Windows. It says "Signed", not "Safe" — a signature identifies the
+  publisher, and Windows will load a signed driver from anyone with a valid
+  certificate. Blank means Windows reported nothing, which is not the same as unsigned
 - **Hide built-in Windows drivers** — tick the filter to leave only the drivers your
   hardware maker installed (graphics, audio, network, …), which is usually what you
   care about when checking whether something needs updating. The count shows both

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.78.x   | :white_check_mark: |
-| < 1.78   | :x:                |
+| 1.79.x   | :white_check_mark: |
+| < 1.79   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -9480,4 +9480,111 @@ public partial class ArchitectureTests
             + "as \"non-negative\":\n  "
             + string.Join("\n  ", offenders));
     }
+
+    /// <summary>
+    /// Every property a PowerShell query fetches must be read back out of the JSON. A property selected
+    /// and never parsed is invisible to the compiler and to every test.
+    /// </summary>
+    /// <remarks>
+    /// This is #1581's defect exactly. <c>DriversViewModel</c> queried <c>Win32_PnPSignedDriver</c> — a CIM
+    /// class named for the one thing it reports — selected <c>DeviceName, DriverVersion, Manufacturer,
+    /// DriverDate</c>, and dropped <c>IsSigned</c>. So the tab that could answer "is this driver from who it
+    /// claims?" showed only <c>Manufacturer</c>, which is a string the driver package supplies about itself.
+    /// Nothing failed: the query worked, the parse worked, the column that should have existed simply did
+    /// not, which is this repo's dominant recurring shape — surface that is fetched or implemented and never
+    /// read.
+    /// <para><b>Scoped to queries piped through <c>ConvertTo-Json</c></b>, because that is the only shape
+    /// where "selected" and "parsed" are separately checkable. The other seven <c>Select-Object</c> call
+    /// sites format their own output — <c>WindowsFeaturesService</c> pipes through
+    /// <c>ForEach-Object { $_.FeatureName + '|' + $_.State }</c> and splits on the delimiter — so a
+    /// JSON-property check would report every one of them as dropped. It did, on the first run: 5 false
+    /// positives across 2 files, which is why the scope is the pipe and not the keyword.</para>
+    /// <para>Both name syntaxes count. A plain list gives <c>Select-Object DeviceName, IsSigned</c>;
+    /// Windows Update builds calculated properties instead, <c>@{N='Title';E={...}}</c>, and its names are
+    /// just as much a contract with the parser.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryPropertyACimQueryFetches_IsReadBackOut()
+    {
+        var appDir = FindAppProjectDir();
+        var offenders = new List<string>();
+        var filesChecked = 0;
+        var namesChecked = 0;
+
+        foreach (var path in Directory
+                     .EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories)
+                     .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                                             StringComparison.Ordinal))
+                     .OrderBy(f => f, StringComparer.Ordinal))
+        {
+            var source = File.ReadAllText(path);
+            if (!source.Contains("ConvertTo-Json", StringComparison.Ordinal)
+                || !source.Contains("Select-Object", StringComparison.Ordinal))
+                continue;
+
+            filesChecked++;
+            var name = Path.GetFileName(path);
+
+            var parsed = JsonPropertyRead().Matches(source)
+                .Select(m => m.Groups[1].Value)
+                .ToHashSet(StringComparer.Ordinal);
+
+            var selected = SelectedPropertyList().Matches(source)
+                .SelectMany(m => m.Groups[1].Value.Split(',', StringSplitOptions.TrimEntries))
+                .Concat(SelectedCalculatedProperty().Matches(source).Select(m => m.Groups[1].Value))
+                .Where(n => n.Length > 0)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            foreach (var property in selected)
+            {
+                namesChecked++;
+                if (!parsed.Contains(property))
+                    offenders.Add($"{name}: the query fetches {property} and nothing reads it");
+            }
+
+            // And the reverse, which is the direction that catches a property REMOVED from the query.
+            // Without it, deleting IsSigned from the Select-Object would fail nothing: the parse tests
+            // supply their own JSON, so they keep passing while the real query stops fetching the value.
+            var selectedSet = selected.ToHashSet(StringComparer.Ordinal);
+            foreach (var property in parsed.OrderBy(p => p, StringComparer.Ordinal))
+            {
+                namesChecked++;
+                if (!selectedSet.Contains(property))
+                    offenders.Add($"{name}: {property} is parsed but the query never fetches it");
+            }
+        }
+
+        // 24 checks across 2 files when measured. A collapse means the pipe-shape detection stopped
+        // matching, and a clean result over zero queries proves nothing. Counted in BOTH directions, so
+        // the number is names-selected plus names-parsed rather than distinct properties; the floor sits
+        // under the real total so a legitimate query change does not read as a broken pattern.
+        Assert.True(filesChecked >= 2 && namesChecked >= 20,
+            $"only {namesChecked} property checks across {filesChecked} JSON-returning queries ran — the "
+            + "pipe-shape detection is out of date, so a pass proves nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "these queries fetch a property that nothing parses. Fetching it costs the same as using it, so "
+            + "the column or field it was meant to feed is simply missing — which no test can see, because "
+            + "the query and the parse both work:\n  "
+            + string.Join("\n  ", offenders)
+            + $"\n({namesChecked} selected properties checked across {filesChecked} queries)");
+    }
+
+    /// <summary>A property read out of a parsed JSON element.</summary>
+    [GeneratedRegex(@"(?:TryGetProperty|GetProperty)\(\s*""([A-Za-z0-9_]+)""", RegexOptions.Compiled)]
+    private static partial Regex JsonPropertyRead();
+
+    /// <summary>A plain property name in a <c>Select-Object</c> list.</summary>
+    /// <remarks>
+    /// Anchored on the keyword and stopping at the pipe, so it reads the list rather than the rest of the
+    /// script. Only bare identifiers are captured; a wildcard or an expression is not a name a parser can
+    /// be held to.
+    /// </remarks>
+    [GeneratedRegex(@"Select-Object\s+((?:[A-Za-z0-9_]+\s*,\s*)*[A-Za-z0-9_]+)", RegexOptions.Compiled)]
+    private static partial Regex SelectedPropertyList();
+
+    /// <summary>A calculated property's name: <c>@{N='Title';E={...}}</c> or <c>@{Name='Title';...}</c>.</summary>
+    [GeneratedRegex(@"@\{\s*N(?:ame)?\s*=\s*'([A-Za-z0-9_]+)'", RegexOptions.Compiled)]
+    private static partial Regex SelectedCalculatedProperty();
 }

--- a/SysManager/SysManager.Tests/DriversViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DriversViewModelTests.cs
@@ -122,6 +122,32 @@ public class DriversViewModelTests
     }
 
     [Fact]
+    public void ParseDriverJson_CarriesTheSignatureStateThrough()
+    {
+        var vm = NewVm();
+        var method = typeof(DriversViewModel)
+            .GetMethod("ParseDriverJson", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        // The third entry omits IsSigned entirely, which is the case that must stay blank rather than
+        // become "Unsigned" — a query change or a Windows edition that stops reporting it lands here.
+        var json = """
+        [
+            {"DeviceName":"Signed one","Manufacturer":"Intel","DriverVersion":"1","IsSigned":true},
+            {"DeviceName":"Unsigned one","Manufacturer":"Somebody","DriverVersion":"2","IsSigned":false},
+            {"DeviceName":"Unknown one","Manufacturer":"Somebody","DriverVersion":"3"}
+        ]
+        """;
+
+        method.Invoke(vm, new object[] { json });
+
+        Assert.Equal(3, vm.Drivers.Count);
+        Assert.Equal("Signed", vm.Drivers[0].SignatureDisplay);
+        Assert.Equal("Unsigned", vm.Drivers[1].SignatureDisplay);
+        Assert.Equal("", vm.Drivers[2].SignatureDisplay);
+        Assert.Null(vm.Drivers[2].IsSigned);
+    }
+
+    [Fact]
     public void ParseDriverJson_SingleObject_PopulatesOneDriver()
     {
         var vm = NewVm();
@@ -352,5 +378,58 @@ public class DriverEntryTests
         Assert.Equal("", entry.Manufacturer);
         Assert.Equal("", entry.DriverVersion);
         Assert.Null(entry.DriverDate);
+        Assert.Null(entry.IsSigned);
+        Assert.Equal("", entry.SignatureDisplay);
+    }
+
+    // ── Signature state (#1581) ──────────────────────────────────────────────
+    //
+    // Win32_PnPSignedDriver is named for exactly this and the query dropped it, so the tab that could
+    // answer "is this from who it claims?" showed only Manufacturer — a string the driver package supplies
+    // about itself. The whole value of these tests is the THIRD state: an absent value must not render as
+    // "Unsigned", because on this tab that is an accusation a user may act on.
+
+    [Theory]
+    [InlineData(true, "Signed")]
+    [InlineData(false, "Unsigned")]
+    [InlineData(null, "")]
+    public void SignatureDisplay_SaysSignedOrUnsignedAndNothingWhenUnknown(bool? signed, string expected)
+        => Assert.Equal(expected, new DriverEntry { IsSigned = signed }.SignatureDisplay);
+
+    /// <summary>
+    /// It says "Signed", never "Safe" — a signature identifies the publisher and nothing more, and Windows
+    /// loads a signed driver from anyone holding a valid certificate.
+    /// </summary>
+    [Fact]
+    public void SignatureDisplay_NeverClaimsTheDriverIsSafe()
+    {
+        foreach (var signed in new bool?[] { true, false, null })
+        {
+            var text = new DriverEntry { IsSigned = signed }.SignatureDisplay;
+            Assert.DoesNotContain("safe", text, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("trusted", text, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData("\"True\"", true)]      // ConvertTo-Json can surface the value as a string
+    [InlineData("\"False\"", false)]
+    [InlineData("null", null)]
+    [InlineData("\"\"", null)]          // present but unparseable is unknown, not false
+    [InlineData("42", null)]
+    public void ParseCimBool_KeepsAbsentDistinctFromFalse(string json, bool? expected)
+    {
+        using var doc = System.Text.Json.JsonDocument.Parse(json);
+        Assert.Equal(expected, DriversViewModel.ParseCimBool(doc.RootElement));
+    }
+
+    [Fact]
+    public void ParseCimBool_WithAnAbsentProperty_IsUnknown()
+    {
+        using var doc = System.Text.Json.JsonDocument.Parse("""{"DeviceName":"x"}""");
+        var absent = doc.RootElement.TryGetProperty("IsSigned", out var el) ? el : default;
+        Assert.Null(DriversViewModel.ParseCimBool(absent));
     }
 }

--- a/SysManager/SysManager/Models/DriverEntry.cs
+++ b/SysManager/SysManager/Models/DriverEntry.cs
@@ -16,6 +16,35 @@ public sealed record DriverEntry
     public string DriverVersion { get; init; } = "";
     public DateTime? DriverDate { get; init; }
 
+    /// <summary>
+    /// Whether Windows reports this driver as digitally signed. <c>null</c> when the value was absent
+    /// from the query result, which is not the same as unsigned.
+    /// </summary>
+    /// <remarks>
+    /// <c>Win32_PnPSignedDriver</c> is named for exactly this, and the query selected four other
+    /// properties and dropped it (#1581) — so the tab that could answer "is this from who it claims?"
+    /// showed only <c>Manufacturer</c>, which is a string the driver package supplies about itself.
+    /// <para>Nullable on purpose. A missing value must not render as "Unsigned": that would turn "Windows
+    /// did not tell us" into an accusation, and on this tab an accusation is what sends someone hunting
+    /// for a driver to remove. Absent stays blank.</para>
+    /// </remarks>
+    public bool? IsSigned { get; init; }
+
     /// <summary>Formatted date for display (yyyy-MM-dd or empty).</summary>
     public string DriverDateDisplay => DriverDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "";
+
+    /// <summary>
+    /// What the signature column shows: <c>Signed</c>, <c>Unsigned</c>, or empty when unknown.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately says "Signed", not "Safe". A signature proves who published the driver, not that the
+    /// driver is good — and Windows itself will load a signed driver from anyone with a valid certificate.
+    /// Overstating it here would be worse than the unverified <c>Manufacturer</c> string it sits beside.
+    /// </remarks>
+    public string SignatureDisplay => IsSigned switch
+    {
+        true => "Signed",
+        false => "Unsigned",
+        null => "",
+    };
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.78.8</Version>
-    <FileVersion>1.78.8.0</FileVersion>
-    <AssemblyVersion>1.78.8.0</AssemblyVersion>
+    <Version>1.79.0</Version>
+    <FileVersion>1.79.0.0</FileVersion>
+    <AssemblyVersion>1.79.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DriversViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DriversViewModel.cs
@@ -83,7 +83,7 @@ public sealed partial class DriversViewModel : ViewModelBase
                 await _runner.RunScriptViaPwshAsync(@"
                     Get-CimInstance Win32_PnPSignedDriver |
                       Where-Object { $_.DeviceName -and $_.DriverVersion } |
-                      Select-Object DeviceName, DriverVersion, Manufacturer, DriverDate |
+                      Select-Object DeviceName, DriverVersion, Manufacturer, DriverDate, IsSigned |
                       ConvertTo-Json -Compress
                 ", cancellationToken: _cts.Token);
             }
@@ -135,6 +135,7 @@ public sealed partial class DriversViewModel : ViewModelBase
                 Manufacturer = el.TryGetProperty("Manufacturer", out var mf) ? mf.GetString() ?? "" : "",
                 DriverVersion = el.TryGetProperty("DriverVersion", out var dv) ? dv.GetString() ?? "" : "",
                 DriverDate = ParseCimDate(el.TryGetProperty("DriverDate", out var dd) ? dd : default),
+                IsSigned = ParseCimBool(el.TryGetProperty("IsSigned", out var sg) ? sg : default),
             }))
             {
                 _allDrivers.Add(entry);
@@ -176,6 +177,24 @@ public sealed partial class DriversViewModel : ViewModelBase
     /// <summary>
     /// CIM dates come as "/Date(ticks)/" strings in JSON.
     /// </summary>
+    /// <summary>
+    /// Reads a CIM boolean, keeping "absent" distinct from "false".
+    /// </summary>
+    /// <remarks>
+    /// The distinction is the point (#1581). If a missing <c>IsSigned</c> collapsed to <c>false</c>, the
+    /// column would call a driver unsigned because Windows declined to say — and on this tab that reads as
+    /// an accusation the user may act on. <c>ConvertTo-Json</c> can also emit the value as the strings
+    /// "True"/"False" depending on how the property is surfaced, so both shapes are accepted; anything else
+    /// is unknown rather than guessed at.
+    /// </remarks>
+    internal static bool? ParseCimBool(JsonElement el) => el.ValueKind switch
+    {
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        JsonValueKind.String => bool.TryParse(el.GetString(), out var parsed) ? parsed : null,
+        _ => null,
+    };
+
     private static DateTime? ParseCimDate(JsonElement el)
     {
         if (el.ValueKind == JsonValueKind.Null || el.ValueKind == JsonValueKind.Undefined)

--- a/SysManager/SysManager/Views/DriversView.xaml
+++ b/SysManager/SysManager/Views/DriversView.xaml
@@ -104,6 +104,22 @@
                                 </Style>
                             </DataGridTextColumn.ElementStyle>
                         </DataGridTextColumn>
+
+                        <!-- Win32_PnPSignedDriver is named for this, and the query dropped it (#1581), so the
+                             one column that could say "is this from who it claims?" was missing while
+                             Manufacturer — a string the driver package supplies about itself — sat beside it.
+                             Blank when Windows did not report a value: "Unsigned" is an accusation a user may
+                             act on, and it must not stand in for "we do not know". Deliberately says "Signed"
+                             rather than "Safe" — a signature identifies the publisher, nothing more. -->
+                        <DataGridTextColumn Header="Signature" Binding="{Binding SignatureDisplay}" Width="100" MinWidth="80"
+                                            SortMemberPath="SignatureDisplay">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="FontSize" Value="12"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
                     </DataGrid.Columns>
                 </DataGrid>
                 <!-- Nothing scanned yet -->


### PR DESCRIPTION
## The problem

`Win32_PnPSignedDriver` is the CIM class the Drivers tab already queried. It is named for one
property, and the query dropped it:

```
Select-Object DeviceName, DriverVersion, Manufacturer, DriverDate |
```

So the one tab that could answer *"is this driver from who it claims?"* answered it with
`Manufacturer` — a string the driver package supplies about itself. Nothing failed. The query
worked, the parse worked, and the column that should have existed simply did not, which is this
repo's dominant recurring shape.

## What changed

**A `Signature` column, read from Windows rather than from the driver.** `IsSigned` joins the
`Select-Object`, and `DriverEntry.SignatureDisplay` renders it.

**Three states, not two.** `bool? IsSigned` — `null` when Windows reported nothing.

| `IsSigned` | Column |
|---|---|
| `true` | `Signed` |
| `false` | `Unsigned` |
| absent | *(blank)* |

Collapsing absent to `false` would turn "Windows did not tell us" into an accusation, and on this
tab an accusation is what sends someone hunting for a driver to remove. `ParseCimBool` keeps the
two apart and also accepts the `"True"`/`"False"` string shape `ConvertTo-Json` sometimes emits,
rather than reading either as unknown.

**It says "Signed", never "Safe".** A signature identifies the publisher and nothing more — Windows
will load a signed driver from anyone holding a valid certificate. Overstating it here would be
worse than the unverified `Manufacturer` string it sits beside. A test pins the wording.

**The column matches the four beside it exactly** — `DataGridTextColumn`, `Width="100"
MinWidth="80"`, `FontSize 12`, `TextSecondary`, `SortMemberPath`. Same shape as `Manufacturer`. No
new converter, no new style, no invented pattern.

## The guard

`ArchitectureTests.EveryPropertyACimQueryFetches_IsReadBackOut` checks **both directions** over
every PowerShell query piped through `ConvertTo-Json`:

- every property `Select-Object` fetches must be read back out of the JSON, and
- every property something parses must actually be fetched.

The reverse direction is the one that matters. Delete `IsSigned` from the query and the parse tests
keep passing, because they supply their own JSON — the real query just quietly stops asking. That
mutation is W1 below, and without the reverse check it is green.

Scoped to the `ConvertTo-Json` pipe, not the `Select-Object` keyword. The other seven call sites
format their own output — `WindowsFeaturesService` pipes through
`ForEach-Object { $_.FeatureName + '|' + $_.State }` and splits on the delimiter — and a
JSON-property check reported 5 of them as dropped on the first run. Both name syntaxes count: a
plain list, and Windows Update's calculated `@{N='Title';E={...}}`.

Floor: `filesChecked >= 2 && namesChecked >= 20`. Measured at **2 files, 24 checks** — 2 of 2
`ConvertTo-Json` files in the app, with no file skipped for lacking a `Select-Object`.

## Red/green proof

Six mutations, each restored and SHA-verified, baseline and final rebuild green:

| | Mutation | Result |
|---|---|---|
| W1 | `IsSigned` removed from the CIM query | **RED** — *IsSigned is parsed but the query never fetches it* |
| W2 | a parsed property never selected (`Manufacturer` → `Vendor`) | **RED** — same guard, parsed side |
| W3 | a selected property never parsed (`InfName` added) | **RED** — *the query fetches InfName and nothing reads it* |
| W4 | absent `IsSigned` collapses to `false` | **RED** — `ParseCimBool_KeepsAbsentDistinctFromFalse` + the carry-through test |
| W5 | `SignatureDisplay` says `"Safe"` | **RED** — `SignatureDisplay_NeverClaimsTheDriverIsSafe` |
| W6 | the floor raised to 999 | **RED** — printed *"only 24 property checks across 2 JSON-returning queries"* |

## Verification

- All four projects: **0 errors, 0 warnings** (Release).
- Unit suite: **5241 total, 0 failed** (was 5227; 14 new cases).
- Protocol I: no debris in added lines, no generic/empty catch, no `ManagementObject`, author
  headers present, all 9 files CRLF, identity `laurentiu021`, leak scan over all 43 patterns with a
  positive control — **0 hits in 300 added lines** (the two repo-wide hits are pre-existing
  privacy-toggle feature names).
- Docs in this PR: README Drivers columns + a paragraph on what the column does and does not
  claim; SECURITY supported versions 1.78.x → 1.79.x; CHANGELOG 1.79.0; csproj 1.79.0.

## Deliberately not in this PR

`Refs #1581`, not `Closes`. The issue also covers Startup Manager and Context Menu, where there is
no Windows-supplied flag to read — that needs real verification of the file on disk
(`X509Certificate.CreateFromSignedFile` + `X509Chain`), which means chain building, a cache, an
off-thread call and a timeout before it can go near a list that renders per row. Different risk,
separate PR.
