### PR TITLE
fix: custom colours could make the app unreadable, with no way back

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -601,7 +601,7 @@ Key services:
   before the first change of a session (best-effort; since 1.68.0 it no longer owns that logic). It reimplements no tweak; `PendingApplyCount` /
   `PendingUndoCount` / `TweakItem.ClassifyTier` are pure, unit-tested helpers.
 - `SafetyDatabase` — curated safety ratings for Windows services.
-- `ThemeService` — runtime theme switching with 12 presets and persistence.
+- `ThemeService` — runtime theme switching with 12 presets and persistence. Two corrections run inside `Shade`, on the already-shifted colours so nothing downstream can undo them: `PanelThatAdmitsReadableText` nudges a Surface toward the Background until this mode's most extreme text clears AA on it, and `Legible` then fits the text to per-surface floors (AAA on the Background, AA on the panels). Both are no-ops for the shipped presets. `ResetToDefault` restores the shipped preset and shade — the only undo Custom mode has, since the four typed colours are persisted and reloaded on every launch.
 - `ToastService` — global glass-style toast notifications.
 
 ## Helpers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.81.1] - 2026-09-09
+
+Custom colours could make the app unreadable, and there was no way back. If you set a dark background with a
+light panel colour, the text ended up white on a white card — and because your colours are saved and restored
+every time the app starts, an unreadable theme stayed unreadable. There is now a "Reset to default theme"
+button in the Appearance menu, and a panel colour that leaves no room for readable text is nudged until it
+does.
+
+### Fixed
+
+- **Custom themes no longer produce unreadable panels.** Background and Surface are separate values, so they
+  could sit on opposite sides of light and dark. The correction that keeps text legible only measured the text
+  against the Background, so a near-black Background with a near-white Surface walked the text toward *white*
+  and put it on a white card at 1.04:1 — and cards, rows and panels are most of what the window shows. The
+  panel is now nudged toward the background until the text this mode produces can be read on it, measured at
+  every position of the background-shade slider. The twelve built-in themes are untouched: their surfaces sit
+  near their backgrounds by design, and a test asserts the correction leaves all of them exactly as they were.
+
+### Added
+
+- **"Reset to default theme" in the Appearance menu.** Custom mode was the only setting in the app with no
+  undo. The only way out of a theme you could not read was deleting a file in `%AppData%` — which the person
+  this app is written for will never find. The button restores the shipped dark theme and the default
+  background shade, and it survives a restart. No confirmation dialog, deliberately: someone reaching for it is
+  probably looking at a screen they cannot read, and the action changes nothing they cannot set again.
+
 ## [1.81.0] - 2026-09-09
 
 Startup Manager now shows how long Windows measured each program delaying your last start-up. This is

--- a/README.md
+++ b/README.md
@@ -159,7 +159,14 @@ A palette button in the top-right corner opens an appearance popup with:
 - **Light mode** — 6 curated presets (Clean Indigo, Sky Breeze, Warm Sand, Mint Fresh, Soft Blossom, Lavender)
 - **Custom mode** — free hex input for accent, background, surface, and text colors
 - Background shade slider for fine-tuning lightness/darkness
+- **Reset to default theme** — one click back to the shipped dark theme and shade, from any mode
 - Settings persist between sessions
+
+Custom colours cannot make the app unreadable. Text is adjusted to stay legible against every surface
+it lands on, and a panel colour that leaves no room for readable text at all — a near-white card on a
+near-black background, say — is nudged toward the background until it does. The twelve built-in themes
+are unaffected by that correction; their surfaces already sit near their backgrounds. If a result is
+still not what you wanted, Reset to default theme puts the shipped theme back and survives a restart.
 
 Graph lines follow the theme rather than fighting it. The Ping, Bandwidth Monitor and Resource
 History charts each draw with a fixed set of colours — blue is CPU, purple is memory — and those

--- a/SysManager/SysManager.Tests/ThemeServiceTests.cs
+++ b/SysManager/SysManager.Tests/ThemeServiceTests.cs
@@ -146,4 +146,119 @@ public class ThemeServiceTests : IDisposable
             $"{channel}: the saved file should hold the colour the user typed ({text}), not a value derived "
             + $"from it. It holds:\n{generation1}");
     }
+    // ---------- the way back from an unreadable theme (#1561) ----------
+
+    [Fact]
+    public void ResetToDefault_PutsBackTheShippedPresetTheModeAndTheShade()
+    {
+        var svc = new ThemeService(_dir);
+        svc.SetPreset("warm-sand");     // a LIGHT preset, so the mode has to move too
+        svc.SetShade(0.9);
+
+        svc.ResetToDefault();
+
+        Assert.Equal(ThemeService.DefaultPresetId, svc.CurrentPresetId);
+        Assert.Equal(ThemeService.DefaultShade, svc.ShadePosition, precision: 3);
+        Assert.Equal("dark", svc.CurrentMode);
+    }
+
+    [Fact]
+    public void ResetToDefault_SurvivesARestart()
+    {
+        // The point of the button. A custom theme is persisted and Load restores it faithfully on every
+        // launch, so a reset that only changed the live theme would be undone by the next start-up — which is
+        // the state the user is trying to escape.
+        var svc = new ThemeService(_dir);
+        svc.SetCustom(Hex("#6366F1"), Hex("#070A0F"), Hex("#FFFFFF"), Hex("#F1F3F7"));
+        Assert.Equal("custom", svc.CurrentMode);
+
+        svc.ResetToDefault();
+
+        var reloaded = new ThemeService(_dir);
+        reloaded.Initialize();
+        Assert.Equal(ThemeService.DefaultPresetId, reloaded.CurrentPresetId);
+        Assert.Equal("dark", reloaded.CurrentMode);
+        Assert.Equal(ThemeService.DefaultShade, reloaded.ShadePosition, precision: 3);
+    }
+
+    // ---------- the panel correction that makes readable text possible at all ----------
+
+    [Theory]
+    [MemberData(nameof(AllPresetIds))]
+    public void PanelCorrection_LeavesEveryShippedSurfaceExactlyAsDesigned(string presetId)
+    {
+        // The correction must be invisible to the twelve designed themes. If it moves one of their surfaces,
+        // it is not correcting a pathological pair — it is redesigning a preset.
+        var p = ThemePreset.Defaults[presetId];
+
+        Assert.Equal(p.Surface, ThemeService.PanelThatAdmitsReadableText(p.Surface, p.Background));
+        Assert.Equal(p.Surface2, ThemeService.PanelThatAdmitsReadableText(p.Surface2, p.Background));
+    }
+
+    [Theory]
+    // A near-white panel under a near-black background, and the reverse. Both are typeable in Custom mode and
+    // neither admits any readable primary text before correction.
+    [InlineData("#070A0F", "#FFFFFF")]
+    [InlineData("#FFFFFF", "#070A0F")]
+    [InlineData("#00FF00", "#0A0A0A")]
+    public void PanelCorrection_PullsAnInvertedPanelUntilTheModesTextFitsOnIt(string background, string surface)
+    {
+        var bg = Hex(background);
+        var corrected = ThemeService.PanelThatAdmitsReadableText(Hex(surface), bg);
+
+        Assert.NotEqual(Hex(surface), corrected);
+
+        // The condition it exists to guarantee: this mode's most extreme text clears AA on the panel, so
+        // Legible has a solution to walk to rather than a floor it cannot reach.
+        var extreme = ThemeService.IsDarkBackground(bg) ? Colors.White : Colors.Black;
+        var ratio = ContrastRatio(extreme, corrected);
+        Assert.True(ratio >= 4.5,
+            $"a corrected panel must admit this mode's extreme text; {extreme} on {corrected} = {ratio:F2}:1");
+    }
+
+    [Fact]
+    public void PanelCorrection_KeepsAsMuchOfThePanelAsItCan()
+    {
+        // Pulled only as far as it takes, not snapped to the background: a user who asked for a lighter panel
+        // keeps the lightest panel that can carry text. If this ever equals the background, the loop is
+        // overshooting and the custom surface has stopped meaning anything.
+        var bg = Hex("#070A0F");
+        var corrected = ThemeService.PanelThatAdmitsReadableText(Hex("#FFFFFF"), bg);
+
+        Assert.NotEqual(bg, corrected);
+        Assert.True(RelativeLuminance(corrected) > RelativeLuminance(bg),
+            "the corrected panel must still be lighter than the background it sits on");
+    }
+
+    public static TheoryData<string> AllPresetIds()
+    {
+        var data = new TheoryData<string>();
+        foreach (var id in ThemePreset.Defaults.Keys) data.Add(id);
+        return data;
+    }
+
+    private static Color Hex(string value) => (Color)ColorConverter.ConvertFromString(value);
+
+    /// <summary>
+    /// Mirrors the WCAG formula rather than calling the service's copy, for the reason
+    /// <c>ThemeService.OnColor</c> documents: a mistake in that formula has to show up as a failing assertion
+    /// instead of being cancelled out by sharing the same bug.
+    /// </summary>
+    private static double ContrastRatio(Color a, Color b)
+    {
+        var (la, lb) = (RelativeLuminance(a), RelativeLuminance(b));
+        return (Math.Max(la, lb) + 0.05) / (Math.Min(la, lb) + 0.05);
+    }
+
+    private static double RelativeLuminance(Color c)
+    {
+        static double Channel(byte v)
+        {
+            var s = v / 255.0;
+            return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+        }
+
+        return (0.2126 * Channel(c.R)) + (0.7152 * Channel(c.G)) + (0.0722 * Channel(c.B));
+    }
+
 }

--- a/SysManager/SysManager.Tests/ThemeTextContrastTests.cs
+++ b/SysManager/SysManager.Tests/ThemeTextContrastTests.cs
@@ -326,6 +326,71 @@ public class ThemeTextContrastTests
     }
 
     /// <summary>
+    /// A custom theme's primary text must clear AA on the Surface it lands on, not only on the Background.
+    /// </summary>
+    /// <remarks>
+    /// Every shipped preset picks a Surface close to its Background, so this held for free and neither the
+    /// correction in <c>Shade</c> nor <see cref="TextPrimary_MeetsWcagAaa_OnBackground"/> ever measured it.
+    /// Custom mode takes the two as independent hex values, so a user can set Background near-black and
+    /// Surface near-white: the correction then walks TextPrimary toward WHITE, because the mode is decided
+    /// from the Background, and lands white text on a white card.
+    /// <para>Cards, DataGrid rows and every panel in the app draw on Surface or Surface2, so this is most of
+    /// what the window actually shows — the Background is largely the gap between the panels.</para>
+    /// <para>AA (4.5:1), not the AAA bar the Background is held to. The stricter bar belongs to the colour the
+    /// theme was designed around; the point here is that a typed pair cannot produce unreadable panels.</para>
+    /// </remarks>
+    [Theory]
+    // Background and Surface at opposite ends, in both directions, which is what Custom mode allows.
+    [InlineData("#070A0F", "#FFFFFF", "#F1F3F7")]
+    [InlineData("#FFFFFF", "#070A0F", "#101418")]
+    // The saturated-green background that mis-classified as dark before IsDarkBackground moved to
+    // luminance, kept as a case because it is the one where mode and appearance disagree most.
+    [InlineData("#00FF00", "#0A0A0A", "#101010")]
+    [InlineData("#7F7F7F", "#FAFAFA", "#202020")]
+    public void CustomTheme_KeepsPrimaryTextLegibleOnSurface(string background, string surface, string text)
+    {
+        var preset = ThemeService.CustomPreset(
+            Hex("#6366F1"), Hex(background), Hex(surface), Hex(text));
+
+        var offenders = new List<string>();
+        var positionsChecked = 0;
+
+        // Every slider position, like EveryShadePosition_KeepsTheTextRampLegible: the shade shifts Surface
+        // and Background by different amounts, so the worst case is not necessarily the default.
+        for (var step = 0; step <= 20; step++)
+        {
+            var position = step * 0.05;
+            var shaded = ThemeService.Shade(preset, position);
+            positionsChecked++;
+
+            foreach (var (label, against) in new[]
+                     {
+                         ("Surface", shaded.Surface),
+                         ("Surface2", shaded.Surface2),
+                     })
+            {
+                var ratio = ContrastRatio(shaded.TextPrimary, against);
+                if (ratio < 4.5)
+                    offenders.Add($"shade {position:F2}: TextPrimary on {label} = {ratio:F2}:1");
+            }
+        }
+
+        // Vacuity floor, same as the sweep above: a loop that stopped running reports a clean sweep of nothing.
+        Assert.Equal(21, positionsChecked);
+
+        Assert.True(offenders.Count == 0,
+            $"a custom theme with Background {background} and Surface {surface} leaves primary text "
+            + "unreadable on the surfaces the app actually draws panels on. The correction in "
+            + "ThemeService.Shade walks TextPrimary away from the BACKGROUND only, and the direction it "
+            + "walks is chosen from the background's luminance, so a light Surface under a dark Background "
+            + "gets white text on white:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>Parses a hex literal the way the appearance popup does.</summary>
+    private static Color Hex(string value) => (Color)ColorConverter.ConvertFromString(value);
+
+    /// <summary>
     /// Mirrors <c>ThemeService.Lerp</c> so the toggle track is derived with the same maths the app uses,
     /// rather than an approximation of it. <c>ThemeStatusBrushTests</c> keeps the same mirror for the
     /// same reason; <c>ThemeService.Lerp</c> is private and is not worth widening for a test.

--- a/SysManager/SysManager/Services/ThemeService.cs
+++ b/SysManager/SysManager/Services/ThemeService.cs
@@ -21,12 +21,23 @@ public sealed class ThemeService
 
     public event Action? ThemeChanged;
 
-    public ThemePreset CurrentTheme { get; private set; } = ThemePreset.Defaults["midnight-indigo"];
-    public string CurrentPresetId { get; private set; } = "midnight-indigo";
-    public string CurrentMode { get; private set; } = "dark";
-    public double ShadePosition { get; private set; } = 0.5;
+    /// <summary>The theme the app ships with, and the shade position it ships at.</summary>
+    /// <remarks>
+    /// Named constants because three things have to agree on them: the field initialisers below,
+    /// <see cref="ResetToDefault"/>, and the slider's own default in <c>ThemePopup.xaml</c>. They were three
+    /// copies of the same two values.
+    /// </remarks>
+    public const string DefaultPresetId = "midnight-indigo";
 
-    private ThemePreset _baseTheme = ThemePreset.Defaults["midnight-indigo"];
+    /// <inheritdoc cref="DefaultPresetId"/>
+    public const double DefaultShade = 0.5;
+
+    public ThemePreset CurrentTheme { get; private set; } = ThemePreset.Defaults[DefaultPresetId];
+    public string CurrentPresetId { get; private set; } = DefaultPresetId;
+    public string CurrentMode { get; private set; } = "dark";
+    public double ShadePosition { get; private set; } = DefaultShade;
+
+    private ThemePreset _baseTheme = ThemePreset.Defaults[DefaultPresetId];
 
     // The shade slider raises SetShade on every tick of a drag; persisting on each one would
     // hammer the disk. Coalesce writes: SetShade applies the shade live but (re)starts this
@@ -90,6 +101,25 @@ public sealed class ThemeService
         Save();
     }
 
+    /// <summary>
+    /// Puts the shipped theme back — the way out of a custom theme that cannot be read.
+    /// </summary>
+    /// <remarks>
+    /// Custom mode was the only setting in the app with no undo. Four typed hex values are persisted and
+    /// <see cref="Load"/> faithfully restores them on every launch, so a theme the user could not read was a
+    /// theme they could not fix from inside the app: the only escape was deleting
+    /// <c>%AppData%\SysManager\theme.json</c>, which the person this app is for will never find. That
+    /// contradicted the product rule that a change the app makes stays reversible (#1561).
+    /// <para>Resets the shade too. A preset alone is not "the shipped theme" if the slider is still parked at
+    /// an extreme the user pushed it to while trying to rescue an unreadable one.</para>
+    /// </remarks>
+    public void ResetToDefault()
+    {
+        ShadePosition = DefaultShade;
+        // SetPreset applies and saves; it also sets CurrentMode from the preset, which clears "custom".
+        SetPreset(DefaultPresetId);
+    }
+
     public void SetAccent(Color accent)
     {
         _baseTheme = _baseTheme with { Accent = accent };
@@ -134,7 +164,22 @@ public sealed class ThemeService
     {
         CurrentMode = "custom";
         CurrentPresetId = "custom";
-        _baseTheme = new ThemePreset(
+        _baseTheme = CustomPreset(accent, background, surface, text);
+        ApplyShade();
+        Save();
+    }
+
+    /// <summary>
+    /// The preset the four popup colours expand into, before <see cref="Shade"/> corrects it.
+    /// </summary>
+    /// <remarks>
+    /// Extracted from <see cref="SetCustom"/> so the custom path can be measured without going through the
+    /// service — <see cref="SetCustom"/> persists to the user's real theme file, so a test that called it to
+    /// find out what a pair of colours produces would overwrite the developer's theme to ask the question.
+    /// </remarks>
+    internal static ThemePreset CustomPreset(Color accent, Color background, Color surface, Color text)
+    {
+        return new ThemePreset(
             Id: "custom",
             Name: "Custom",
             IsDark: IsDarkBackground(background),
@@ -146,8 +191,44 @@ public sealed class ThemeService
             TextPrimary: text,
             TextSecondary: Lerp(text, background, 0.3),
             TextMuted: Lerp(text, background, 0.55));
-        ApplyShade();
-        Save();
+    }
+
+    /// <summary>
+    /// Pulls a panel colour toward the background until readable text on that panel is possible at all,
+    /// leaving it alone when it already is.
+    /// </summary>
+    /// <remarks>
+    /// Background and Surface are independent hex values in Custom mode, and some pairs admit no readable text
+    /// whatsoever. Primary text owes AAA to the Background and AA to the panels drawn on it; against
+    /// <c>#070A0F</c> and <c>#FFFFFF</c> those demand a relative luminance of at least 0.30 and at most 0.183,
+    /// so no colour satisfies both. The old code never noticed, because <see cref="Legible"/> corrected primary
+    /// against the Background alone: that pair rendered white text on a white card at 1.04:1, and cards, rows
+    /// and panels are what the window mostly shows.
+    /// <para><b>Correcting the text cannot fix that, which is why this sits at the input.</b> Two earlier
+    /// attempts did try the text — adding the surfaces to the correction, then searching in both directions —
+    /// and reached 2.05:1 and 4.49:1 respectively, because they were looking for a colour that does not
+    /// exist.</para>
+    /// <para>The condition is the requirement itself rather than a geometric proxy: the panel has to admit the
+    /// most extreme text this mode can produce, which is white on a dark theme and black on a light one, at AA.
+    /// Stopping merely on the same side of <see cref="IsDarkBackground"/>'s line left the panel sitting on the
+    /// threshold, and text then measured 4.01–4.49:1 — right, in shape, and still short.</para>
+    /// <para>Pulled only as far as it takes: a user who asked for a lighter panel keeps the lightest panel that
+    /// can carry text. Shipped presets never enter the loop, since their surfaces sit near their backgrounds
+    /// by design.</para>
+    /// </remarks>
+    internal static Color PanelThatAdmitsReadableText(Color panel, Color background)
+    {
+        var extremeText = IsDarkBackground(background) ? Colors.White : Colors.Black;
+        if (ContrastAgainst(extremeText, panel) >= 4.5) return panel;
+
+        for (var step = 1; step <= 50; step++)
+        {
+            var candidate = Lerp(panel, background, step * 0.02);
+            if (ContrastAgainst(extremeText, candidate) >= 4.5) return candidate;
+        }
+
+        // The background itself, which always admits its own mode's text: the whole ramp is built from it.
+        return background;
     }
 
     /// <summary>
@@ -195,18 +276,33 @@ public sealed class ThemeService
     {
         var offset = (position - 0.5) * 0.12;
 
+        var background = ShiftLightness(baseTheme.Background, offset);
+
+        // The panel correction runs HERE, on the shifted colours, not on the seeded ones. It was tried in
+        // CustomPreset first and the shade undid it: ShiftLightness moves Background and Surface by different
+        // amounts, so a panel corrected before the shift drifted back out of range and text measured 4.12:1 at
+        // the top of the slider while passing in the middle. This is also where Legible runs, so nothing
+        // downstream can revert either correction.
         var shaded = baseTheme with
         {
-            Background = ShiftLightness(baseTheme.Background, offset),
-            Surface = ShiftLightness(baseTheme.Surface, offset),
-            Surface2 = ShiftLightness(baseTheme.Surface2, offset),
+            Background = background,
+            Surface = PanelThatAdmitsReadableText(ShiftLightness(baseTheme.Surface, offset), background),
+            Surface2 = PanelThatAdmitsReadableText(ShiftLightness(baseTheme.Surface2, offset), background),
             Border = ShiftLightness(baseTheme.Border, offset)
         };
 
         // TextPrimary is corrected first because the two DERIVED surfaces are lerped toward it, so they
         // cannot be computed until it is final. Derived here with the same factors Apply uses, from the
         // shaded Surface2 and the corrected primary — which is exactly the pair Apply will be handed.
-        var primary = Legible(shaded.TextPrimary, baseTheme.IsDark, 7.0, shaded.Background);
+        // Surface and Surface2 at AA alongside the Background at AAA. Every shipped preset picks a Surface
+        // close to its Background, so holding primary to the Background alone held for free and neither this
+        // correction nor ThemeTextContrastTests ever measured the rest — while Custom mode takes Background
+        // and Surface as independent hex values. Background #070A0F with Surface #FFFFFF walked primary
+        // toward WHITE, because the direction comes from the background, and put white text on a white card
+        // at 1.04:1. Cards, rows and panels are what the window mostly shows; the Background is the gap
+        // between them.
+        var primary = Legible(shaded.TextPrimary, baseTheme.IsDark,
+                              (shaded.Background, 7.0), (shaded.Surface, 4.5), (shaded.Surface2, 4.5));
         var surface3 = Lerp(shaded.Surface2, primary, 0.05);
         var surface4 = Lerp(shaded.Surface2, primary, 0.10);
 
@@ -222,36 +318,48 @@ public sealed class ThemeService
         return shaded with
         {
             TextPrimary = primary,
-            TextSecondary = Legible(shaded.TextSecondary, baseTheme.IsDark, 4.5,
-                                    shaded.Surface2, surface4),
-            TextMuted = Legible(shaded.TextMuted, baseTheme.IsDark, 4.5,
-                                shaded.Background, shaded.Surface, shaded.Surface2, surface3, surface4)
+            TextSecondary = Legible(shaded.TextSecondary, baseTheme.IsDark,
+                                    (shaded.Surface2, 4.5), (surface4, 4.5)),
+            TextMuted = Legible(shaded.TextMuted, baseTheme.IsDark,
+                                (shaded.Background, 4.5), (shaded.Surface, 4.5), (shaded.Surface2, 4.5),
+                                (surface3, 4.5), (surface4, 4.5))
         };
     }
 
     /// <summary>
-    /// Returns <paramref name="text"/> unchanged when it already clears <paramref name="minimum"/> against
-    /// every surface, otherwise walks it away from them until it does.
+    /// Returns <paramref name="text"/> unchanged when it already clears every target's floor, otherwise walks
+    /// it away from the surfaces until it does.
     /// </summary>
     /// <remarks>
-    /// "Away" is toward white on a dark theme and toward black on a light one, decided from the preset's own
-    /// mode rather than by comparing luminances, so a surface shifted close to the text cannot flip the
-    /// direction mid-walk. 2% steps to a 80% ceiling, matching <c>ChartTheme.ReadableAgainst</c>; every real
-    /// preset clears its floor far earlier, and the ceiling exists so a pathological custom theme terminates
-    /// rather than looping.
+    /// Per-surface floors, because primary text owes AAA to the Background and AA to the panels drawn on top
+    /// of it, and one number cannot say both.
+    /// <para>"Away" is toward white on a dark theme and toward black on a light one, decided from the preset's
+    /// own mode rather than by comparing luminances, so a surface shifted close to the text cannot flip the
+    /// direction mid-walk. 2% steps to an 80% ceiling, matching <c>ChartTheme.ReadableAgainst</c>; every
+    /// shipped preset clears its floors in the mode's own direction, usually at step 0.</para>
+    /// <para>One direction, deliberately. Walking the other way was tried and it cannot help: a target set
+    /// that straddles the text has no solution to find — AAA against <c>#070A0F</c> needs a relative luminance
+    /// of at least 0.30 and AA against <c>#FFFFFF</c> needs at most 0.183 — so a search in either direction
+    /// lands short. That pair is prevented at the input instead, by
+    /// <see cref="PanelThatAdmitsReadableText"/>, which is where the actual defect was.</para>
     /// </remarks>
-    private static Color Legible(Color text, bool isDark, double minimum, params Color[] surfaces)
+    private static Color Legible(Color text, bool isDark, params (Color Surface, double Minimum)[] targets)
     {
         var target = isDark ? Colors.White : Colors.Black;
 
-        for (var step = 0; step <= 40; step++)
+        // All the way to the extreme, not the old 80% ceiling. The ceiling was there so a pathological
+        // custom theme terminated, which the step count already guarantees, and it was the last thing keeping
+        // text short: with the panel corrected to admit this mode's extreme text, that extreme is a solution,
+        // and stopping at 80% of the way to it measured 4.45:1 where white measures 20:1. Shipped presets are
+        // unaffected — they clear their floors at step 0.
+        for (var step = 0; step <= 50; step++)
         {
             var candidate = Lerp(text, target, step * 0.02);
-            if (surfaces.All(surface => ContrastAgainst(candidate, surface) >= minimum))
+            if (targets.All(t => ContrastAgainst(candidate, t.Surface) >= t.Minimum))
                 return candidate;
         }
 
-        return Lerp(text, target, 0.8);
+        return target;
     }
 
     public void Apply(ThemePreset theme)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.81.0</Version>
-    <FileVersion>1.81.0.0</FileVersion>
-    <AssemblyVersion>1.81.0.0</AssemblyVersion>
+    <Version>1.81.1</Version>
+    <FileVersion>1.81.1.0</FileVersion>
+    <AssemblyVersion>1.81.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/ThemePopup.xaml
+++ b/SysManager/SysManager/Views/ThemePopup.xaml
@@ -171,6 +171,18 @@
                             </Grid>
                         </Border>
                     </StackPanel>
+
+                    <!-- The way back. Custom mode was the only setting in the app with no undo: four typed hex
+                         values are persisted and restored on every launch, so a theme the user could not read
+                         was one they could not fix from inside the app — the only escape was deleting
+                         theme.json (#1561). Outside both panels because a preset plus an extreme shade can
+                         also be worth abandoning, and because the button that rescues you from an unreadable
+                         theme should not itself be behind a mode switch. -->
+                    <Button x:Name="ResetThemeButton" Content="Reset to default theme"
+                            Style="{StaticResource GhostButton}"
+                            HorizontalAlignment="Left" Margin="0,16,0,0" Padding="10,6" FontSize="12"
+                            ToolTip="Puts the shipped dark theme and the default background shade back."
+                            Click="ResetTheme_Click"/>
                 </StackPanel>
             </ScrollViewer>
         </Grid>

--- a/SysManager/SysManager/Views/ThemePopup.xaml.cs
+++ b/SysManager/SysManager/Views/ThemePopup.xaml.cs
@@ -237,6 +237,38 @@ public partial class ThemePopup : UserControl
         ApplyCustomFromInputs();
     }
 
+    /// <summary>
+    /// Puts the shipped theme back and re-syncs the popup to it.
+    /// </summary>
+    /// <remarks>
+    /// No confirmation dialog. The user reaching for this is most likely looking at a theme they cannot read,
+    /// so a dialog would be one more unreadable thing between them and the fix — and the action is not
+    /// destructive: it changes four colours and a slider, all of which they can set again.
+    /// <para>The re-sync has to be explicit. <see cref="SyncUiToService"/> only runs once, on Loaded, and the
+    /// mode radios and shade slider hold their own state — without this the popup would keep showing "Custom"
+    /// and the old slider position over a theme that is no longer either.</para>
+    /// </remarks>
+    private void ResetTheme_Click(object sender, RoutedEventArgs e)
+    {
+        // The radio FIRST, so Mode_Changed's own SetPreset happens before the reset rather than after it.
+        // Checking it from Custom raises Checked, which applies the companion preset — harmless in itself, but
+        // it must not be the last write.
+        DarkMode.IsChecked = true;
+        ThemeService.Instance.ResetToDefault();
+
+        // Suppressed, or putting the slider back would raise Shade_Changed and save a shade position on top
+        // of the one the reset just restored.
+        _suppressShadeEvent = true;
+        ShadeSlider.Value = ThemeService.DefaultShade;
+        _suppressShadeEvent = false;
+
+        UpdatePanels();
+        // Seed the custom boxes from the default too, so switching to Custom after a reset starts from a
+        // readable theme rather than from the colours that made the reset necessary.
+        PopulateCustomFields(ThemeService.Instance.CurrentTheme);
+        BuildPresetCards();
+    }
+
     private void CustomAccent_Click(object sender, MouseButtonEventArgs e) => FocusHex(CustomAccentHex);
     private void CustomBg_Click(object sender, MouseButtonEventArgs e) => FocusHex(CustomBgHex);
     private void CustomSurface_Click(object sender, MouseButtonEventArgs e) => FocusHex(CustomSurfaceHex);


### PR DESCRIPTION
## The defect

Background and Surface are independent hex values in Custom mode, so they can sit on opposite sides of
light and dark. The correction that keeps text legible measured primary text against the **Background
alone** — so a near-black Background with a near-white Surface walked the text toward *white* and put it
on a white card:

```
shade 0.00: TextPrimary on Surface = 1.04:1
```

Cards, DataGrid rows and every panel draw on Surface or Surface2. The Background is largely the gap
between them, so this is most of what the window shows.

Custom mode was also **the only setting in the app with no undo.** The four typed values are persisted
and `Load` restores them faithfully on every launch, so a theme the user could not read was one they
could not fix from inside the app. The only escape was deleting `%AppData%\SysManager\theme.json`.

### Note on the issue's own premises

Two of #1561's three points were already fixed and I re-derived them before starting rather than
implementing them:

- `IsDark` is **no longer** an RGB sum. `IsDarkBackground` uses `RelativeLuminance(background) < 0.18`,
  extracted to one helper, and its remark already cites the same `#00FF00` / `#7F7F7F` / `#FCD34D`
  numbers the issue reported.
- A custom theme **does** go through the legibility correction — `SetCustom` routes through `ApplyShade`,
  which the remark there documents as a previous fix.

What remained was the reset (nothing anywhere) and a contrast hole — a different and worse one than the
issue described.

## Why the fix is at the input, not on the text

Correcting the text cannot fix that pair. AAA against `#070A0F` needs a relative luminance of **at least
0.30**; AA against `#FFFFFF` needs **at most 0.183**. No colour satisfies both. Two attempts on the text
demonstrated it rather than assumed it:

| Attempt | Best reached |
|---|---|
| add Surface/Surface2 to the correction | 2.05:1 |
| also search in both directions | 4.49:1 |

So `PanelThatAdmitsReadableText` nudges the panel toward the background until this mode's **most extreme**
text — white on a dark theme, black on a light one — clears AA on it. That is exactly the condition
`Legible` needs in order to have a solution to walk to, stated as the requirement rather than as a
geometric proxy: stopping merely on the same side of the light/dark line left the panel *on* the
threshold and text measured 4.01–4.49:1, right in shape and still short.

**It runs inside `Shade`, on the already-shifted colours.** Placing it in `CustomPreset` was tried and the
shade undid it: `ShiftLightness` moves Background and Surface by different amounts, so text passed in the
middle of the slider and measured 4.12:1 at the ends. That failure pattern is mutation C2.

Two supporting changes fall out of it:

- `Legible` takes **per-surface floors**, because primary owes AAA to the Background and AA to the panels
  drawn on it, and one number cannot say both.
- its walk runs to the extreme instead of stopping at 80% of the way there. With the panel corrected that
  extreme *is* a solution; stopping short measured 4.45:1 where white measures 20:1. The 80% ceiling
  existed so a pathological theme terminated, which the step count already guarantees.

**The twelve shipped presets are untouched.** Their surfaces sit near their backgrounds by design, so the
correction is a no-op for all of them — asserted per preset, and mutation C8 shows what it looks like when
that stops being true.

## The way back

`ResetToDefault()` restores the shipped preset **and** the default shade — a preset alone is not "the
shipped theme" if the slider is still parked where the user pushed it while trying to rescue an unreadable
one. `DefaultPresetId` / `DefaultShade` replace three copies of the same two values.

The popup gets a `GhostButton` outside both panels, so it is reachable in every mode: a preset plus an
extreme shade can also be worth abandoning, and the control that rescues you should not be behind a mode
switch. **No confirmation dialog** — someone reaching for it is probably looking at a screen they cannot
read, and nothing it changes is unrecoverable.

## Red/green proof

Eight mutations, restored and SHA-verified, baseline and final rebuild green:

| | Mutation | Result |
|---|---|---|
| C1 | the panel correction removed | **RED** — 1.15:1 on Surface |
| C2 | the correction runs pre-shade | **RED** — 4.48:1 downward, at the slider extremes only |
| C3 | the panel snapped to the background | **RED** — `KeepsAsMuchOfThePanelAsItCan`, got `#FF070A0F` |
| C4 | primary held to the Background only | **RED** — 1.04:1, the state the code shipped in |
| C5 | the text walk stops at 80% again | **RED** — 4.42–4.49:1, short by a fraction |
| C6 | `ResetToDefault` leaves the shade alone | **RED** — expected 0.5, got 0.9 |
| C7 | `ResetToDefault` does not persist | **RED** — reload gave `"custom"` |
| C8 | the correction moves preset surfaces too | **RED** — midnight-indigo `#FF0E1218` → `#FF0D1117` |

C2 and C5 are the two designs I tried and discarded, kept as mutations so the placement and the ceiling
cannot quietly regress to them.

## Verification

- All four projects: **0 errors, 0 warnings** (Release).
- Unit suite: **5288 total, 0 failed** (was 5266; 22 new cases).
- One real catch during the sweep: `EveryLabelledControl_IsAnnouncedWithTheWordsPrintedOnIt` failed
  because the button showed "Reset to default theme" and announced "Reset to **the** default theme"
  (WCAG 2.5.3). The redundant `AutomationProperties.Name` is gone; the Content is the name.
- Protocol I: no debris, no generic catch, no `MessageBox.Show`; all 9 files CRLF; leak scan over all 43
  patterns — **0 hits in 404 added lines**.
- Docs in this PR: README's Theme customization section gains the reset bullet and a paragraph on what
  cannot happen any more; ARCHITECTURE records both corrections and where they run; CHANGELOG 1.81.1;
  csproj 1.81.1. SECURITY needs no change — a patch stays inside the supported 1.81.x line.

## Laptop verification still owed

The visual side: that the reset button reads correctly in all twelve presets, and that a deliberately
inverted custom pair now renders readable panels rather than a blank-looking window. The maths is asserted
here; how it *looks* is a main-PC-can't-run-the-app item.

Closes #1561
