### PR TITLE
test: two operation-lock guard tests raced the constructor's own initialisation

### DIFF
--- a/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/PerformanceViewModelTests.cs
@@ -323,7 +323,14 @@ public class PerformanceViewModelTests
     [Fact]
     public async Task TrimRam_WhenSystemModificationLocked_BailsAtGuard()
     {
-        var vm = NewVm();
+        // Initialisation is awaited before the command runs, and that is load-bearing rather than tidy. The
+        // constructor fires InitAsync and forgets it; InitAsync awaits the snapshot gate, so its continuation
+        // is still pending here. `await ExecuteAsync` yields, the continuation gets pumped, and RefreshAsync
+        // overwrites StatusMessage with "Reading performance settings…" — on top of the guard message this
+        // test is asserting. It passed 40/40 locally and failed on CI, which is what an unpumped continuation
+        // looks like: the race is decided by how loaded the machine is.
+        var vm = NewVm(completeInitialization: true);
+        await vm.InitializationComplete;
 
         var prevDialog = DialogService.Instance;
         var dialog = Substitute.For<IDialogService>();
@@ -349,9 +356,15 @@ public class PerformanceViewModelTests
     [Fact]
     public async Task ApplyPowerPlan_WhenSystemModificationLocked_BailsAtGuard()
     {
-        var vm = NewVm();
+        // Awaited for the reason TrimRam's sibling above documents: the constructor's pending InitAsync
+        // continuation otherwise lands during `await ExecuteAsync` and overwrites the guard message. This is
+        // the test that actually went red on CI while passing 40/40 locally.
+        var vm = NewVm(completeInitialization: true);
+        await vm.InitializationComplete;
+
         // Force SelectedPlan away from the current plan so the "already set" early-return
-        // (before the lock guard) doesn't short-circuit the command first.
+        // (before the lock guard) doesn't short-circuit the command first. AFTER the await, because
+        // initialisation ends in SyncTogglesFromProfile, which assigns SelectedPlan itself.
         vm.SelectedPlan = "ultimate";
 
         var prevDialog = DialogService.Instance;


### PR DESCRIPTION
## The failure

An unrelated pull request (#2199, theme-only) went red on `Build & unit tests`:

```
SysManager.Tests.PerformanceViewModelTests.ApplyPowerPlan_WhenSystemModificationLocked_BailsAtGuard
  Assert.Contains() Failure: Sub-string not found
  String:    "Reading performance settings…"
  Not found: "already running"
```

`total: 5288, failed: 1, succeeded: 5287`.

## The race

`PerformanceViewModel`'s constructor calls `InitializeAsync(InitAsync)` and forgets the task.
`InitAsync` **awaits the snapshot gate first**, so its continuation is still pending when a test
starts. The test then does `await SomeCommand.ExecuteAsync(null)` — which yields, the continuation
gets pumped, and `RefreshAsync` sets `StatusMessage = "Reading performance settings…"` right over the
guard message being asserted.

The failing string is not a wrong message from the command. It is the *initialisation's* message,
arriving late.

## Diagnosis, not a re-run

I worked this out rather than retrying the job, and ruled out two plausible alternatives first:

- **A `DialogService.Instance` race across classes** — ruled out. `ArchitectureTests.ProcessWideStaticUsers_AreInTheSerializedCollection` already enforces `[Collection("ProcessWideStatics")]` for every class naming `DialogService.Instance`, `DialogAnswer`, `OperationLockService.Instance` or `AdminHelper.ForceElevation`, and it is green.
- **A stale `OperationHandle` releasing another holder's lock** — ruled out by reading `OperationLockService`: `TryAcquire` returns null without creating a handle when the category is taken, and `OperationHandle.Dispose` is `Interlocked`-guarded, so two live handles for one category cannot exist.
- **Reproduction attempt:** 40 consecutive runs of the class in isolation, **0 failures**. That is the tell, not a contradiction: an unpumped continuation is decided by how loaded the machine is, so a CI runner loses a race a busy developer machine wins.

## The fix

Both affected tests now construct with `completeInitialization: true` and `await vm.InitializationComplete`
before touching the command. This is the pattern the same file already uses in five places, and its
own factory comment already says so: *"Tests that need initialized state opt in and await
InitializationComplete."*

`ApplyPowerPlan` also moves its `SelectedPlan = "ultimate"` assignment **after** the await, because
initialisation ends in `SyncTogglesFromProfile`, which assigns `SelectedPlan` itself — set before the
await, the line would be silently overwritten and the test would be back to depending on the machine.

`RestoreAll_WhenSystemModificationLocked_BailsAtGuard` was already safe: it awaits through its
`SeedSnapshotAsync` helper.

## No guard, and why that is a decision

The standing rule here is to turn a failure into a mechanical check. I measured what such a check would
catch before writing one, and it would be the wrong rule:

| Measured on current source | |
|---|---|
| test methods asserting on a `StatusMessage` | **117** |
| of those, never awaiting `InitializationComplete` | **66** |
| async methods writing `StatusMessage` in view-models with a fire-and-forget init | **91** across **34** view-models |

Most of those 66 are correct as written — `Constructor_InitialStatusMessageIsEmpty` and
`Constructor_StatusMessageEmpty` assert the pre-initialisation state on purpose, and many others test a
view-model whose init never reaches a `StatusMessage` write. A guard landing with dozens of legitimate
findings gets suppressed rather than fixed, which is worse than no guard. The precise condition — "the
test asserts a message the init also writes, after a yield point" — needs data-flow analysis to express.

Filed as an issue instead, with these numbers, so the exposure is tracked rather than quietly dropped.

## Verification

- `SysManager.Tests` build: **0 errors, 0 warnings** (Release).
- Unit suite: **5266 total, 0 failed**.
- `test:` prefix, so no release and no version bump. CRLF preserved.
