### PR TITLE
feat: Startup Manager now shows where each entry actually lives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.80.0] - 2026-09-09
+
+Startup Manager now shows where each entry actually lives: a registry Run key and which hive it is in, a
+Startup folder, or Task Scheduler. The app had worked this out for every entry since the tab shipped and
+then kept it to itself. It matters because entries are not equal. Turning off an all-users entry needs
+administrator rights, and one placed by a system policy cannot be turned off from this tab at all, yet all
+three looked identical in the list.
+
+### Added
+
+- **Startup Manager — a Location column.** Every scan filled `Location` in for all three sources, the tests
+  asserted it was never blank, and no column bound it, so the work was thrown away on every refresh
+  (#1587). The column sits after Publisher with the same styling, ellipsizes from the end so the hive stays
+  readable, and puts the full path on hover.
+
+### Changed
+
+- **A field the startup scan fills in must now be shown or declared logic-only.** The build fails on a third
+  option, which is what `Location` had been for as long as the tab existed. `Source`, `RegistryKey`,
+  `ValueName` and `TaskPath` are named as steering the toggle and the Open button rather than being
+  displayed; anything else added later fails until someone decides which it is. The check also runs per
+  construction site rather than over their union, because a field dropped from one of the three would leave
+  that one source blank while the other two looked correct — the hardest kind of gap to notice.
+
 ## [1.79.0] - 2026-09-09
 
 The Drivers tab now shows whether Windows reports each driver as digitally signed. Until now the only clue

--- a/README.md
+++ b/README.md
@@ -483,11 +483,15 @@ a confirmation before it runs:
 - Toggle on/off without deleting the original entry (same mechanism as Task Manager) — the disable
   flag is written to the location Windows actually reads for that kind of entry, so a disabled item
   really stays down
-- Sort by name, publisher, safety, or status via clickable column headers
+- Sort by name, publisher, location, safety, or status via clickable column headers
 - Plain-language description for recognised programs (from the built-in database) instead
   of a raw command line, plus a Safety chip — Windows / Known app / Not recognised — so you
   can tell what an entry is before deciding whether to turn it off
 - Shows name, publisher, and enabled/disabled status; the full command path is on hover
+- **A Location column** saying where the entry actually lives — which registry Run key and hive, which
+  Startup folder, or Task Scheduler. This is the difference between an entry you can switch off yourself,
+  one that needs administrator rights, and one a system policy holds in place; long paths shorten from
+  the end, with the full value on hover
 - Open file location in Explorer
 
 ### Windows Features

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.79.x   | :white_check_mark: |
-| < 1.79   | :x:                |
+| 1.80.x   | :white_check_mark: |
+| < 1.80   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -6507,6 +6507,133 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Every field the startup scan fills in on a <c>StartupEntry</c> is either bound in
+    /// <c>StartupView.xaml</c> or named here as logic-only. A new one is neither, so it fails until someone
+    /// decides which it is.
+    /// </summary>
+    /// <remarks>
+    /// <para>The same defect as <see cref="EveryScheduledTaskFieldTheQueryFetches_IsBoundInTheView"/>, one
+    /// tab over. <c>Location</c> was assigned at all three construction sites — the folder builder, the
+    /// scheduled-task reader and the Run-key reader — and <c>StartupServiceTests</c> asserted it was never
+    /// blank, while no column bound it (#1587). So a Run entry whose toggle needs admin, and a policy-key
+    /// entry that cannot be toggled from this tab at all, looked exactly like a plain per-user one.</para>
+    /// <para><b>Why this is per-tab and not a widening of
+    /// <see cref="EveryViewModelProperty_IsShownOrRead"/>.</b> Both global guards test a property NAME
+    /// against every view concatenated, and four types own a <c>Location</c>: <c>ContextMenuEntry</c>,
+    /// <c>BrokenShortcut</c>, a nested type in <c>SettingsWatchdogViewModel</c>, and this one. Three of them
+    /// are bound, so the name is present in the XAML blob and <c>StartupEntry.Location</c> read as bound by
+    /// bindings that belong to other tabs. Measured: with the criterion tightened to word-boundary matching
+    /// AND a declaring-type requirement on the C# side, it still did not appear, because
+    /// <c>ContextMenuView.xaml</c> alone satisfies the name. Only the tab's own view can answer for the
+    /// tab's own model.</para>
+    /// <para><c>Location</c> is required in its column form, <c>Binding="{Binding Location}"</c>, not merely
+    /// somewhere in the file: it is bound twice, as the column value and as that column's tooltip, so a bare
+    /// check would stay green with the column deleted. Same distinction the Task Scheduler guard documents
+    /// for <c>DescriptionDisplay</c>.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryStartupFieldTheScanFillsIn_IsBoundInTheViewOrDeclaredLogicOnly()
+    {
+        var appDir = FindAppProjectDir();
+        var service = DocComment().Replace(
+            File.ReadAllText(Path.Combine(appDir, "Services", "StartupService.cs")), string.Empty);
+        var view = WithoutXamlComments(
+            File.ReadAllText(Path.Combine(appDir, "Views", "StartupView.xaml")));
+
+        // What the user is entitled to see, because the scan pays to work it out.
+        string[] displayed = ["Name", "Command", "Location", "IsEnabled", "Publisher", "StatusText"];
+        // Not display: these steer the toggle and the Open button. Demanding UI for them would push this
+        // guard into asking for columns nobody wants, which is how the sibling guard's scope was drawn too.
+        string[] logicOnly = ["Source", "RegistryKey", "ValueName", "TaskPath"];
+
+        var perSite = ObjectInitializerBodies(service, "StartupEntry")
+            .Select(body => InitializerAssignment().Matches(body)
+                .Select(m => m.Groups[1].Value)
+                .ToHashSet(StringComparer.Ordinal))
+            .ToList();
+        var assigned = new SortedSet<string>(perSite.SelectMany(s => s), StringComparer.Ordinal);
+
+        // Vacuity floor. If the construction sites are reshaped and this parses nothing, every check below
+        // passes over an empty set. 3 sites, 10 distinct fields when measured.
+        Assert.True(perSite.Count >= 3 && assigned.Count >= 9,
+            $"only {assigned.Count} assigned StartupEntry fields were parsed across {perSite.Count} "
+            + "construction sites — the initializer detection is out of date, so a pass proves nothing. "
+            + "Found: " + string.Join(", ", assigned));
+
+        // EVERY site, not the union. A field dropped from one of the three would still be in the union, and
+        // the tab would render blank for that one source only — which is the hardest kind of gap to notice,
+        // because the other two sources look right.
+        var partial = perSite
+            .Select((fields, i) => (Site: i + 1, Missing: displayed.Except(fields, StringComparer.Ordinal).ToList()))
+            .Where(x => x.Missing.Count > 0)
+            .Select(x => $"construction site {x.Site} does not assign {string.Join(", ", x.Missing)}")
+            .ToList();
+        Assert.True(partial.Count == 0,
+            "a displayed field is filled in at some StartupEntry construction sites and not others, so the "
+            + "column is blank for entries from that one source while the rest look correct:\n  "
+            + string.Join("\n  ", partial));
+
+        // A field that is neither displayed nor declared logic-only is the defect itself: nobody has decided
+        // whether the user should see it. #1581's IsSigned and this Location both entered exactly here.
+        var undecided = assigned.Except(displayed).Except(logicOnly, StringComparer.Ordinal).ToList();
+        Assert.True(undecided.Count == 0,
+            "the startup scan fills these in and this guard does not know whether the user should see them. "
+            + "Bind them in StartupView.xaml and add them to `displayed`, or declare them logic-only and say "
+            + $"why:\n  {string.Join("\n  ", undecided)}");
+
+        // And the reverse: a name in `displayed` that the scan stopped assigning would make its binding
+        // check meaningless while still passing.
+        var notAssigned = displayed.Except(assigned, StringComparer.Ordinal).ToList();
+        Assert.True(notAssigned.Count == 0,
+            "these are listed as displayed but the scan no longer assigns them, so the binding checks below "
+            + $"are measuring nothing:\n  {string.Join("\n  ", notAssigned)}");
+
+        var unbound = displayed
+            .Where(f => !view.Contains($"{{Binding {f}}}", StringComparison.Ordinal)
+                     && !view.Contains($"{{Binding {f},", StringComparison.Ordinal))
+            .ToList();
+        Assert.True(unbound.Count == 0,
+            "the startup scan works these out on every refresh and StartupView.xaml shows none of them, so "
+            + "the user cannot see data the app already holds — the defect neither the compiler nor a "
+            + $"view-model test can see:\n  {string.Join("\n  ", unbound)}");
+
+        Assert.True(view.Contains("Binding=\"{Binding Location}\"", StringComparison.Ordinal),
+            "Location is bound somewhere in StartupView.xaml but not as a column value. It is also the "
+            + "column's own tooltip, so the tooltip alone satisfies a bare check while the column is gone — "
+            + "which is the state #1587 reported. Require the column.");
+    }
+
+    /// <summary>
+    /// The brace-matched bodies of every <c>new T { … }</c> and <c>new() { … }</c> in <paramref name="source"/>.
+    /// </summary>
+    /// <remarks>
+    /// <c>new()</c> counts because the target-typed form is how <c>BuildStartupFolderEntry</c> constructs its
+    /// entry, and keying only on the spelled-out type name would have skipped a third of the sites.
+    /// </remarks>
+    private static IEnumerable<string> ObjectInitializerBodies(string source, string typeName)
+    {
+        foreach (var m in Regex.Matches(source, $@"new\s*(?:{Regex.Escape(typeName)}\s*|\(\)\s*)\{{")
+                     .Cast<Match>())
+        {
+            var open = m.Index + m.Length - 1;
+            var depth = 0;
+            for (var i = open; i < source.Length; i++)
+            {
+                if (source[i] == '{') depth++;
+                else if (source[i] == '}' && --depth == 0)
+                {
+                    yield return source[(open + 1)..i];
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>A property assignment at the start of a line inside an object initializer.</summary>
+    [GeneratedRegex(@"^\s*(\w+)\s*=(?!=)", RegexOptions.Compiled | RegexOptions.Multiline)]
+    private static partial Regex InitializerAssignment();
+
+    /// <summary>
     /// The CHANGELOG's version headers must form an unbroken descending run — no version may be missing
     /// between the newest and oldest entry, and none may appear twice.
     /// </summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.79.0</Version>
-    <FileVersion>1.79.0.0</FileVersion>
-    <AssemblyVersion>1.79.0.0</AssemblyVersion>
+    <Version>1.80.0</Version>
+    <FileVersion>1.80.0.0</FileVersion>
+    <AssemblyVersion>1.80.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -127,6 +127,26 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
+                    <!-- Where the entry actually lives: a Run key and its hive, a Startup folder, or Task
+                         Scheduler. StartupService has filled this in for every source since the tab shipped
+                         and the unit tests assert it is never blank, but no column bound it (#1587) — so an
+                         entry whose toggle needs admin, or one in the policy Run key that cannot be toggled
+                         from here at all, looked identical to a plain per-user Run entry. Same ElementStyle
+                         as Publisher above; a registry path is longer than a company name, hence 150 rather
+                         than 140, and it ellipsizes from the end so the hive stays visible with the full
+                         value on hover. -->
+                    <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="150" MinWidth="100"
+                                        SortMemberPath="Location" IsReadOnly="True">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+                                <Setter Property="FontSize" Value="12"/>
+                                <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+                                <Setter Property="ToolTip" Value="{Binding Location}"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+
                     <!-- Safety/provenance from the built-in database. Chip structure matches the Process
                          Manager tab's Safety column (ProcessManagerView.xaml) and uses the same
                          ProcessSafety* converters, so "is this Windows, or something I installed?" is


### PR DESCRIPTION
## The problem

`Location` was assigned at all three `StartupEntry` construction sites — the folder builder, the
scheduled-task reader, the Run-key reader — `StartupServiceTests.ScanAsync_EntriesHaveLocation`
asserted it was never blank, and **no column bound it** (#1587). The scan worked it out on every
refresh and threw the answer away.

That matters because the entries are not equivalent:

| Entry | What the toggle does |
|---|---|
| per-user Run key | works |
| all-users Run key | needs administrator rights |
| policy Run key | cannot be toggled from this tab at all |
| Startup folder / scheduled task | works, different mechanism |

All of them looked identical in the list.

## What changed

A `Location` column after Publisher, with Publisher's exact `ElementStyle` (`TextSecondary`,
`FontSize 12`, `CharacterEllipsis`, self-tooltip) and `SortMemberPath`. `Width="150"` rather than
Publisher's 140 because a registry path is longer than a company name; it ellipsizes from the end so
the hive stays readable, and the full value is on hover.

## The guard

`EveryStartupFieldTheScanFillsIn_IsBoundInTheViewOrDeclaredLogicOnly` — every field the scan fills
in on a `StartupEntry` is either bound in `StartupView.xaml` or named as logic-only. `Source`,
`RegistryKey`, `ValueName` and `TaskPath` steer the toggle and the Open button. A **third** option is
exactly what `Location` had been since the tab shipped, so a newly assigned field fails until someone
decides which bucket it is in.

Two deliberate strengthenings:

- **Per construction site, not over their union.** A field dropped from one of the three sites stays
  in the union, and the tab would render blank for that one source while the other two looked
  correct. That is mutation S4.
- **`Location` is required in its column form**, `Binding="{Binding Location}"`, not merely present.
  It is bound twice — column value and that column's tooltip — so a bare check stays green with the
  column deleted. That is mutation S2, and it is green without this assertion.

### Why per-tab, rather than widening `EveryViewModelProperty_IsShownOrRead`

Both global guards test a property **name** against every view concatenated. Four types own a
`Location`: `ContextMenuEntry`, `BrokenShortcut`, a nested type in `SettingsWatchdogViewModel`, and
this one. Three are bound, so the name is present in the XAML blob and `StartupEntry.Location` read
as bound by other tabs' bindings.

I measured this rather than assuming it. With the criterion tightened two ways — word-boundary
matching instead of `Contains` (`Location` is a substring of `OpenFileLocationCommand`, so the very
button that proves nothing binds it made it look bound) **and** a declaring-type requirement on the
C# side (`ContextMenuViewModel` reads `e.Location` twice, and a global name search credits that to
`StartupEntry`) — it still did not surface, because `ContextMenuView.xaml` alone satisfies the name.
Only the tab's own view can answer for the tab's own model. I will file the global-guard limitation
separately; it is a real weakness, but fixing it means resolving each view's item type across 65
views.

## Red/green proof

Six mutations, each restored and SHA-verified, baseline and final rebuild green:

| | Mutation | Result |
|---|---|---|
| S1 | the Location column is deleted | **RED** — the unbound check |
| S2 | the column binds `Command`, the tooltip still binds `Location` | **RED** — the column-form check |
| S3 | the scan assigns `Icon`, which is in neither list | **RED** — *the guard does not know whether the user should see them: Icon* |
| S4 | one of three sites stops assigning `Location` | **RED** — *construction site 1 does not assign Location* (also reddens `ScanAsync_EntriesHaveLocation`) |
| S5 | `Location` dropped from `displayed` | **RED** — the undecided check, from the guard's side |
| S6 | the floor raised to 999 | **RED** — printed *"10 assigned StartupEntry fields across 3 construction sites"* |

## Verification

- All four projects: **0 errors, 0 warnings** (Release).
- Unit suite: **5242 total, 0 failed** (was 5241; the new guard).
- Protocol I: no debris, no generic/empty catch, no `ManagementObject` in added lines; all 6 files
  CRLF; identity `laurentiu021`; leak scan over all 43 patterns — **0 hits in 187 added lines**.
- Docs in this PR: README Startup Manager gains the column in the sort list and its own bullet;
  SECURITY 1.79.x → 1.80.x; CHANGELOG 1.80.0; csproj 1.80.0.

## Not in this PR

`Refs #1587`, not `Closes`. The issue's second half is a startup-impact figure sourced from
`BootAnalyzerService`'s existing per-component boot-delay events. That needs attribution that fails
closed on a fuzzy name match (a wrong match blames the wrong program for someone else's delay), an
elevation gate, and a decision about where a badge goes in an already-wide grid. Separate risk,
separate PR.
