### PR TITLE
feat: long jobs now report progress on the Windows taskbar button

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,6 +43,13 @@ leaves carry none, so the icon column belongs to the twelve headings rather than
 Collapsed groups show a child count badge, a written two-line subtitle passed to `Group()` and asserted to
 fit that budget, and a tooltip still generated from the child labels.
 `MainWindowViewModel.SelectedNav` mirrors selection into `NavItem.IsSelected`.
+`NavItem` also mirrors the tab's `IsBusy`, `Progress` and `IsProgressIndeterminate` out of its view-model,
+and `MainWindowViewModel.MapTaskbarProgress` turns the selected tab's pair into the Windows taskbar
+button's `ProgressState`/`ProgressValue` (bound in `MainWindow.xaml`). Both progress signals are read,
+not one: 37 view-models set the indeterminate flag and 10 set a percentage, and Deep Cleanup, File
+Shredder and Speed Test — the three longest operations — are in the second group only. The mapping reads
+the MIRRORED values and never `NavItem.Content`, because touching Content materialises the view-model and
+would rebuild every lazy tab the shell asked about.
 The flat Dashboard row and grouped leaf rows are invokable `SidebarNavButton`
 controls. Their inner visuals consume selection through the shared `SidebarNavRow`,
 `SidebarNavText`, and `SidebarActiveMark` styles, while `SelectionStatus` exposes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.83.0] - 2026-09-09
+
+The taskbar button now shows how far a long job has got. Start an SFC scan, a bulk install or a deep
+cleanup, minimise the window, and the SysManager button on the taskbar fills up as the work progresses —
+so "is it still going, or did it freeze?" no longer means restoring the window and finding the right tab.
+That mattered more here than in most apps, because closing SysManager hides it to the tray instead of
+quitting, so the taskbar was the only signal left and it showed nothing at all.
+
+### Added
+
+- **Progress on the Windows taskbar button.** Fed from whichever tab you have open: a percentage where the
+  tab knows one, a moving bar where it does not, and nothing when nothing is running. Both signals are used
+  deliberately — the three longest operations in the app (Deep Cleanup, File Shredder, Speed Test) report a
+  percentage while most tabs report only "working", so using one would have left the button blank exactly
+  where it is needed most.
+- Blank rather than an empty bar when a job finishes, because an empty bar reads as "starting".
+
+### Changed
+
+- **The taskbar follows the tab you are looking at**, and only that one. Two tabs can work at once and there
+  is no right way to pick a winner between them, so the button answers for the tab you are actually asking
+  about. It never builds a tab you have not opened just to ask what it is doing, which is what keeps
+  start-up as quick as it is.
+
 ## [1.82.0] - 2026-09-09
 
 SysManager can now follow your Windows light/dark setting instead of staying on whichever theme you last

--- a/README.md
+++ b/README.md
@@ -1025,6 +1025,11 @@ offers, "rate us" prompts:
   remembers the answer. If you pick the notification area, it tells you where the
   window went so it doesn't look like it vanished. Right-click the tray icon to
   reopen or exit at any time.
+- **Progress on the taskbar button** — a long job keeps reporting while the window is
+  minimised. The SysManager button on the taskbar fills up as an SFC scan, a bulk
+  install or a deep cleanup progresses, and shows a moving bar for the tabs that know
+  they are working but not how far along. It follows the tab you have open, and it
+  goes blank when the job finishes rather than sitting at an empty bar
 
 ### Updates (for SysManager itself)
 - Auto-check on startup against the GitHub Releases API, plus a manual

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.82.x   | :white_check_mark: |
-| < 1.82   | :x:                |
+| 1.83.x   | :white_check_mark: |
+| < 1.83   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/NavItemLazyContentTests.cs
+++ b/SysManager/SysManager.Tests/NavItemLazyContentTests.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
+using System.Windows.Shell;
 using SysManager.ViewModels;
 
 namespace SysManager.Tests;
@@ -134,4 +136,130 @@ public class NavItemLazyContentTests
         var item = new NavItem { Id = "bad", Label = "Bad", ViewType = typeof(object) };
         Assert.Throws<InvalidOperationException>(() => _ = item.Content);
     }
+    // ---------- taskbar progress (#1584) ----------
+
+    private sealed class ProgressVm : ViewModelBase
+    {
+    }
+
+    [Fact]
+    public void WireBusy_MirrorsTheViewModelsProgressImmediately()
+    {
+        // Not only on the next change. A tab opened while an operation is already running would otherwise
+        // publish nothing to the taskbar until the next percentage tick, and an indeterminate operation
+        // never ticks at all.
+        var vm = new ProgressVm { Progress = 42, IsProgressIndeterminate = true, IsBusy = true };
+        var item = new NavItem { Id = "t", Label = "T", ViewType = typeof(object), Content = vm }.WireBusy();
+
+        Assert.Equal(42, item.Progress);
+        Assert.True(item.IsProgressIndeterminate);
+    }
+
+    [Fact]
+    public void ProgressChangesOnTheViewModel_ReachTheNavItem()
+    {
+        var vm = new ProgressVm();
+        var item = new NavItem { Id = "t", Label = "T", ViewType = typeof(object), Content = vm }.WireBusy();
+
+        vm.Progress = 70;
+        vm.IsProgressIndeterminate = true;
+
+        Assert.Equal(70, item.Progress);
+        Assert.True(item.IsProgressIndeterminate);
+
+        vm.IsProgressIndeterminate = false;
+        Assert.False(item.IsProgressIndeterminate);
+    }
+
+    [Theory]
+    [InlineData(1, 0.01)]
+    [InlineData(42, 0.42)]
+    [InlineData(100, 1.0)]
+    public void MapTaskbarProgress_APercentageBecomesANormalBar(int progress, double expected)
+    {
+        var item = new NavItem { Id = "t", Label = "T", ViewType = typeof(object), Progress = progress };
+
+        var (state, value) = MainWindowViewModel.MapTaskbarProgress(item);
+
+        Assert.Equal(TaskbarItemProgressState.Normal, state);
+        Assert.Equal(expected, value, precision: 6);
+    }
+
+    [Fact]
+    public void MapTaskbarProgress_IndeterminateWinsOverAPercentage()
+    {
+        // A view-model setting both is mid-operation with no meaningful total. The indeterminate flag is the
+        // more specific claim, and a bar parked on a stale percentage would be worse than a marquee.
+        var item = new NavItem
+        {
+            Id = "t", Label = "T", ViewType = typeof(object),
+            Progress = 42, IsProgressIndeterminate = true,
+        };
+
+        Assert.Equal(TaskbarItemProgressState.Indeterminate,
+                     MainWindowViewModel.MapTaskbarProgress(item).State);
+    }
+
+    [Theory]
+    [InlineData(0)]     // also what a finished operation leaves behind — an empty green bar reads as "starting"
+    [InlineData(-1)]
+    [InlineData(101)]
+    public void MapTaskbarProgress_NothingMeaningfulShowsNothing(int progress)
+    {
+        var item = new NavItem { Id = "t", Label = "T", ViewType = typeof(object), Progress = progress };
+
+        var (state, value) = MainWindowViewModel.MapTaskbarProgress(item);
+
+        Assert.Equal(TaskbarItemProgressState.None, state);
+        Assert.Equal(0, value);
+    }
+
+    [Fact]
+    public void MapTaskbarProgress_WithNoSelectedTab_ShowsNothing()
+        => Assert.Equal(TaskbarItemProgressState.None,
+                        MainWindowViewModel.MapTaskbarProgress(null).State);
+
+    [Fact]
+    public void MapTaskbarProgress_DoesNotMaterialiseTheTabsViewModel()
+    {
+        // The whole lazy-startup design turns on this. Reading NavItem.Content builds the view-model, so a
+        // shell that asked Content what to show on the taskbar would rebuild every tab it looked at — and
+        // the mapping is called on every navigation and every progress tick.
+        var built = 0;
+        var item = LazyItem(() => { built++; return new ProgressVm(); });
+
+        _ = MainWindowViewModel.MapTaskbarProgress(item);
+
+        Assert.False(item.IsContentCreated);
+        Assert.Equal(0, built);
+    }
+
+    [Fact]
+    public void MainWindow_BindsTheTaskbarButtonToBothHalvesOfTheState()
+    {
+        // The repo's dominant defect shape: a view-model property that is computed, tested, and bound by
+        // nothing. Neither half is an [ObservableProperty], so the general unreachable-property guard cannot
+        // see them — only the shipped XAML can answer for this one.
+        var xaml = File.ReadAllText(Path.Combine(FindAppDir(), "MainWindow.xaml"));
+        var markup = System.Text.RegularExpressions.Regex.Replace(
+            xaml, "<!--.*?-->", string.Empty, System.Text.RegularExpressions.RegexOptions.Singleline);
+
+        Assert.Contains("<TaskbarItemInfo", markup, StringComparison.Ordinal);
+        Assert.Contains("ProgressState=\"{Binding TaskbarProgressState}\"", markup, StringComparison.Ordinal);
+        Assert.Contains("ProgressValue=\"{Binding TaskbarProgressValue}\"", markup, StringComparison.Ordinal);
+    }
+
+    /// <summary>Walks up to the app project directory, the way the architecture guards do.</summary>
+    private static string FindAppDir()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir, "SysManager", "SysManager");
+            if (File.Exists(Path.Combine(candidate, "MainWindow.xaml"))) return candidate;
+            dir = Path.GetDirectoryName(dir.TrimEnd(Path.DirectorySeparatorChar));
+        }
+        throw new DirectoryNotFoundException("could not locate the app project from " + AppContext.BaseDirectory);
+    }
+
 }

--- a/SysManager/SysManager.Tests/NavItemLazyContentTests.cs
+++ b/SysManager/SysManager.Tests/NavItemLazyContentTests.cs
@@ -192,8 +192,11 @@ public class NavItemLazyContentTests
         // more specific claim, and a bar parked on a stale percentage would be worse than a marquee.
         var item = new NavItem
         {
-            Id = "t", Label = "T", ViewType = typeof(object),
-            Progress = 42, IsProgressIndeterminate = true,
+            Id = "t",
+            Label = "T",
+            ViewType = typeof(object),
+            Progress = 42,
+            IsProgressIndeterminate = true,
         };
 
         Assert.Equal(TaskbarItemProgressState.Indeterminate,

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -14,6 +14,16 @@
         <vm:MainWindowViewModel/>
     </Window.DataContext>
 
+    <!-- Progress on the taskbar button. This is the only progress signal left once the window is
+         minimised, and closing this app HIDES it to the tray rather than exiting (see OnClosing), so a
+         multi-minute SFC scan or bulk install used to run with a live in-app percentage and a completely
+         silent taskbar (#1584). Fed by the selected tab's mirrored progress; the view-model decides
+         Indeterminate vs Normal vs None so the rule is testable without a Window. -->
+    <Window.TaskbarItemInfo>
+        <TaskbarItemInfo ProgressState="{Binding TaskbarProgressState}"
+                         ProgressValue="{Binding TaskbarProgressValue}"/>
+    </Window.TaskbarItemInfo>
+
     <Window.Resources>
         <!-- Each leaf is a real Button so it exposes one invokable UIA peer and remains
              keyboard-operable without inheriting the app's command-button chrome. -->

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.82.0</Version>
-    <FileVersion>1.82.0.0</FileVersion>
-    <AssemblyVersion>1.82.0.0</AssemblyVersion>
+    <Version>1.83.0</Version>
+    <FileVersion>1.83.0.0</FileVersion>
+    <AssemblyVersion>1.83.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -3,6 +3,8 @@
 // License: MIT
 
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows.Shell;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.DependencyInjection;
@@ -295,6 +297,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     partial void OnSelectedNavChanged(NavItem? oldValue, NavItem? newValue)
     {
         UpdateSelectionState(oldValue, newValue);
+        FollowTaskbarProgress(oldValue, newValue);
 
         if (newValue is null)
         {
@@ -321,6 +324,76 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         // Gate on visibility as well: the tray menu can navigate while the window is hidden (see
         // NavigateTo), and starting a loop nothing can see is the very cost this gate exists to avoid.
         SetActive(newValue.Content, IsWindowVisible); // accessing Content materialises the entered tab's VM
+    }
+
+    /// <summary>
+    /// What the Windows taskbar button shows: the selected tab's progress, or nothing.
+    /// </summary>
+    /// <remarks>
+    /// The taskbar was the one progress signal the app never used, and it is the ONLY one left once the
+    /// window is minimised — which this app actively encourages, since closing it hides to the tray rather
+    /// than exiting (#1584). An SFC scan or a bulk winget install ran for minutes with a live in-app
+    /// percentage while the button showed nothing, so "is it still working or did it freeze?" needed the
+    /// window restored and the right tab found.
+    /// <para>The SELECTED tab only. Two tabs can work at once, and picking a winner between them is a
+    /// design question with no obviously right answer; the selected one is the tab the user is asking about.
+    /// <c>OperationLockService</c> already prevents concurrent same-category work.</para>
+    /// </remarks>
+    public TaskbarItemProgressState TaskbarProgressState =>
+        MapTaskbarProgress(SelectedNav).State;
+
+    /// <inheritdoc cref="TaskbarProgressState"/>
+    public double TaskbarProgressValue => MapTaskbarProgress(SelectedNav).Value;
+
+    /// <summary>
+    /// Maps a tab's mirrored progress onto the taskbar's two-part API.
+    /// </summary>
+    /// <remarks>
+    /// Reads the MIRRORED values on the <see cref="NavItem"/>, never <c>NavItem.Content</c>: touching Content
+    /// materialises the view-model, which would rebuild every lazy tab the moment the shell asked what to
+    /// show on the taskbar and undo the lazy-startup design.
+    /// <para>Indeterminate wins over a percentage. A view-model that sets both is mid-operation with no
+    /// meaningful total — <c>IsProgressIndeterminate</c> is the more specific claim, and a bar that jumps to
+    /// a stale percentage would be worse than a marquee.</para>
+    /// <para><c>Progress</c> of 0 maps to None rather than to an empty Normal bar: 0 is also the value a
+    /// finished operation leaves behind, and an empty green bar reads as "starting" rather than "done".</para>
+    /// </remarks>
+    internal static (TaskbarItemProgressState State, double Value) MapTaskbarProgress(NavItem? tab)
+    {
+        if (tab is null) return (TaskbarItemProgressState.None, 0);
+        if (tab.IsProgressIndeterminate) return (TaskbarItemProgressState.Indeterminate, 0);
+        if (tab.Progress is > 0 and <= 100)
+            return (TaskbarItemProgressState.Normal, tab.Progress / 100.0);
+        return (TaskbarItemProgressState.None, 0);
+    }
+
+    /// <summary>
+    /// Re-reads the taskbar state after the selected tab, or that tab's own progress, moves.
+    /// </summary>
+    private void RaiseTaskbarProgressChanged()
+    {
+        OnPropertyChanged(nameof(TaskbarProgressState));
+        OnPropertyChanged(nameof(TaskbarProgressValue));
+    }
+
+    /// <summary>
+    /// Follows the selected tab's progress, and only that tab's.
+    /// </summary>
+    /// <remarks>
+    /// Re-pointed on every navigation rather than subscribing to all 58 tabs: a stale subscription would let
+    /// a background tab drive the button, which is the opposite of what the selected-tab rule says.
+    /// </remarks>
+    private void FollowTaskbarProgress(NavItem? oldValue, NavItem? newValue)
+    {
+        if (oldValue is not null) oldValue.PropertyChanged -= OnSelectedTabProgressChanged;
+        if (newValue is not null) newValue.PropertyChanged += OnSelectedTabProgressChanged;
+        RaiseTaskbarProgressChanged();
+    }
+
+    private void OnSelectedTabProgressChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(NavItem.Progress) or nameof(NavItem.IsProgressIndeterminate))
+            RaiseTaskbarProgressChanged();
     }
 
     internal static void UpdateSelectionState(NavItem? oldValue, NavItem? newValue)

--- a/SysManager/SysManager/ViewModels/NavItem.cs
+++ b/SysManager/SysManager/ViewModels/NavItem.cs
@@ -90,7 +90,22 @@ public sealed partial class NavItem : ObservableObject, IDisposable
     [ObservableProperty] private bool _isBusy;
 
     /// <summary>
-    /// Wire IsBusy forwarding from the underlying ViewModel. Called automatically on first
+    /// The tab's progress, mirrored from its view-model so the shell can publish it to the Windows taskbar
+    /// button without reaching into the view-model — or forcing a never-opened tab to build one.
+    /// </summary>
+    /// <remarks>
+    /// Both signals, not one. 37 view-models set <see cref="ViewModelBase.IsProgressIndeterminate"/> and 10
+    /// set <see cref="ViewModelBase.Progress"/>, and the three longest operations in the app — Deep Cleanup,
+    /// File Shredder and Speed Test — are in the second group only. A taskbar driven off the indeterminate
+    /// flag alone would be silent exactly where a user is most likely to have minimised the window.
+    /// </remarks>
+    [ObservableProperty] private int _progress;
+
+    /// <inheritdoc cref="Progress"/>
+    [ObservableProperty] private bool _isProgressIndeterminate;
+
+    /// <summary>
+    /// Wire busy/progress forwarding from the underlying ViewModel. Called automatically on first
     /// materialisation of <see cref="Content"/>. For an eagerly-assigned instance that must
     /// forward IsBusy before it is ever displayed, call this after construction.
     /// </summary>
@@ -109,6 +124,8 @@ public sealed partial class NavItem : ObservableObject, IDisposable
             vm.PropertyChanged -= OnViewModelPropertyChanged;
             vm.PropertyChanged += OnViewModelPropertyChanged;
             IsBusy = vm.IsBusy;
+            Progress = vm.Progress;
+            IsProgressIndeterminate = vm.IsProgressIndeterminate;
         }
     }
 
@@ -127,8 +144,15 @@ public sealed partial class NavItem : ObservableObject, IDisposable
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(ViewModelBase.IsBusy) && sender is ViewModelBase vm)
-            IsBusy = vm.IsBusy;
+        if (sender is not ViewModelBase vm) return;
+        switch (e.PropertyName)
+        {
+            case nameof(ViewModelBase.IsBusy): IsBusy = vm.IsBusy; break;
+            case nameof(ViewModelBase.Progress): Progress = vm.Progress; break;
+            case nameof(ViewModelBase.IsProgressIndeterminate):
+                IsProgressIndeterminate = vm.IsProgressIndeterminate;
+                break;
+        }
     }
 
     public UserControl View


### PR DESCRIPTION
## The gap

`TaskbarItemInfo`, `JumpList` and `ProgressState` had **zero** matches across the app — re-derived on
current source before starting. So an SFC scan or a bulk winget install ran for minutes with a live in-app
percentage while the taskbar button showed nothing.

That matters more here than in most apps: **closing the window hides it to the tray rather than exiting**,
so once minimised the taskbar was the only progress signal left, and it was silent. "Is it still working or
did it freeze?" required restoring the window and finding the right tab.

## What changed

`MainWindow.xaml` gets a `<Window.TaskbarItemInfo>` bound to two computed properties on the shell
view-model. `MapTaskbarProgress` — pure, `internal`, testable without a Window — decides the state.

### Both signals, not one

This is the part I'd have got wrong by following the issue's shape without measuring:

| | count |
|---|---|
| view-models setting `IsProgressIndeterminate` | **37** |
| view-models setting `Progress` | **10** |

**Deep Cleanup, File Shredder and Speed Test set `Progress` and never the indeterminate flag** — and those
are the three longest operations in the app. A taskbar driven off the indeterminate flag alone would have
been blank exactly where a user is most likely to have minimised the window. Both are read.

### The three rules, and why each one

- **Indeterminate wins over a percentage.** A view-model setting both is mid-operation with no meaningful
  total; a bar parked on a stale number is worse than a marquee. (Mutation T3.)
- **`Progress` of 0 → `None`, not an empty `Normal` bar.** 0 is also what a finished operation leaves
  behind, and an empty green bar reads as "starting" rather than "done". (Mutation T4.)
- **The mapping never touches `NavItem.Content`.** Reading Content materialises the view-model, so a shell
  that asked Content what to show would rebuild every lazy tab it looked at — on every navigation and every
  progress tick — undoing the lazy-startup design this repo already fixed once. It reads the mirrored values
  instead, and a test pins that the mapping builds nothing. (Mutation T5.)

### Wiring

`NavItem`'s existing `IsBusy` forwarding is **extended, not duplicated** — the same `PropertyChanged`
subscription now carries `Progress` and `IsProgressIndeterminate`, `Dispose` already unsubscribed it, and
`WireBusy` seeds all three so a tab opened mid-operation publishes immediately rather than at the next tick
(an indeterminate operation never ticks at all). The shell follows **only the selected tab** and re-points on
navigation, so a background tab cannot drive the button. Two tabs can work at once and there is no right way
to pick a winner; the selected one is the tab the user is asking about.

Zero new dependencies — `System.Windows.Shell.TaskbarItemInfo` ships with WPF.

## Red/green proof

Six mutations, restored and SHA-verified across three files, baseline and final rebuild green:

| | Mutation | Result |
|---|---|---|
| T1 | `IsProgressIndeterminate` not mirrored | **RED** — `ProgressChangesOnTheViewModel_ReachTheNavItem` |
| T2 | `WireBusy` does not seed the mirrors | **RED** — expected 42, got 0 |
| T3 | a percentage wins over indeterminate | **RED** — expected `Indeterminate`, got `Normal` |
| T4 | `Progress` 0 shows an empty green bar | **RED** — expected `None`, got `Normal` |
| T5 | the mapper reads `NavItem.Content` | **RED** — `DoesNotMaterialiseTheTabsViewModel`, plus four collateral reds |
| T6 | the XAML binding removed | **RED** — `MainWindow_BindsTheTaskbarButtonToBothHalvesOfTheState` |

T6 exists because neither property is an `[ObservableProperty]`, so the general
`EveryViewModelProperty_IsShownOrRead` guard cannot see them. Computed, tested and bound by nothing is this
repo's dominant defect shape; only the shipped XAML can answer for these two.

## Verification

- All four projects: **0 errors, 0 warnings** (Release).
- Unit suite: **5308 total, 0 failed** (was 5296; 12 new cases).
- Protocol I: no debris, no generic catch, no `MessageBox.Show`; all 9 files CRLF; leak scan over all 43
  patterns — **0 hits in 288 added lines**.
- Docs in this PR: README's System Tray section gains the taskbar bullet next to "Closing is your choice",
  which is the behaviour that makes it matter; ARCHITECTURE records the mirroring, why both signals are
  read, and why Content is never touched; SECURITY 1.82.x → 1.83.x; CHANGELOG 1.83.0; csproj 1.83.0.

## Laptop verification owed

That the button actually fills, marquees and clears — the mapping and the binding are asserted here, but a
taskbar needs a running Windows shell, and this machine never launches the app. Worth checking during a real
SFC run (indeterminate) and a bulk install (percentage), plus that switching tabs mid-job re-points the
button and that finishing clears it rather than leaving a stale bar.

Closes #1584
