### PR TITLE
feat: Startup Manager now shows what Windows measured each entry costing at boot

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,7 +87,7 @@ QA-verified is marked with `IsInDevelopment` (surfaced as a PREVIEW badge) inste
 - `SystemHealthViewModel` — SMART, memory diagnostic, multi-drive chkdsk.
 - `CleanupViewModel` — TEMP, Recycle Bin, SFC, DISM (background-aware).
 - `DeepCleanupViewModel` — scan-first deep cleanup + large-files finder.
-- `StartupViewModel` — startup program management (enable/disable via registry).
+- `StartupViewModel` — startup program management (enable/disable via registry). Also attributes Windows' own boot-delay measurements to entries, reading them from the same `BootAnalyzerService` the Boot Analyzer tab uses (one shared singleton) and only when elevated, since those events cannot be read otherwise. Attribution is whole-string on the entry name or its executable file name and fails closed, because a near-match would blame the wrong program on the one tab whose action is to disable it.
 - `DuplicateFileViewModel` — duplicate file finder with partial-hash pre-filter.
 - `DiskAnalyzerViewModel` — disk space breakdown by folder with drill-down. Remembers the last scan of each root via `DiskScanHistoryService` and shows a "since last scan" delta; the read-and-remember is best-effort, so a history failure degrades to no delta rather than breaking a completed scan.
 - `ProcessManagerViewModel` — running processes with kill, filter, sort. The kill path has three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.81.0] - 2026-09-09
+
+Startup Manager now shows how long Windows measured each program delaying your last start-up. This is
+Windows' own number, not a guess this app makes, and it is the one thing that tells you which of twenty
+startup entries is actually worth turning off. The app had been reading these measurements all along and
+showing them only on the Boot Analyzer tab, which is not where anyone goes to decide what to switch off. It
+needs administrator rights, because that is what reading them requires, and the banner at the top of the tab
+says so.
+
+### Added
+
+- **Startup Manager — a Startup impact column.** Sourced from the same Windows Diagnostics-Performance
+  events the Boot Analyzer tab reads (#1587), presented the way that tab presents them: the bare figure,
+  "3.2 s" or "800 ms". Sorting is on the underlying milliseconds, so the slowest entry really does come
+  first — sorting the text would put "800 ms" above "3.2 s". The tooltip gives the whole sentence, including
+  which start-up was measured and what Windows classified the program as.
+- **Attribution that fails closed.** A figure appears only when Windows' report matches the entry whole:
+  its name, or the executable file name in its command line, compared case-insensitively and in full. A
+  prefix, a substring or a near-match shows nothing. A wrong match would tell you a program you depend on
+  cost you three seconds, on the one tab whose action is to switch that program off, so no measurement is
+  the right answer when there is any doubt. An entry Windows never flagged stays blank rather than showing
+  "0 s", which would be a claim that it is fast.
+
+### Changed
+
+- **Reading the boot measurements is skipped entirely without administrator rights.** They cannot be read
+  without them, so an unelevated scan no longer pays to open an event log that will return nothing. The
+  elevation banner now says what the rights unlock, rather than only mentioning the on/off switches.
+
 ## [1.80.0] - 2026-09-09
 
 Startup Manager now shows where each entry actually lives: a registry Run key and which hive it is in, a

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ a confirmation before it runs:
 - Toggle on/off without deleting the original entry (same mechanism as Task Manager) — the disable
   flag is written to the location Windows actually reads for that kind of entry, so a disabled item
   really stays down
-- Sort by name, publisher, location, safety, or status via clickable column headers
+- Sort by name, publisher, location, safety, status, or startup impact via clickable column headers
 - Plain-language description for recognised programs (from the built-in database) instead
   of a raw command line, plus a Safety chip — Windows / Known app / Not recognised — so you
   can tell what an entry is before deciding whether to turn it off
@@ -492,6 +492,12 @@ a confirmation before it runs:
   Startup folder, or Task Scheduler. This is the difference between an entry you can switch off yourself,
   one that needs administrator rights, and one a system policy holds in place; long paths shorten from
   the end, with the full value on hover
+- **A Startup impact column** — how long Windows measured that program delaying your last start-up, from
+  Windows' own boot-performance events rather than an estimate. Sorts by the real delay, so the slowest
+  entry comes first. A figure appears only when Windows' report matches the entry exactly, by name or by
+  executable file name: a near-match would blame the wrong program, and this is the tab where you act on
+  that. Blank means Windows measured nothing, never "0 s". Requires administrator rights, because reading
+  those events does — the banner at the top of the tab says so
 - Open file location in Explorer
 
 ### Windows Features

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.80.x   | :white_check_mark: |
-| < 1.80   | :x:                |
+| 1.81.x   | :white_check_mark: |
+| < 1.81   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/StartupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/StartupViewModelTests.cs
@@ -18,17 +18,31 @@ namespace SysManager.Tests;
 [Collection("ProcessWideStatics")]
 public class StartupViewModelTests
 {
+    /// <summary>
+    /// A view-model with the elevation probe pinned to <paramref name="elevated"/>.
+    /// </summary>
+    /// <remarks>
+    /// Unelevated by default, and that is the point rather than a convenience: the scan reads Windows'
+    /// boot-delay events only when elevated, so a suite run from an administrator console would have every
+    /// one of these tests open an event log and depend on what that machine last measured. The probe is
+    /// injected so the test decides, not the console it was started from.
+    /// </remarks>
+    private static StartupViewModel NewVm(bool elevated = false,
+                                          Func<Task<IReadOnlyList<BootDegradation>>>? readDegradations = null)
+        => new(new StartupService(), () => elevated,
+               readDegradations ?? (() => Task.FromResult<IReadOnlyList<BootDegradation>>([])));
+
     [Fact]
     public void Constructor_EntriesCollectionNotNull()
     {
-        var vm = new StartupViewModel(new Services.StartupService());
+        var vm = NewVm();
         Assert.NotNull(vm.Entries);
     }
 
     [Fact]
     public void Constructor_CommandsExist()
     {
-        var vm = new StartupViewModel(new Services.StartupService());
+        var vm = NewVm();
         Assert.NotNull(vm.ScanCommand);
         Assert.NotNull(vm.ToggleEntryCommand);
         Assert.NotNull(vm.EnableAllCommand);
@@ -38,7 +52,7 @@ public class StartupViewModelTests
     [Fact]
     public void Constructor_DefaultCounts()
     {
-        var vm = new StartupViewModel(new Services.StartupService());
+        var vm = NewVm();
         // Before scan completes, counts should be 0
         Assert.Equal(0, vm.EnabledCount);
         Assert.Equal(0, vm.DisabledCount);
@@ -48,14 +62,14 @@ public class StartupViewModelTests
     [Fact]
     public void ScanSummary_HasDefaultValue()
     {
-        var vm = new StartupViewModel(new Services.StartupService());
+        var vm = NewVm();
         Assert.False(string.IsNullOrEmpty(vm.ScanSummary));
     }
 
     [Fact]
     public async Task ScanAsync_PopulatesEntries()
     {
-        var vm = new StartupViewModel(new Services.StartupService());
+        var vm = NewVm();
         // The constructor fires the scan and forgets it; this is the task it started.
         await vm.InitializationComplete;
         // On any Windows machine there should be at least 1 startup item.
@@ -66,7 +80,7 @@ public class StartupViewModelTests
     [Fact]
     public async Task ScanAsync_UpdatesScanSummary()
     {
-        var vm = new StartupViewModel(new Services.StartupService());
+        var vm = NewVm();
         // The constructor fires the scan and forgets it; this is the task it started.
         await vm.InitializationComplete;
         // After scan, summary should contain counts if entries were found
@@ -77,7 +91,7 @@ public class StartupViewModelTests
     [Fact]
     public async Task ScanAsync_CountsAreConsistent()
     {
-        var vm = new StartupViewModel(new Services.StartupService());
+        var vm = NewVm();
         // The constructor fires the scan and forgets it; this is the task it started.
         await vm.InitializationComplete;
         Assert.Equal(vm.Entries.Count, vm.TotalCount);
@@ -87,7 +101,7 @@ public class StartupViewModelTests
     [Fact]
     public void ToggleEntry_NullDoesNotThrow()
     {
-        var vm = new StartupViewModel(new Services.StartupService());
+        var vm = NewVm();
         var ex = Record.Exception(() => vm.ToggleEntryCommand.Execute(null));
         Assert.Null(ex);
     }
@@ -95,7 +109,7 @@ public class StartupViewModelTests
     [Fact]
     public void ToggleEntry_WrongTypeDoesNotThrow()
     {
-        var vm = new StartupViewModel(new Services.StartupService());
+        var vm = NewVm();
         // Simulates WPF DataGrid virtualization passing a non-StartupEntry object
         var ex = Record.Exception(() => vm.ToggleEntryCommand.Execute("not a StartupEntry"));
         Assert.Null(ex);
@@ -104,7 +118,7 @@ public class StartupViewModelTests
     [Fact]
     public void OpenFileLocation_NullDoesNotThrow()
     {
-        var vm = new StartupViewModel(new Services.StartupService());
+        var vm = NewVm();
         var ex = Record.Exception(() => vm.OpenFileLocationCommand.Execute(null));
         Assert.Null(ex);
     }
@@ -112,7 +126,7 @@ public class StartupViewModelTests
     [Fact]
     public void OpenFileLocation_WrongTypeDoesNotThrow()
     {
-        var vm = new StartupViewModel(new Services.StartupService());
+        var vm = NewVm();
         // Simulates WPF DataGrid virtualization passing a non-StartupEntry object
         var ex = Record.Exception(() => vm.OpenFileLocationCommand.Execute(42));
         Assert.Null(ex);
@@ -128,7 +142,7 @@ public class StartupViewModelTests
         // Regression: "Enable All" re-arms every disabled startup item (registry/task writes)
         // and adds boot time, so it must ask first. Declining must short-circuit BEFORE any
         // write — proven here by the entry staying disabled (SetEnabledAsync is never reached).
-        var vm = new StartupViewModel(new StartupService());
+        var vm = NewVm();
         // Wait for the ctor's auto-scan to finish before seeding, so it cannot overwrite the seeded
         // entry mid-test. The task itself, not a sampled IsBusy flag.
         await vm.InitializationComplete;
@@ -158,7 +172,7 @@ public class StartupViewModelTests
     public async Task EnableAll_WithNoDisabledEntries_DoesNotPrompt()
     {
         // Nothing to enable → no confirmation dialog (and no write). Guards against nagging.
-        var vm = new StartupViewModel(new StartupService());
+        var vm = NewVm();
         // Wait for the ctor's auto-scan to finish before seeding, so it cannot overwrite the seeded
         // entry mid-test. The task itself, not a sampled IsBusy flag.
         await vm.InitializationComplete;
@@ -187,7 +201,7 @@ public class StartupViewModelTests
         // state; the NotBusy gate stops them overlapping and interleaving registry writes.
         // Drive IsBusy explicitly rather than asserting the post-construction baseline: the
         // constructor kicks off an async auto-scan that briefly sets IsBusy itself.
-        var vm = new StartupViewModel(new Services.StartupService());
+        var vm = NewVm();
 
         vm.IsBusy = true;
         Assert.False(vm.ScanCommand.CanExecute(null));
@@ -199,4 +213,150 @@ public class StartupViewModelTests
         Assert.True(vm.EnableAllCommand.CanExecute(null));
         Assert.True(vm.ToggleEntryCommand.CanExecute(null));
     }
+    // ---------- boot impact attribution (#1587) ----------
+
+    private static BootDegradation Slow(string name, long ms, int day = 1, string kind = "Application")
+        => new(new DateTime(2026, 9, day, 8, 0, 0, DateTimeKind.Local), kind, name, ms);
+
+    [Theory]
+    [InlineData("Discord")]           // Windows reported the friendly name; matches the entry name
+    [InlineData("discord")]           // and case never decides an attribution
+    [InlineData("DISCORD")]
+    public void MatchDegradation_MatchesTheEntryNameWholeAndCaseInsensitively(string reported)
+    {
+        var entry = new StartupEntry { Name = "Discord", Command = @"C:\Users\x\Discord\app.exe --start" };
+        var match = StartupViewModel.MatchDegradation(entry, [Slow(reported, 3200)]);
+
+        Assert.NotNull(match);
+        Assert.Equal(3200, match!.DurationMs);
+    }
+
+    [Theory]
+    [InlineData("app.exe")]                          // reported as the bare file name
+    [InlineData(@"C:\Users\x\Discord\app.exe")]  // or as a full path, which reduces to the same name
+    public void MatchDegradation_MatchesTheExecutableFileName(string reported)
+    {
+        // The entry's own name is nothing like the executable, which is the ordinary case for a Run key
+        // whose value name was chosen by an installer.
+        var entry = new StartupEntry { Name = "SomeInstallerName", Command = @"C:\Users\x\Discord\app.exe --start" };
+        Assert.NotNull(StartupViewModel.MatchDegradation(entry, [Slow(reported, 1500)]));
+    }
+
+    [Theory]
+    [InlineData("Disc")]              // a prefix of the name
+    [InlineData("Discord Client")]    // the name as a prefix of the report
+    [InlineData("MyDiscord")]         // a substring match
+    [InlineData("other.exe")]         // a different executable
+    [InlineData("")]                  // nothing reported at all
+    public void MatchDegradation_RefusesAnythingShortOfAWholeMatch(string reported)
+    {
+        // Fail closed. A near miss here tells someone a program they depend on cost them three seconds, on a
+        // tab whose one action is to switch that program off.
+        var entry = new StartupEntry { Name = "Discord", Command = @"C:\Users\x\Discord\app.exe" };
+        Assert.Null(StartupViewModel.MatchDegradation(entry, [Slow(reported, 3200)]));
+    }
+
+    [Fact]
+    public void MatchDegradation_WithNoNameAndNoExecutable_MatchesNothing()
+    {
+        // Both sides empty must not read as equal, or an unnamed entry would inherit every unnamed report.
+        var entry = new StartupEntry { Name = "", Command = "" };
+        Assert.Null(StartupViewModel.MatchDegradation(entry, [Slow("", 900), Slow("chrome.exe", 900)]));
+    }
+
+    [Fact]
+    public void MatchDegradation_TakesTheNewestMeasurement()
+    {
+        // The column says "the last start-up", so an entry that was slow once and is not any more must stop
+        // saying so rather than keeping its worst number.
+        var entry = new StartupEntry { Name = "Discord", Command = @"C:\x\app.exe" };
+        var match = StartupViewModel.MatchDegradation(entry,
+            [Slow("Discord", 9000, day: 1), Slow("Discord", 400, day: 5), Slow("Discord", 7000, day: 3)]);
+
+        Assert.NotNull(match);
+        Assert.Equal(400, match!.DurationMs);
+    }
+
+    [Fact]
+    public void ApplyBootImpact_FillsInTheFigureTheDetailAndTheSortKey()
+    {
+        var matched = new StartupEntry { Name = "Discord", Command = @"C:\x\app.exe" };
+        var unmatched = new StartupEntry { Name = "Steam", Command = @"C:\x\steam.exe" };
+
+        StartupViewModel.ApplyBootImpact([matched, unmatched], [Slow("Discord", 3200)]);
+
+        Assert.Equal("3.2 s", matched.StartupImpact);
+        Assert.Equal(3200, matched.StartupImpactMs);
+        Assert.Contains("3.2 s", matched.StartupImpactDetail, StringComparison.Ordinal);
+        Assert.Contains("2026-09-01", matched.StartupImpactDetail, StringComparison.Ordinal);
+
+        // Not "0 s", not "None". A zero would be a claim that Steam is fast, and nothing measured it.
+        Assert.Equal("", unmatched.StartupImpact);
+        Assert.Equal(0, unmatched.StartupImpactMs);
+        Assert.Equal("", unmatched.StartupImpactDetail);
+    }
+
+    [Fact]
+    public void ApplyBootImpact_WithNothingMeasured_LeavesEveryEntryBlank()
+    {
+        var entry = new StartupEntry { Name = "Discord", Command = @"C:\x\app.exe" };
+        StartupViewModel.ApplyBootImpact([entry], []);
+        Assert.Equal("", entry.StartupImpact);
+    }
+
+    [Theory]
+    [InlineData(@"""C:\Program Files\Foo\bar.exe"" --flag", "bar.exe")]
+    [InlineData(@"C:\Program Files\Foo\bar.exe --flag", "bar.exe")]
+    [InlineData("bar.exe", "bar.exe")]
+    // The first extension in the string wins, so an argument naming another file cannot take over.
+    [InlineData(@"C:\Windows\rundll32.exe C:\x\thing.dll,Entry", "rundll32.exe")]
+    [InlineData(@"C:\x\slowdriver.sys", "slowdriver.sys")]
+    [InlineData("Some Friendly App Name", "")]
+    [InlineData("", "")]
+    public void ExecutableFileName_ReadsTheFileNameWithoutTouchingTheDisk(string command, string expected)
+        => Assert.Equal(expected, StartupViewModel.ExecutableFileName(command));
+
+    [Fact]
+    public void ExecutableFileName_DoesNotDependOnThePathExisting()
+    {
+        // The reason this is not ExtractExecutablePath, which probes File.Exists to decide where an unquoted
+        // path ends: attribution has to give the same answer on a machine where the program is not installed.
+        const string absent = @"Q:\nowhere\definitely-not-here\ghost.exe --flag";
+        Assert.False(System.IO.File.Exists(absent));
+        Assert.Equal("ghost.exe", StartupViewModel.ExecutableFileName(absent));
+    }
+
+    [Fact]
+    public async Task Scan_WhenNotElevated_NeverAsksWindowsForBootMeasurements()
+    {
+        // Asserted on whether the reader is CALLED, not on the outcome. The outcome cannot prove this gate:
+        // the real reader also returns nothing when the rights are missing, so with the gate deleted an
+        // unelevated run still shows an empty column while paying to open an event log on every scan.
+        var reads = 0;
+        var vm = NewVm(elevated: false, readDegradations: () =>
+        {
+            reads++;
+            return Task.FromResult<IReadOnlyList<BootDegradation>>([Slow("Discord", 3200)]);
+        });
+        await vm.InitializationComplete;
+
+        Assert.Equal(0, reads);
+        Assert.All(vm.Entries, e => Assert.Equal("", e.StartupImpact));
+    }
+
+    [Fact]
+    public async Task Scan_WhenElevated_AsksWindowsForBootMeasurements()
+    {
+        // The other side of the same branch, so the gate cannot be satisfied by never reading at all.
+        var reads = 0;
+        var vm = NewVm(elevated: true, readDegradations: () =>
+        {
+            reads++;
+            return Task.FromResult<IReadOnlyList<BootDegradation>>([]);
+        });
+        await vm.InitializationComplete;
+
+        Assert.Equal(1, reads);
+    }
+
 }

--- a/SysManager/SysManager/Models/StartupEntry.cs
+++ b/SysManager/SysManager/Models/StartupEntry.cs
@@ -39,6 +39,32 @@ public sealed partial class StartupEntry : ObservableObject
     /// </summary>
     [ObservableProperty] private string _safety = "";
 
+    /// <summary>
+    /// How long Windows measured this entry delaying the most recent start-up it noticed, formatted the way
+    /// the Boot Analyzer tab formats it ("3.2 s", "800 ms"). Empty when Windows reported nothing about it.
+    /// </summary>
+    /// <remarks>
+    /// Windows' own measurement, from the Diagnostics-Performance events the Boot Analyzer tab already reads
+    /// — not an estimate this app invents. Empty is the normal case: Windows only records a component when it
+    /// crossed a delay threshold, and reading those events at all requires administrator rights.
+    /// <para>Blank rather than "0 s" or "None" when there is no measurement. The distinction matters on a
+    /// column whose whole purpose is "which of these twenty is worth turning off": a zero would be a claim
+    /// that this entry is fast, and nothing here supports that claim.</para>
+    /// </remarks>
+    [ObservableProperty] private string _startupImpact = "";
+
+    /// <summary>
+    /// The raw delay in milliseconds behind <see cref="StartupImpact"/>, or 0 when unmeasured. Exists so the
+    /// column sorts numerically — sorting the display string would put "800 ms" above "3.2 s".
+    /// </summary>
+    [ObservableProperty] private long _startupImpactMs;
+
+    /// <summary>
+    /// The whole sentence behind <see cref="StartupImpact"/>, including when the start-up was and what
+    /// Windows classified the component as. The column shows the bare figure; this goes on its tooltip.
+    /// </summary>
+    [ObservableProperty] private string _startupImpactDetail = "";
+
     /// <summary>Registry key path (for registry-based entries).</summary>
     public string RegistryKey { get; init; } = "";
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.80.0</Version>
-    <FileVersion>1.80.0.0</FileVersion>
-    <AssemblyVersion>1.80.0.0</AssemblyVersion>
+    <Version>1.81.0</Version>
+    <FileVersion>1.81.0.0</FileVersion>
+    <AssemblyVersion>1.81.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -421,6 +421,10 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         // ONE session restore point for the graph, as in DI: a second instance would let two
         // tabs each attempt a snapshot, and Windows refuses the second within 24h anyway.
         var sessionRestorePoint = new SessionRestorePoint(restorePoints.CreateAsync);
+        // ONE boot analyzer, as in DI: Boot Analyzer reads its history and Startup Manager reads the same
+        // per-component delay events to fill in its Startup impact column. Two instances would open the same
+        // event log twice for one answer.
+        var bootAnalyzer = new BootAnalyzerService();
         var gamingCpu = new CpuAffinityService();
         // ONE gaming service for the whole graph. Performance Mode asks it whether a profile is live
         // before it records a recovery baseline, so a second copy would answer "no" while the first
@@ -446,7 +450,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(BatteryHealthViewModel)] = new BatteryHealthViewModel(battery),
             [typeof(UninstallerViewModel)] = new UninstallerViewModel(new UninstallerService(runner)),
             [typeof(PerformanceViewModel)] = new PerformanceViewModel(new PerformanceService(runner, restorePoints), gamingProfiles),
-            [typeof(StartupViewModel)] = new StartupViewModel(new StartupService()),
+            [typeof(StartupViewModel)] = new StartupViewModel(new StartupService(), bootAnalyzer),
             [typeof(NetworkSharedState)] = networkShared,
             [typeof(PingViewModel)] = new PingViewModel(networkShared),
             [typeof(TracerouteViewModel)] = new TracerouteViewModel(networkShared),
@@ -475,7 +479,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             [typeof(ProfileViewModel)] = new ProfileViewModel(new ProfileService()),
             [typeof(BrowserCleanerViewModel)] = new BrowserCleanerViewModel(new BrowserCleanerService()),
             [typeof(PrivacyMonitorViewModel)] = new PrivacyMonitorViewModel(new PrivacyMonitorService()),
-            [typeof(BootAnalyzerViewModel)] = new BootAnalyzerViewModel(new BootAnalyzerService()),
+            [typeof(BootAnalyzerViewModel)] = new BootAnalyzerViewModel(bootAnalyzer),
             [typeof(TimerResolutionViewModel)] = new TimerResolutionViewModel(new TimerResolutionService()),
             [typeof(FileLockViewModel)] = new FileLockViewModel(new FileLockService()),
             [typeof(DisplayProfileViewModel)] = new DisplayProfileViewModel(new DisplayProfileService()),

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -19,6 +19,15 @@ namespace SysManager.ViewModels;
 public sealed partial class StartupViewModel : ViewModelBase
 {
     private readonly StartupService _service;
+    private readonly Func<bool> _isElevatedProbe;
+
+    /// <summary>
+    /// Where Windows' boot-delay measurements come from. A delegate rather than the service itself, so a test
+    /// can prove the elevation gate by whether this is called at all — the outcome cannot prove it, because
+    /// the real reader also returns nothing when the rights are missing.
+    /// </summary>
+    private readonly Func<Task<IReadOnlyList<BootDegradation>>> _readDegradations;
+
     private readonly List<StartupEntry> _allEntries = [];
 
     public BulkObservableCollection<StartupEntry> Entries { get; } = new();
@@ -30,10 +39,27 @@ public sealed partial class StartupViewModel : ViewModelBase
     [ObservableProperty] private string _scanSummary = "Click Scan to discover startup items.";
     [ObservableProperty] private bool _hideWindowsEntries;
 
-    public StartupViewModel(StartupService service)
+    public StartupViewModel(StartupService service, BootAnalyzerService boot)
+        : this(service, AdminHelper.IsElevated,
+               () => (boot ?? throw new ArgumentNullException(nameof(boot))).ReadDegradationsAsync())
+    {
+    }
+
+    /// <summary>Test seam: the same view-model with the elevation probe and the boot reader supplied.</summary>
+    /// <param name="service">The startup scan.</param>
+    /// <param name="isElevated">
+    /// How this view-model asks whether the process is elevated. Injected rather than called inline, because
+    /// the boot-impact read below happens only when elevated and a test has to be able to drive both sides of
+    /// that branch. Same seam and same two-constructor shape as <c>WindowsUpdateViewModel</c>.
+    /// </param>
+    /// <param name="readDegradations">Windows' boot-delay measurements. See <see cref="_readDegradations"/>.</param>
+    internal StartupViewModel(StartupService service, Func<bool> isElevated,
+                              Func<Task<IReadOnlyList<BootDegradation>>> readDegradations)
     {
         _service = service;
-        IsElevated = AdminHelper.IsElevated();
+        _isElevatedProbe = isElevated ?? throw new ArgumentNullException(nameof(isElevated));
+        _readDegradations = readDegradations ?? throw new ArgumentNullException(nameof(readDegradations));
+        IsElevated = _isElevatedProbe();
         // Scan, EnableAll and ToggleEntry all read or write the same startup registry/task
         // state; running them concurrently could interleave registry writes and produce
         // inconsistent counts. Re-evaluate their CanExecute when IsBusy flips so only one
@@ -93,6 +119,13 @@ public sealed partial class StartupViewModel : ViewModelBase
                 var exePath = ExtractExecutablePath(item.Command);
                 item.Icon = IconExtractorService.GetIcon(exePath ?? item.Command);
             }
+
+            // Only when elevated. Reading Diagnostics-Performance needs administrator rights, and without
+            // them the reader catches the access denial and returns nothing — so an unelevated run would pay
+            // for opening an event log on every scan to fill in no figures at all. The banner at the top of
+            // the tab is what tells the user why the column is empty.
+            if (_isElevatedProbe())
+                ApplyBootImpact(sorted, await _readDegradations().ConfigureAwait(false));
 
             void Publish()
             {
@@ -229,6 +262,93 @@ public sealed partial class StartupViewModel : ViewModelBase
         }
         catch (InvalidOperationException) { StatusMessage = "Could not open file location."; }
         catch (System.ComponentModel.Win32Exception) { StatusMessage = "Could not open file location."; }
+    }
+
+    /// <summary>
+    /// Attaches Windows' own boot-delay measurement to any entry it can be attributed to with certainty.
+    /// </summary>
+    /// <remarks>
+    /// Attribution fails closed. A wrong match is worse than no match here: it tells someone a program they
+    /// depend on cost them three seconds, and the action this tab offers is to switch that program off. So
+    /// only a whole-string, case-insensitive equality counts — against the entry's own name, or against the
+    /// executable file name in its command line. Windows reports a component either way depending on the
+    /// event ("slowdriver.sys" on one, "Some App" on another), and neither comparison is a substring or a
+    /// prefix. Anything less certain leaves the column blank.
+    /// <para>Newest measurement wins, because the column claims to describe the last start-up. Windows keeps
+    /// several boots of history and an entry that was slow once and is not any more should not keep saying so.</para>
+    /// </remarks>
+    internal static void ApplyBootImpact(IEnumerable<StartupEntry> entries,
+                                         IReadOnlyList<BootDegradation> degradations)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        ArgumentNullException.ThrowIfNull(degradations);
+        if (degradations.Count == 0) return;
+
+        foreach (var entry in entries)
+        {
+            var match = MatchDegradation(entry, degradations);
+            if (match is null) continue;
+
+            entry.StartupImpact = match.DurationDisplay;
+            entry.StartupImpactMs = match.DurationMs;
+            entry.StartupImpactDetail =
+                $"Windows measured this delaying start-up by {match.DurationDisplay} on {match.WhenDisplay}. "
+                + $"Windows classified it as: {match.Kind}.";
+        }
+    }
+
+    /// <summary>The newest degradation that is certainly this entry, or null.</summary>
+    internal static BootDegradation? MatchDegradation(StartupEntry entry,
+                                                      IReadOnlyList<BootDegradation> degradations)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentNullException.ThrowIfNull(degradations);
+
+        var exe = ExecutableFileName(entry.Command);
+        return degradations
+            .Where(d => Identifies(d.Name, entry.Name) || Identifies(d.Name, exe)
+                     || Identifies(ExecutableFileName(d.Name), exe))
+            .OrderByDescending(d => d.When)
+            .FirstOrDefault();
+
+        // Empty never identifies anything — an entry with no name, or a command with no executable in it,
+        // would otherwise match every degradation that also came out empty.
+        static bool Identifies(string reported, string candidate)
+            => candidate.Length > 0 && string.Equals(reported, candidate, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The executable file name in a command line — <c>chrome.exe</c> — or empty when there is none.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <see cref="ExtractExecutablePath"/>, which probes the filesystem with
+    /// <c>File.Exists</c> to decide where an unquoted path ends. That is right for opening a folder in
+    /// Explorer and wrong here: matching has to give the same answer on any machine, including a test one
+    /// where the path does not exist. Keyed on the extension instead, which is what makes it pure.
+    /// </remarks>
+    internal static string ExecutableFileName(string command)
+    {
+        if (string.IsNullOrWhiteSpace(command)) return "";
+
+        string[] extensions = [".exe", ".bat", ".cmd", ".com", ".sys", ".dll"];
+        var best = -1;
+        var length = 0;
+        foreach (var extension in extensions)
+        {
+            var at = command.IndexOf(extension, StringComparison.OrdinalIgnoreCase);
+            // Earliest extension in the string, so arguments that name another file are ignored:
+            // rundll32.exe C:\thing.dll,Entry is rundll32.exe, not thing.dll.
+            if (at >= 0 && (best < 0 || at < best))
+            {
+                best = at;
+                length = extension.Length;
+            }
+        }
+        if (best < 0) return "";
+
+        var end = best + length;
+        var start = command.LastIndexOfAny(['\\', '/', '"', ' '], best) + 1;
+        return command[start..end];
     }
 
     private static string? ExtractExecutablePath(string command)

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -28,8 +28,8 @@
 
         <!-- Elevation banner -->
         <v:AdminBanner Grid.Row="1" Margin="0,0,0,12"
-                       NotElevatedMessage="Changing startup entries requires administrator privileges."
-                       ElevatedMessage="Running as administrator — you can enable and disable any startup entry."/>
+                       NotElevatedMessage="Changing startup entries requires administrator privileges, and so does reading Windows' start-up delay measurements — the Startup impact column stays empty without them."
+                       ElevatedMessage="Running as administrator — you can enable and disable any startup entry, and Startup impact shows what Windows measured each one delaying the last start-up."/>
 
         <!-- Toolbar -->
         <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,0,0,12" Padding="12">
@@ -235,6 +235,25 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
+
+                    <!-- Windows' own measurement of what delayed the last start-up, from the same
+                         Diagnostics-Performance events the Boot Analyzer tab reads (#1587) — the app owned
+                         this number and kept it in a tab nobody has a reason to open, while this is the tab
+                         where it answers a question: which of twenty entries is worth turning off.
+                         Presentation follows BootAnalyzerView's own "Delay" column: the bare figure, no chip.
+                         Sorted on StartupImpactMs, because sorting the display string puts "800 ms" above
+                         "3.2 s". Blank when Windows reported nothing about the entry, which is the normal
+                         case and never rendered as a zero. -->
+                    <DataGridTextColumn Header="Startup impact" Binding="{Binding StartupImpact}" Width="110" MinWidth="90"
+                                        SortMemberPath="StartupImpactMs" IsReadOnly="True">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+                                <Setter Property="FontSize" Value="12"/>
+                                <Setter Property="ToolTip" Value="{Binding StartupImpactDetail}"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
 
                     <DataGridTemplateColumn Header="" Width="80" MinWidth="80" CanUserSort="False" CanUserResize="False">
                         <DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
## The problem

`BootAnalyzerService.ReadDegradationsAsync` has always read Windows' per-component boot-delay events
(Diagnostics-Performance 101–110) into `BootDegradation(When, Kind, Name, DurationMs)`, and showed them
on the Boot Analyzer tab. That is not the tab anyone opens to decide what to switch off (#1587). The app
owned the one number that answers "which of these twenty is worth turning off" and kept it somewhere
with no reason to go.

## What changed

A sortable **Startup impact** column, presented the way `BootAnalyzerView` presents the same data —
`DataGridTextColumn`, the bare figure, no chip. `SortMemberPath="StartupImpactMs"` because sorting the
display string puts `800 ms` above `3.2 s`. The tooltip carries the sentence: what was measured, when,
and what Windows classified the component as.

### Attribution fails closed

Windows reports a component either as a file name (`slowdriver.sys`, event 102) or as a friendly name
(`Some App`, event 101 via `FriendlyName`) — both shapes are already covered by
`BootAnalyzerServiceTests`. So a figure appears only on a **whole-string, case-insensitive** match against:

- the entry's own name, or
- the executable file name in its command line.

| Windows reported | Entry `Discord`, command `…\app.exe` | Result |
|---|---|---|
| `Discord` / `discord` / `DISCORD` | whole match on the name | **3.2 s** |
| `app.exe` or `C:\…\app.exe` | whole match on the executable | **1.5 s** |
| `Disc` | prefix of the name | *(blank)* |
| `Discord Client` | name is a prefix of the report | *(blank)* |
| `MyDiscord` | substring | *(blank)* |
| `other.exe` | different executable | *(blank)* |
| nothing | never flagged | *(blank)*, never `0 s` |

A wrong match tells someone a program they depend on cost them three seconds, on the one tab whose
action is to disable it — so no figure is the correct answer whenever there is doubt. `0 s` would be a
claim that an entry is fast, and nothing measured it. Newest measurement wins, because the column claims
to describe the last start-up.

### `ExecutableFileName` is new, and deliberately not `ExtractExecutablePath`

The existing helper probes `File.Exists` to decide where an unquoted path ends. Right for opening a
folder in Explorer, wrong for attribution, which has to give the same answer on a machine where the
program is not installed — there is a test that asserts a path does **not** exist and still resolves.
It keys on the extension and takes the **first** one in the string, so
`rundll32.exe C:\x\thing.dll,Entry` is `rundll32.exe` and an argument cannot take over the attribution.

### The elevation gate, and why the seam is a delegate

Those events cannot be read without administrator rights, so an unelevated scan no longer pays to open
an event log that returns nothing. The `AdminBanner` messages now say what the rights unlock.

The injected seam is `Func<Task<IReadOnlyList<BootDegradation>>>`, not the service, because **the gate
cannot be proved from the outcome**: the real reader also returns nothing without the rights, so with
the gate deleted an unelevated run still shows an empty column. Only a call counter sees the
difference, which is mutation I5 below — and it is the reason the shape is a delegate.

`MainWindowViewModel`'s hand-built graph now shares one `BootAnalyzerService` between the two tabs that
read it, matching what DI already does, with the same kind of comment the other shared locals carry.

## Red/green proof

Six mutations, restored and SHA-verified, baseline and final rebuild green:

| | Mutation | Result |
|---|---|---|
| I1 | attribution accepts a prefix | **RED** — `RefusesAnythingShortOfAWholeMatch("Discord Client")`, got a 3.2 s match |
| I2 | empty identifies empty | **RED** — `WithNoNameAndNoExecutable_MatchesNothing`, got the 900 ms unnamed report |
| I3 | oldest measurement wins | **RED** — `TakesTheNewestMeasurement`, expected 400, got 9000 |
| I4 | an unmatched entry reads `0 s` | **RED** — expected `""`, got `"0 s"` |
| I5 | the elevation gate removed | **RED** — read counter expected 0, got 1 |
| I6 | the last extension wins | **RED** — expected `rundll32.exe`, got `thing.dll` |

The existing 14 `StartupViewModelTests` now go through one `NewVm` factory that pins the probe
unelevated. Not cosmetic: without it, a suite run from an administrator console would have every one of
those tests open an event log and depend on what that machine last measured.

## Verification

- All four projects: **0 errors, 0 warnings** (Release).
- Unit suite: **5266 total, 0 failed** (was 5242; 24 new cases).
- Protocol I: no debris, no generic catch, no `MessageBox.Show`; all 10 files CRLF; leak scan over all
  43 patterns — **0 hits in 401 added lines**.
- Docs in this PR: README gains the column in the sort list and its own bullet; ARCHITECTURE records the
  shared singleton and the fail-closed attribution; SECURITY 1.80.x → 1.81.x; CHANGELOG 1.81.0;
  csproj 1.81.0.

## Known limit, stated rather than hidden

If Windows reports a friendly name that matches neither the entry name nor its executable — an installer
that named its Run value one thing while Windows knows the app as another — the column stays blank for
that entry. That is the fail-closed side of the trade and it is the right side to be on here. Anyone
widening it should widen the *evidence*, not the matching: carry the event's `FileName` field alongside
`Name` on `BootDegradation` so there is a second exact key, rather than loosening the comparison.

`Closes #1587` — with the Location column in v1.80.0, both halves of the issue are now in.
