### PR TITLE
feat: run scheduled maintenance on battery and offer an idle condition

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -601,7 +601,15 @@ Key services:
   `IPowerShellRunner` seam. Registered in the current-user context (no admin); only ever
   touches its own task — never enumerates or modifies others. The command is built from a
   fixed argument whitelist (`MaintenanceSchedule.CliArguments`), so no free-form input reaches
-  the scheduler; result-code description is a pure, unit-tested helper.
+  the scheduler; result-code description is a pure, unit-tested helper. The task's power and idle
+  policy is splatted into `New-ScheduledTaskSettingsSet` from typed `[bool]` parameters, so it is
+  still a whitelisted value rather than free-form text; `RegisterParameters` is a pure `internal`
+  helper precisely so a test can assert the policy reaches the script without registering a real
+  task on the machine running it. `AllowStartIfOnBatteries` defaults to `$false` in that cmdlet,
+  and inheriting the default is what kept an unplugged laptop from ever running the schedule —
+  the settings block now opts in unless the user unticks it. The status read also selects
+  `NumberOfMissedRuns`, because Windows expresses "the conditions blocked this run" by simply not
+  running: there is no result code for it, so the count is the only honest explanation available.
 - `TweaksHubService` — thin orchestrator behind the Tweaks Hub tab: loads `PrivacyService`
   toggles as tier-classified `TweakItem`s, applies/reverts a selected set via the same
   reversible `PrivacyService.ApplyToggle`, and takes the shared `ISessionRestorePoint` snapshot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.84.0] - 2026-09-09
+
+Scheduled maintenance now actually runs on a laptop that is not plugged in. Windows refuses to start a
+scheduled task on battery unless it is told otherwise, and SysManager had never told it — so on any laptop
+used unplugged, the Scheduled Maintenance tab showed a confident "Next run" time and then quietly did
+nothing, sometimes for weeks. The tab now also lets you ask for the opposite, waiting until you are away
+from the PC, tells you in words what the settings you picked will do, and shows Windows' own count of runs
+that never happened.
+
+### Fixed
+
+- **Maintenance on battery.** The scheduled task is now created with permission to start on battery, and to
+  keep running if you unplug mid-way. This is the whole bug: the tab promised "no need to remember it
+  yourself" while the run it promised was being skipped, and Windows reports a skipped run as nothing at
+  all — no error, no result code, just a Last run that never moves.
+
+### Added
+
+- **"Only run when I'm not using the PC".** Off by default, deliberately: waiting for an idle machine
+  brings back the same "never ran" problem on a PC that is always in use, so it is a choice you make rather
+  than a default you have to discover.
+- **A plain sentence describing the schedule you are about to save**, conditions included — "Every day at
+  03:00, only while plugged in" — updated as you change the settings, so the consequence of a tick is
+  visible before you commit to it.
+- **A warning when Windows has skipped runs.** It shows the count Windows recorded and the likely reasons
+  (the PC was off, asleep, or blocked by one of the conditions). This is the only signal Windows gives for
+  a run that was skipped, and it stays hidden when there is nothing to report rather than announcing a
+  reassuring zero.
+- **A one-hour cap on a maintenance run**, so a wedged background run cannot sit in the scheduler forever.
+
 ## [1.83.0] - 2026-09-09
 
 The taskbar button now shows how far a long job has got. Start an SFC scan, a bulk install or a deep

--- a/README.md
+++ b/README.md
@@ -681,6 +681,15 @@ a confirmation before it runs:
   runs SysManager in the background (via its CLI) to clean temporary files or purge
   standby memory, daily or weekly at a time you pick
 - See the **last run, next run, and last result** of the task at a glance
+- **Runs on battery too.** Windows will not start a scheduled task on battery unless it is
+  told to, so on an unplugged laptop the schedule would silently never fire — it now starts
+  regardless, and keeps going if you unplug mid-run. Untick it if you would rather it waited
+  for mains power.
+- **Optional "only when I'm not using the PC"** condition, off by default
+- **The schedule you are about to save is spelled out in words**, conditions included, and
+  updates as you change the settings
+- **Windows' own count of skipped runs is shown** when it is not zero — the only signal
+  Windows gives for a run its conditions blocked
 - Update or remove the schedule any time, each with a confirmation
 - Runs in your user context (no admin required) and only ever touches its own task
   at `\SysManager\Scheduled Maintenance` — no other scheduled tasks are affected

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.83.x   | :white_check_mark: |
-| < 1.83   | :x:                |
+| 1.84.x   | :white_check_mark: |
+| < 1.84   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -6444,20 +6444,38 @@ public partial class ArchitectureTests
     /// answer the app already had. This is SysManager's most persistent defect class: state that is
     /// implemented, unit-tested, and bound by nothing, which neither the compiler nor a view-model test
     /// can see — only an assertion against the shipped XAML.</para>
+    /// <para>Both tabs that query the Windows task store are in scope. The Scheduled Maintenance tab is the
+    /// second instance: its status script selected <c>NumberOfMissedRuns</c>, which is the ONLY signal
+    /// Windows gives for "the conditions blocked the run" — there is no result code for a skipped run — so
+    /// without it on screen a stale Last run beside a confident Next run was the whole story a user got
+    /// (#1578). Widened here rather than copied into a second guard, because it is the same question.</para>
     /// </summary>
     [Fact]
     public void EveryScheduledTaskFieldTheQueryFetches_IsBoundInTheView()
     {
-        var service = File.ReadAllText(
-            Path.Combine(FindAppProjectDir(), "Services", "TaskSchedulerService.cs"));
-        var view = File.ReadAllText(
-            Path.Combine(FindAppProjectDir(), "Views", "TaskSchedulerView.xaml"));
+        var appDir = FindAppProjectDir();
 
         // XAML comments are stripped before matching. A comment in the view that merely NAMES a property
         // would otherwise satisfy the check — the first draft of this guard stayed green with the "Next
         // run" column deleted, because the comment above it mentioned NextRunDisplay. Only a real binding
         // counts.
-        var bindings = XmlComment().Replace(view, string.Empty);
+        var services = new Dictionary<string, string>(StringComparer.Ordinal);
+        var views = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        string Service(string file)
+        {
+            if (!services.TryGetValue(file, out var text))
+                services[file] = text = File.ReadAllText(Path.Combine(appDir, "Services", file));
+            return text;
+        }
+
+        string Bindings(string file)
+        {
+            if (!views.TryGetValue(file, out var text))
+                views[file] = text = XmlComment().Replace(
+                    File.ReadAllText(Path.Combine(appDir, "Views", file)), string.Empty);
+            return text;
+        }
 
         // Only assert on fields the service genuinely asks Windows for — otherwise this guard drifts into
         // demanding UI for data that is not collected.
@@ -6468,9 +6486,10 @@ public partial class ArchitectureTests
         // could not fail however the query changed. Found by an adversarial audit of this guard. A
         // selection fragment cannot be supplied by a comment, and stripping comments is not enough here —
         // the field genuinely appears in prose too.
-        (string Fetched, string Bound)[] contract =
+        (string ServiceFile, string ViewFile, string Fetched, string Bound)[] contract =
         [
-            ("@{ n='State'; e={ [string]$_.State } }, Author, Description", "{Binding AuthorDisplay}"),
+            ("TaskSchedulerService.cs", "TaskSchedulerView.xaml",
+             "@{ n='State'; e={ [string]$_.State } }, Author, Description", "{Binding AuthorDisplay}"),
             // DescriptionDisplay, not the raw field: most Windows tasks carry no description, and the
             // raw binding rendered those rows as an empty cell.
             //
@@ -6479,19 +6498,28 @@ public partial class ArchitectureTests
             // substring check would be satisfied by the tooltip alone, and the column could quietly go
             // back to the raw field while this guard stayed green. A tooltip is `Value="`, a column is
             // `Binding="`; only the latter is the cell. Caught by mutating exactly that.
-            ("Author, Description", "Binding=\"{Binding DescriptionDisplay}\""),
-            ("Select-Object LastRunTime, NextRunTime", "{Binding NextRunDisplay}"),
-            ("Select-Object LastRunTime, NextRunTime", "{Binding LastRunDisplay}"),
+            ("TaskSchedulerService.cs", "TaskSchedulerView.xaml",
+             "Author, Description", "Binding=\"{Binding DescriptionDisplay}\""),
+            ("TaskSchedulerService.cs", "TaskSchedulerView.xaml",
+             "Select-Object LastRunTime, NextRunTime", "{Binding NextRunDisplay}"),
+            ("TaskSchedulerService.cs", "TaskSchedulerView.xaml",
+             "Select-Object LastRunTime, NextRunTime", "{Binding LastRunDisplay}"),
+            // MissedRunsWarning, not the raw count: a bare "0" is noise on a tab that already shows three
+            // status fields, so the view model turns the count into a sentence and an empty string when
+            // there is nothing to report. The binding drives the warning card's Visibility as well as its
+            // text, which is a real use of the value.
+            ("MaintenanceSchedulerService.cs", "ScheduledMaintenanceView.xaml",
+             "MissedRunsCount = $info.NumberOfMissedRuns", "{Binding MissedRunsWarning}"),
         ];
 
         var notFetched = new List<string>();
         var notBound = new List<string>();
-        foreach (var (fetched, bound) in contract)
+        foreach (var (serviceFile, viewFile, fetched, bound) in contract)
         {
-            if (!service.Contains(fetched, StringComparison.Ordinal))
-                notFetched.Add(fetched);
-            else if (!bindings.Contains(bound, StringComparison.Ordinal))
-                notBound.Add($"{fetched} -> expected a real '{bound}' in TaskSchedulerView.xaml");
+            if (!Service(serviceFile).Contains(fetched, StringComparison.Ordinal))
+                notFetched.Add($"{serviceFile}: {fetched}");
+            else if (!Bindings(viewFile).Contains(bound, StringComparison.Ordinal))
+                notBound.Add($"{fetched} -> expected a real '{bound}' in {viewFile}");
         }
 
         // Vacuity floor: if the service stopped selecting these, the loop above would silently check
@@ -6501,10 +6529,72 @@ public partial class ArchitectureTests
             + $"fix the guard rather than trusting its pass:\n  {string.Join("\n  ", notFetched)}");
 
         Assert.True(notBound.Count == 0,
-            "the Task Scheduler query pays to fetch these fields on every scan and the view displays "
-            + "none of them, so the work is thrown away and the user cannot see data the app already "
+            "these queries pay to fetch a field on every scan and the matching view displays none of "
+            + "them, so the work is thrown away and the user cannot see data the app already "
             + $"holds:\n  {string.Join("\n  ", notBound)}");
     }
+
+    /// <summary>
+    /// Every condition a maintenance schedule can carry has a control the user can actually tick.
+    /// </summary>
+    /// <remarks>
+    /// A near miss of the unreachable-surface family that the existing guards do not cover.
+    /// <see cref="EveryViewModelProperty_IsShownOrRead"/> asks "is it shown or read", and both of these are
+    /// READ — <c>BuildSchedule()</c> passes them straight into the record — so deleting a checkbox leaves
+    /// that guard green while the condition becomes permanently whatever its default is. The failure is
+    /// silent in the other direction too: every value-level test still passes, because they construct the
+    /// record directly.
+    /// <para>The population is derived from the record's own optional <c>bool</c> parameters rather than
+    /// listed, so a third condition fails here until it has a control. <c>IsChecked="{Binding …}"</c> is the
+    /// required shape and not merely the name: a CheckBox binds <c>IsChecked</c> two-way by default, which is
+    /// what makes the tick reach the schedule, and a condition mentioned in a tooltip or bound one-way to
+    /// something else is not a control.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryMaintenanceConditionTheScheduleCarries_HasACheckBoxInTheView()
+    {
+        var appDir = FindAppProjectDir();
+        var model = File.ReadAllText(Path.Combine(appDir, "Models", "MaintenanceSchedule.cs"));
+        var view = XmlComment().Replace(
+            File.ReadAllText(Path.Combine(appDir, "Views", "ScheduledMaintenanceView.xaml")), string.Empty);
+
+        // Sliced to the MaintenanceSchedule record's parameter list. MaintenanceStatus lives in the same
+        // file and has optional parameters of its own, and those are read back from Windows rather than
+        // chosen — a file-wide match would demand a checkbox for them.
+        const string declaration = "public sealed record MaintenanceSchedule(";
+        var start = model.IndexOf(declaration, StringComparison.Ordinal);
+        Assert.True(start >= 0,
+            "could not find the MaintenanceSchedule record declaration — if the model was renamed, update "
+            + "this guard rather than letting it pass on a slice it never found");
+
+        var body = model.IndexOf("\n{", start, StringComparison.Ordinal);
+        Assert.True(body > start, "the MaintenanceSchedule declaration has no parameter list to read");
+        var parameters = model[start..body];
+
+        var conditions = OptionalBoolParameter().Matches(parameters)
+            .Select(m => m.Groups["name"].Value)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        // Vacuity floor: two conditions today (RunOnBattery, OnlyWhenIdle). A slice that parsed none would
+        // pass an empty loop and report success.
+        Assert.True(conditions.Count >= 2,
+            $"parsed only {conditions.Count} optional bool conditions from the MaintenanceSchedule "
+            + "declaration, out of 2 measured — the pattern is no longer reading the parameter list");
+
+        var untickable = conditions
+            .Where(name => !view.Contains($"IsChecked=\"{{Binding {name}}}\"", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(untickable.Count == 0,
+            "a maintenance schedule carries these conditions and the tab offers no control for them, so "
+            + "each one is permanently stuck at its default and the user cannot see that it applies at "
+            + $"all:\n  {string.Join("\n  ", untickable)}");
+    }
+
+    /// <summary>An optional <c>bool</c> parameter in a record declaration, capturing its name.</summary>
+    [GeneratedRegex(@"\bbool\s+(?<name>\w+)\s*=\s*(?:true|false)\s*[,)]", RegexOptions.Compiled)]
+    private static partial Regex OptionalBoolParameter();
 
     /// <summary>
     /// Every field the startup scan fills in on a <c>StartupEntry</c> is either bound in

--- a/SysManager/SysManager.Tests/MaintenanceScheduleTests.cs
+++ b/SysManager/SysManager.Tests/MaintenanceScheduleTests.cs
@@ -124,4 +124,152 @@ public class MaintenanceScheduleTests
             Assert.NotEqual(CliCommand.Help, parsed);
         }
     }
+    // ── Power and idle policy (#1578): the conditions that decide whether the schedule happens at all ──
+
+    [Fact]
+    public void ByDefault_TheScheduleMayRunOnBatteryAndDoesNotWaitForIdle()
+    {
+        // The defaults ARE the fix. New-ScheduledTaskSettingsSet leaves AllowStartIfOnBatteries false, so
+        // inheriting it meant an unplugged laptop never ran the schedule at all.
+        var schedule = new MaintenanceSchedule(MaintenanceAction.Cleanup, MaintenanceFrequency.Daily, 3, 0);
+
+        Assert.True(schedule.RunOnBattery);
+        Assert.False(schedule.OnlyWhenIdle);
+    }
+
+    [Fact]
+    public void Summary_WithTheDefaults_StatesTheTimeAndNoConditions()
+    {
+        var schedule = new MaintenanceSchedule(MaintenanceAction.Cleanup, MaintenanceFrequency.Daily, 3, 0);
+
+        Assert.Equal("Every day at 03:00", schedule.Summary);
+    }
+
+    [Theory]
+    [InlineData(false, false, "Every day at 03:00, only while plugged in")]
+    [InlineData(true, true, "Every day at 03:00, only when you are not using the PC")]
+    [InlineData(false, true, "Every day at 03:00, only while plugged in and only when you are not using the PC")]
+    public void Summary_NamesEveryConditionThatCanStopTheRun(bool onBattery, bool onlyIdle, string expected)
+    {
+        // Only the RESTRICTIONS are named. "Even on battery" is the default and adds nothing to plan around;
+        // "only while plugged in" is the sentence that explains a run that never came.
+        var schedule = new MaintenanceSchedule(
+            MaintenanceAction.Cleanup, MaintenanceFrequency.Daily, 3, 0,
+            RunOnBattery: onBattery, OnlyWhenIdle: onlyIdle);
+
+        Assert.Equal(expected, schedule.Summary);
+    }
+
+    [Fact]
+    public void Summary_KeepsTheWeeklyDay_WithConditionsAppended()
+    {
+        var schedule = new MaintenanceSchedule(
+            MaintenanceAction.Cleanup, MaintenanceFrequency.Weekly, 3, 30, DayOfWeek.Sunday,
+            RunOnBattery: false);
+
+        Assert.Equal("Every Sunday at 03:30, only while plugged in", schedule.Summary);
+    }
+
+    // ── The policy has to REACH the script, not just the record ──
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void RegisterParameters_CarryThePowerAndIdlePolicy(bool onBattery, bool onlyIdle)
+    {
+        var schedule = new MaintenanceSchedule(
+            MaintenanceAction.Cleanup, MaintenanceFrequency.Daily, 3, 0,
+            RunOnBattery: onBattery, OnlyWhenIdle: onlyIdle);
+
+        var parameters = MaintenanceSchedulerService.RegisterParameters(schedule, @"C:\x\SysManager.exe");
+
+        Assert.Equal(onBattery, parameters["OnBattery"]);
+        Assert.Equal(onlyIdle, parameters["OnlyIfIdle"]);
+    }
+
+    [Fact]
+    public void RegisterScript_AppliesTheBatteryFlagsOnlyWhenAsked()
+    {
+        // The flags must sit INSIDE the conditional, not in the unconditional settings block — otherwise
+        // unticking "Run even when on battery" would change the record and nothing else.
+        var script = CodeOnly(MaintenanceSchedulerService.RegisterScript);
+
+        Assert.Contains("if ($OnBattery) {", script, StringComparison.Ordinal);
+        Assert.Contains("$settingsArgs['AllowStartIfOnBatteries'] = $true", script, StringComparison.Ordinal);
+        Assert.Contains("$settingsArgs['DontStopIfGoingOnBatteries'] = $true", script, StringComparison.Ordinal);
+        Assert.Contains("if ($OnlyIfIdle) { $settingsArgs['RunOnlyIfIdle'] = $true }", script,
+                        StringComparison.Ordinal);
+
+        // Each flag appears exactly once, and after its own guard rather than before any of them.
+        foreach (var flag in new[] { "AllowStartIfOnBatteries", "RunOnlyIfIdle" })
+        {
+            var guard = flag == "RunOnlyIfIdle" ? "if ($OnlyIfIdle)" : "if ($OnBattery)";
+            Assert.True(script.IndexOf(guard, StringComparison.Ordinal)
+                        < script.IndexOf(flag, StringComparison.Ordinal),
+                        $"{flag} must appear after {guard}, or it is applied unconditionally");
+        }
+    }
+
+    [Fact]
+    public void RegisterScript_BoundsTheRunWithoutAUtilityCmdlet()
+    {
+        // A bounded ExecutionTimeLimit so a wedged maintenance run cannot sit in the scheduler forever, and
+        // [TimeSpan]::FromHours rather than New-TimeSpan: the runner's runspace is CreateDefault2, which loads
+        // Microsoft.PowerShell.Core only, so a Utility cmdlet here is not something to depend on.
+        var script = CodeOnly(MaintenanceSchedulerService.RegisterScript);
+
+        Assert.Contains("ExecutionTimeLimit = [TimeSpan]::FromHours(1)", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("New-TimeSpan", script, StringComparison.Ordinal);
+    }
+
+    /// <summary>The script with its <c>#</c> comments removed, so an assertion cannot match its own prose.</summary>
+    /// <remarks>
+    /// Both script assertions above failed on their first run for exactly that reason. The script's comment
+    /// explains that "AllowStartIfOnBatteries defaults to $FALSE" and that the limit uses
+    /// "[TimeSpan]::FromHours, not New-TimeSpan" — so a DoesNotContain on New-TimeSpan found the word in the
+    /// sentence saying not to use it, and an ordering check found AllowStartIfOnBatteries in the comment
+    /// ABOVE its own guard. Match the code shape, never the documentation of it.
+    /// </remarks>
+    private static string CodeOnly(string script) => string.Join(
+        Environment.NewLine,
+        script.Split('\n').Where(line => !line.TrimStart().StartsWith("#", StringComparison.Ordinal)));
+
+    // ── Missed runs: the only signal Windows gives for "the conditions blocked it" ──
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    public void MissedRunsWarning_IsSilentWhenNothingWasMissed(int? missed)
+    {
+        // Not "0 missed runs". A reassuring zero is noise on a tab that already shows three status fields.
+        var status = new MaintenanceStatus(true, "Ready", null, null, "Last run succeeded", missed);
+
+        Assert.Null(status.MissedRunsWarning);
+    }
+
+    [Theory]
+    [InlineData(1, "1 scheduled run did not happen")]
+    [InlineData(4, "4 scheduled runs did not happen")]
+    public void MissedRunsWarning_CountsInThePlainSingularOrPlural(int missed, string expected)
+    {
+        var status = new MaintenanceStatus(true, "Ready", null, null, "Last run succeeded", missed);
+
+        Assert.NotNull(status.MissedRunsWarning);
+        Assert.StartsWith(expected, status.MissedRunsWarning, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NotRegistered_IsTheShapeEveryFailurePathReturns()
+    {
+        var status = MaintenanceStatus.NotRegistered;
+
+        Assert.False(status.Exists);
+        Assert.Null(status.State);
+        Assert.Null(status.LastRun);
+        Assert.Null(status.NextRun);
+        Assert.Null(status.LastResultDescription);
+        Assert.Null(status.MissedRuns);
+        Assert.Null(status.MissedRunsWarning);
+    }
+
 }

--- a/SysManager/SysManager.Tests/MaintenanceSchedulerServiceTests.cs
+++ b/SysManager/SysManager.Tests/MaintenanceSchedulerServiceTests.cs
@@ -136,6 +136,45 @@ public class MaintenanceSchedulerServiceTests
         Assert.Equal("Last run failed (file not found)", status.LastResultDescription);
     }
 
+    /// <summary>
+    /// <c>NumberOfMissedRuns</c> survives the trip through <see cref="PSObject"/>, whichever integral type
+    /// the host hands it back as.
+    /// </summary>
+    /// <remarks>
+    /// The count comes back <c>uint</c> from the CIM layer but <c>int</c> through some hosts — the same split
+    /// <c>LastTaskResult</c> already has to handle — so a single-type cast would read null on whichever host
+    /// disagreed, and the missed-runs warning (#1578) would just never appear. Absent is its own row because
+    /// a task that has never been evaluated has no count at all, and that must read as "nothing to report"
+    /// rather than zero.
+    /// </remarks>
+    [Fact]
+    public async Task GetStatusAsync_ReadsMissedRuns_FromEitherIntegralType()
+    {
+        foreach (object? raw in new object?[] { 4, 4u, 4L, "4" })
+        {
+            var row = StatusRow("Ready", 0);
+            row.Properties.Add(new PSNoteProperty("MissedRunsCount", raw));
+            var (svc, _) = NewService(row);
+
+            var status = await svc.GetStatusAsync();
+
+            Assert.Equal(4, status.MissedRuns);
+            Assert.StartsWith("4 scheduled runs did not happen", status.MissedRunsWarning, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_NoMissedRunsProperty_ReportsNothing()
+    {
+        var (svc, _) = NewService(StatusRow("Ready", 0)); // the row has no MissedRunsCount at all
+
+        var status = await svc.GetStatusAsync();
+
+        Assert.True(status.Exists);
+        Assert.Null(status.MissedRuns);
+        Assert.Null(status.MissedRunsWarning);
+    }
+
     [Fact]
     public async Task GetStatusAsync_PowerShellThrows_ReturnsExistsFalse()
     {

--- a/SysManager/SysManager.Tests/ScheduledMaintenanceViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ScheduledMaintenanceViewModelTests.cs
@@ -1,0 +1,229 @@
+// SysManager · ScheduledMaintenanceViewModelTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using NSubstitute;
+using SysManager.Models;
+using SysManager.Services;
+using SysManager.ViewModels;
+using Xunit;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="ScheduledMaintenanceViewModel"/> — the power and idle conditions (#1578)
+/// and the live summary that states them, from the bound property through to the parameters the
+/// PowerShell seam actually receives.
+/// </summary>
+/// <remarks>
+/// Serialized: the Save-gate test swaps the process-wide <c>DialogService.Instance</c>.
+/// </remarks>
+[Collection("ProcessWideStatics")]
+public class ScheduledMaintenanceViewModelTests
+{
+    /// <summary>
+    /// A view model over a runner that answers "no task registered", so the constructor's status read
+    /// completes without touching the real Task Scheduler.
+    /// </summary>
+    private static (ScheduledMaintenanceViewModel vm, IPowerShellRunner ps) NewVm()
+    {
+        var ps = Substitute.For<IPowerShellRunner>();
+        ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+          .Returns(new Collection<PSObject>());
+        var vm = new ScheduledMaintenanceViewModel(new MaintenanceSchedulerService(ps));
+        // Awaiting the init task is what keeps this off the race the two guard tests in #2200 hit:
+        // the constructor kicks off RefreshAsync, so asserting immediately reads a half-built VM.
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return (vm, ps);
+    }
+
+    [Fact]
+    public void Defaults_RunOnBatteryOn_IdleOff()
+    {
+        // These two defaults ARE the fix for #1578: the tab inherited AllowStartIfOnBatteries = false
+        // from New-ScheduledTaskSettingsSet, so an unplugged laptop never ran the schedule at all.
+        var (vm, _) = NewVm();
+
+        Assert.True(vm.RunOnBattery);
+        Assert.False(vm.OnlyWhenIdle);
+    }
+
+    [Fact]
+    public void PendingSummary_WithTheDefaults_NamesNoConditions()
+    {
+        var (vm, _) = NewVm();
+        vm.SelectedFrequency = MaintenanceFrequency.Daily;
+        vm.SelectedHour = 3;
+        vm.SelectedMinute = 0;
+
+        Assert.Equal("Every day at 03:00", vm.PendingSummary);
+    }
+
+    [Theory]
+    [InlineData(false, false, "Every day at 03:00, only while plugged in")]
+    [InlineData(true, true, "Every day at 03:00, only when you are not using the PC")]
+    [InlineData(false, true, "Every day at 03:00, only while plugged in and only when you are not using the PC")]
+    public void PendingSummary_TracksTheTickedConditions(bool onBattery, bool onlyIdle, string expected)
+    {
+        var (vm, _) = NewVm();
+        vm.SelectedFrequency = MaintenanceFrequency.Daily;
+        vm.SelectedHour = 3;
+        vm.SelectedMinute = 0;
+
+        vm.RunOnBattery = onBattery;
+        vm.OnlyWhenIdle = onlyIdle;
+
+        Assert.Equal(expected, vm.PendingSummary);
+    }
+
+    /// <summary>
+    /// <see cref="ScheduledMaintenanceViewModel.PendingSummary"/> is a computed getter, so a binding only
+    /// updates if each contributing setter raises it by name.
+    /// </summary>
+    /// <remarks>
+    /// The live preview is the whole point of showing the conditions before the user commits, and the
+    /// failure mode is silent: the getter is correct, the text on screen is stale, and every value-level
+    /// test above still passes. Enumerating the setters rather than testing one keeps a seventh
+    /// contributing field from being added without its notification.
+    /// <para>Six fields, not seven: the summary answers <em>when</em>, so the chosen action is deliberately
+    /// absent from it — the action's own label is shown in the picker and in the confirmation. The tail of
+    /// this test pins that, so the list above reads as a decision rather than an omission.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryFieldThePendingSummaryReads_RaisesItWhenChanged()
+    {
+        var (vm, _) = NewVm();
+        vm.SelectedFrequency = MaintenanceFrequency.Daily;
+        vm.SelectedHour = 3;
+        vm.SelectedMinute = 0;
+        vm.SelectedDay = DayOfWeek.Sunday;
+
+        (string field, Action change)[] setters =
+        [
+            ("SelectedFrequency", () => vm.SelectedFrequency = MaintenanceFrequency.Weekly),
+            ("SelectedDay", () => vm.SelectedDay = DayOfWeek.Wednesday),
+            ("SelectedHour", () => vm.SelectedHour = 21),
+            ("SelectedMinute", () => vm.SelectedMinute = 45),
+            ("RunOnBattery", () => vm.RunOnBattery = false),
+            ("OnlyWhenIdle", () => vm.OnlyWhenIdle = true),
+        ];
+
+        foreach (var (field, change) in setters)
+        {
+            var before = vm.PendingSummary;
+            var raised = false;
+            void Watch(object? _, System.ComponentModel.PropertyChangedEventArgs e)
+            {
+                if (e.PropertyName == nameof(ScheduledMaintenanceViewModel.PendingSummary)) raised = true;
+            }
+
+            vm.PropertyChanged += Watch;
+            try { change(); }
+            finally { vm.PropertyChanged -= Watch; }
+
+            // Both halves matter: a field that does not change the sentence would make the notification
+            // assertion vacuous, and the notification is what the binding actually listens to.
+            Assert.NotEqual(before, vm.PendingSummary);
+            Assert.True(raised, $"changing {field} did not raise PendingSummary — the preview text goes stale");
+        }
+
+        var beforeAction = vm.PendingSummary;
+        vm.SelectedAction = vm.SelectedAction == MaintenanceAction.Cleanup
+            ? MaintenanceAction.PurgeStandby
+            : MaintenanceAction.Cleanup;
+        Assert.Equal(beforeAction, vm.PendingSummary);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task SaveSchedule_SendsTheTickedConditionsToPowerShell(bool onBattery, bool onlyIdle)
+    {
+        // The end-to-end question a value test cannot answer: does the checkbox reach the scheduler, or
+        // does it change a record nobody passes on? The runner returns no rows, so RegisterAsync reports
+        // failure and the activity log stays untouched — the parameters are still recorded.
+        var (vm, ps) = NewVm();
+        vm.SelectedFrequency = MaintenanceFrequency.Daily;
+        vm.RunOnBattery = onBattery;
+        vm.OnlyWhenIdle = onlyIdle;
+
+        var previous = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.SaveScheduleCommand.Execute(null);
+            await vm.SaveScheduleCommand.ExecutionTask!;
+        }
+        finally
+        {
+            DialogService.Instance = previous;
+        }
+
+        await ps.Received(1).RunAsync(
+            Arg.Any<string>(),
+            Arg.Is<IDictionary<string, object?>?>(p =>
+                p != null && p.ContainsKey("OnBattery") &&
+                (bool)p["OnBattery"]! == onBattery &&
+                (bool)p["OnlyIfIdle"]! == onlyIdle),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SaveSchedule_WhenTheUserDeclines_SendsNothing()
+    {
+        var (vm, ps) = NewVm();
+        ps.ClearReceivedCalls(); // the constructor's status read is not what this asserts about
+
+        var previous = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            vm.SaveScheduleCommand.Execute(null);
+            if (vm.SaveScheduleCommand.ExecutionTask is { } running) await running;
+        }
+        finally
+        {
+            DialogService.Instance = previous;
+        }
+
+        dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+        await ps.DidNotReceive().RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(),
+                                          Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void MissedRunsWarning_IsEmptyWhenNoTaskIsRegistered()
+    {
+        // Empty string, not the record's null: the view binds Visibility to this, and FlexVis collapses
+        // on empty. A "0 missed runs" or a stray placeholder here would show an empty warning card.
+        var (vm, _) = NewVm();
+
+        Assert.False(vm.IsScheduled);
+        Assert.Equal("", vm.MissedRunsWarning);
+    }
+
+    [Fact]
+    public async Task MissedRunsWarning_SurfacesWindowsCount_WhenTheTaskExists()
+    {
+        var row = new PSObject();
+        row.Properties.Add(new PSNoteProperty("State", "Ready"));
+        row.Properties.Add(new PSNoteProperty("LastTaskResult", 0));
+        row.Properties.Add(new PSNoteProperty("MissedRunsCount", 3u)); // CIM hands this back unsigned
+
+        var ps = Substitute.For<IPowerShellRunner>();
+        ps.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>?>(), Arg.Any<CancellationToken>())
+          .Returns(new Collection<PSObject> { row });
+        var vm = new ScheduledMaintenanceViewModel(new MaintenanceSchedulerService(ps));
+        await vm.InitializationComplete;
+
+        Assert.True(vm.IsScheduled);
+        Assert.StartsWith("3 scheduled runs did not happen", vm.MissedRunsWarning, StringComparison.Ordinal);
+    }
+}

--- a/SysManager/SysManager/Models/MaintenanceSchedule.cs
+++ b/SysManager/SysManager/Models/MaintenanceSchedule.cs
@@ -42,7 +42,9 @@ public sealed record MaintenanceSchedule(
     int Hour,
     int Minute,
     // Day of week for weekly schedules (ignored for daily). Sunday = 0.
-    DayOfWeek DayOfWeek = DayOfWeek.Sunday)
+    DayOfWeek DayOfWeek = DayOfWeek.Sunday,
+    bool RunOnBattery = true,
+    bool OnlyWhenIdle = false)
 {
     /// <summary>The CLI argument string this schedule runs (whitelisted, no user text).</summary>
     public string CliArguments => Action switch
@@ -70,10 +72,33 @@ public sealed record MaintenanceSchedule(
 
     public string ActionLabel => LabelFor(Action);
 
-    /// <summary>A plain-language summary of when this runs (e.g. "Every Sunday at 03:00").</summary>
-    public string Summary => Frequency == MaintenanceFrequency.Daily
-        ? $"Every day at {Hour:D2}:{Minute:D2}"
-        : $"Every {DayOfWeek} at {Hour:D2}:{Minute:D2}";
+    /// <summary>
+    /// A plain-language summary of when this runs, including the conditions that can stop it
+    /// (e.g. "Every Sunday at 03:00, only while plugged in and only when you are not using the PC").
+    /// </summary>
+    /// <remarks>
+    /// The conditions belong in the sentence because they decide whether the schedule happens at all, and
+    /// the tab used to promise the time unconditionally while Windows quietly applied a policy nobody had
+    /// been shown (#1578). A summary that states the time and hides the conditions is the part that made
+    /// "it says next run 03:00 but it never ran" possible.
+    /// </remarks>
+    public string Summary
+    {
+        get
+        {
+            var when = Frequency == MaintenanceFrequency.Daily
+                ? $"Every day at {Hour:D2}:{Minute:D2}"
+                : $"Every {DayOfWeek} at {Hour:D2}:{Minute:D2}";
+
+            // Only the RESTRICTIONS are named. "Even on battery" is the default and adds nothing a user
+            // needs to plan around; "only while plugged in" is the one that explains a run that never came.
+            List<string> conditions = [];
+            if (!RunOnBattery) conditions.Add("only while plugged in");
+            if (OnlyWhenIdle) conditions.Add("only when you are not using the PC");
+
+            return conditions.Count == 0 ? when : $"{when}, {string.Join(" and ", conditions)}";
+        }
+    }
 }
 
 /// <summary>The live state of the registered maintenance task, read back from Windows.</summary>
@@ -82,4 +107,29 @@ public sealed record MaintenanceStatus(
     string? State,
     DateTime? LastRun,
     DateTime? NextRun,
-    string? LastResultDescription);
+    string? LastResultDescription,
+    // How many scheduled runs Windows recorded as missed.
+    int? MissedRuns = null)
+{
+    /// <summary>No task is registered — the same shape every failure path returns.</summary>
+    /// <remarks>
+    /// A named value rather than five nulls at three call sites. Adding a field to this record previously
+    /// meant editing each of them, and a missed one is a compile error only because every field happens to
+    /// be nullable.
+    /// </remarks>
+    public static MaintenanceStatus NotRegistered { get; } = new(false, null, null, null, null);
+
+    /// <summary>
+    /// How Windows says the schedule is not firing, or null when there is nothing to report.
+    /// </summary>
+    /// <remarks>
+    /// There is no <c>LastTaskResult</c> code for "skipped because the conditions were not met" — Windows
+    /// expresses that by simply not running, which is exactly why a stale Last run and a confident Next run
+    /// were all the user got (#1578). <c>NumberOfMissedRuns</c> is the signal that does exist, so this is the
+    /// honest version of the explanation rather than an invented result code.
+    /// </remarks>
+    public string? MissedRunsWarning => MissedRuns is > 0
+        ? $"{MissedRuns} scheduled run{(MissedRuns == 1 ? "" : "s")} did not happen — the PC was probably "
+          + "off, asleep, or blocked by one of the conditions below."
+        : null;
+}

--- a/SysManager/SysManager/Services/MaintenanceSchedulerService.cs
+++ b/SysManager/SysManager/Services/MaintenanceSchedulerService.cs
@@ -43,17 +43,9 @@ public sealed class MaintenanceSchedulerService
 
         try
         {
-            var parameters = new Dictionary<string, object?>
-            {
-                ["Exe"] = exePath,
-                ["Args"] = schedule.CliArguments,
-                ["Folder"] = TaskFolder,
-                ["Name"] = TaskName,
-                ["Daily"] = schedule.Frequency == MaintenanceFrequency.Daily,
-                ["At"] = $"{schedule.Hour:D2}:{schedule.Minute:D2}",
-                ["DayOfWeek"] = schedule.DayOfWeek.ToString(),
-            };
-            Collection<PSObject> results = await _ps.RunAsync(RegisterScript, parameters, ct).ConfigureAwait(false);
+            Collection<PSObject> results = await _ps
+                .RunAsync(RegisterScript, RegisterParameters(schedule, exePath), ct)
+                .ConfigureAwait(false);
             // The script emits the registered task's state; one row back == success.
             return results.Count == 1 && Str(results[0], "State") is not null;
         }
@@ -64,6 +56,28 @@ public sealed class MaintenanceSchedulerService
         }
     }
 
+    /// <summary>
+    /// The parameters <see cref="RegisterScript"/> is invoked with, for a schedule and an executable path.
+    /// </summary>
+    /// <remarks>
+    /// Pure and <c>internal</c> so a test can assert that a schedule's power and idle policy actually reaches
+    /// the script. The alternative — calling <c>RegisterAsync</c> — registers a real Windows scheduled task on
+    /// the machine running the test, which is not something a unit suite may do to a developer's PC.
+    /// </remarks>
+    internal static Dictionary<string, object?> RegisterParameters(MaintenanceSchedule schedule, string exePath)
+        => new()
+        {
+            ["Exe"] = exePath,
+            ["Args"] = schedule.CliArguments,
+            ["Folder"] = TaskFolder,
+            ["Name"] = TaskName,
+            ["Daily"] = schedule.Frequency == MaintenanceFrequency.Daily,
+            ["At"] = $"{schedule.Hour:D2}:{schedule.Minute:D2}",
+            ["DayOfWeek"] = schedule.DayOfWeek.ToString(),
+            ["OnBattery"] = schedule.RunOnBattery,
+            ["OnlyIfIdle"] = schedule.OnlyWhenIdle,
+        };
+
     /// <summary>Reads the current state of the maintenance task (Exists=false if not registered).</summary>
     public async Task<MaintenanceStatus> GetStatusAsync(CancellationToken ct = default)
     {
@@ -71,7 +85,7 @@ public sealed class MaintenanceSchedulerService
         {
             var parameters = new Dictionary<string, object?> { ["Folder"] = TaskFolder, ["Name"] = TaskName };
             Collection<PSObject> results = await _ps.RunAsync(StatusScript, parameters, ct).ConfigureAwait(false);
-            if (results.Count == 0) return new MaintenanceStatus(false, null, null, null, null);
+            if (results.Count == 0) return MaintenanceStatus.NotRegistered;
 
             var row = results[0];
             return new MaintenanceStatus(
@@ -79,12 +93,13 @@ public sealed class MaintenanceSchedulerService
                 State: Str(row, "State"),
                 LastRun: Date(row, "LastRunTime"),
                 NextRun: Date(row, "NextRunTime"),
-                LastResultDescription: DescribeResult(row));
+                LastResultDescription: DescribeResult(row),
+                MissedRuns: Count(row, "MissedRunsCount"));
         }
         catch (RuntimeException ex)
         {
             Log.Debug("Maintenance status read failed: {Error}", ex.Message);
-            return new MaintenanceStatus(false, null, null, null, null);
+            return MaintenanceStatus.NotRegistered;
         }
     }
 
@@ -114,16 +129,33 @@ public sealed class MaintenanceSchedulerService
     // principal — so it needs no admin to register and runs only when that user is logged on,
     // never with elevation. (Previously this relied on the cmdlet's default principal; the
     // explicit principal makes the security posture deliberate rather than implicit.)
-    private const string RegisterScript = """
+    internal const string RegisterScript = """
         param([string]$Exe, [string]$Args, [string]$Folder, [string]$Name,
-              [bool]$Daily, [string]$At, [string]$DayOfWeek)
+              [bool]$Daily, [string]$At, [string]$DayOfWeek,
+              [bool]$OnBattery, [bool]$OnlyIfIdle)
         $action = New-ScheduledTaskAction -Execute $Exe -Argument $Args
         if ($Daily) {
             $trigger = New-ScheduledTaskTrigger -Daily -At $At
         } else {
             $trigger = New-ScheduledTaskTrigger -Weekly -DaysOfWeek $DayOfWeek -At $At
         }
-        $settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -DontStopOnIdleEnd
+        # Splatted from typed [bool] parameters, so the policy is still a whitelisted value and never
+        # free-form text. AllowStartIfOnBatteries defaults to $FALSE in New-ScheduledTaskSettingsSet, and
+        # inheriting that default is the defect: on a laptop running unplugged the task simply did not start,
+        # and -StartWhenAvailable then fired it late, whenever the condition next cleared.
+        # [TimeSpan]::FromHours, not New-TimeSpan: the runner's runspace is InitialSessionState.CreateDefault2,
+        # which loads Microsoft.PowerShell.Core only — a Utility cmdlet here cannot be relied on.
+        $settingsArgs = @{
+            StartWhenAvailable = $true
+            DontStopOnIdleEnd  = $true
+            ExecutionTimeLimit = [TimeSpan]::FromHours(1)
+        }
+        if ($OnBattery) {
+            $settingsArgs['AllowStartIfOnBatteries'] = $true
+            $settingsArgs['DontStopIfGoingOnBatteries'] = $true
+        }
+        if ($OnlyIfIdle) { $settingsArgs['RunOnlyIfIdle'] = $true }
+        $settings = New-ScheduledTaskSettingsSet @settingsArgs
         $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
         Register-ScheduledTask -TaskName $Name -TaskPath $Folder -Action $action -Trigger $trigger `
             -Settings $settings -Principal $principal -Description "SysManager automated maintenance." `
@@ -139,10 +171,11 @@ public sealed class MaintenanceSchedulerService
         if ($null -eq $task) { return }
         $info = Get-ScheduledTaskInfo -TaskName $Name -TaskPath $Folder -ErrorAction SilentlyContinue
         [PSCustomObject]@{
-            State          = [string]$task.State
-            LastRunTime    = $info.LastRunTime
-            NextRunTime    = $info.NextRunTime
-            LastTaskResult = $info.LastTaskResult
+            State           = [string]$task.State
+            LastRunTime     = $info.LastRunTime
+            NextRunTime     = $info.NextRunTime
+            LastTaskResult  = $info.LastTaskResult
+            MissedRunsCount = $info.NumberOfMissedRuns
         }
         """;
 
@@ -178,6 +211,24 @@ public sealed class MaintenanceSchedulerService
     }
 
     private static string? Str(PSObject? obj, string property) => obj?.Properties[property]?.Value?.ToString();
+
+    /// <summary>
+    /// Reads a count Windows reports as one of several integral CIM types, or null when it is absent.
+    /// </summary>
+    /// <remarks>
+    /// <c>NumberOfMissedRuns</c> comes back as <c>uint</c> from the CIM layer but as <c>int</c> through some
+    /// hosts, and the existing <c>DescribeResult</c> already has to handle both for <c>LastTaskResult</c> —
+    /// so a single-type cast here would silently read null on whichever host disagreed.
+    /// </remarks>
+    private static int? Count(PSObject? obj, string property) => obj?.Properties[property]?.Value switch
+    {
+        int value => value,
+        uint value => (int)Math.Min(value, int.MaxValue),
+        long value => (int)Math.Clamp(value, 0, int.MaxValue),
+        string text when int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            => parsed,
+        _ => null,
+    };
 
     private static DateTime? Date(PSObject? obj, string property) => obj?.Properties[property]?.Value switch
     {

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.83.0</Version>
-    <FileVersion>1.83.0.0</FileVersion>
-    <AssemblyVersion>1.83.0.0</AssemblyVersion>
+    <Version>1.84.0</Version>
+    <FileVersion>1.84.0.0</FileVersion>
+    <AssemblyVersion>1.84.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ScheduledMaintenanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ScheduledMaintenanceViewModel.cs
@@ -35,11 +35,37 @@ public sealed partial class ScheduledMaintenanceViewModel : ViewModelBase
     [ObservableProperty] private int _selectedMinute = 0;
     [ObservableProperty] private bool _isWeekly = true;
 
+    /// <summary>
+    /// Whether the task may start while the machine is on battery. Defaults to true, which is a CHANGE from
+    /// what Windows applied before: New-ScheduledTaskSettingsSet leaves AllowStartIfOnBatteries false, so on
+    /// an unplugged laptop the schedule quietly never started while this tab displayed a Next run time
+    /// (#1578). The maintenance verbs this tab can schedule are cheap and non-destructive, so running them
+    /// unplugged is the behaviour a user asking for automatic maintenance expects.
+    /// </summary>
+    [ObservableProperty] private bool _runOnBattery = true;
+
+    /// <summary>
+    /// Whether the task waits until the machine is idle. Off by default, deliberately: it reintroduces the
+    /// "never ran" failure on a PC that is always in use, so it is the user's choice to make rather than a
+    /// default they would have to discover.
+    /// </summary>
+    [ObservableProperty] private bool _onlyWhenIdle;
+
     [ObservableProperty] private bool _isScheduled;
     [ObservableProperty] private string _currentSummary = "";
     [ObservableProperty] private string _lastRun = "";
     [ObservableProperty] private string _nextRun = "";
     [ObservableProperty] private string _lastResult = "";
+
+    /// <summary>
+    /// Windows' own count of scheduled runs that did not happen, in words, or empty when there are none.
+    /// </summary>
+    /// <remarks>
+    /// The missing half of the story. There is no LastTaskResult code for "skipped because the conditions were
+    /// not met" — Windows just does not run — so a stale Last run beside a confident Next run was everything
+    /// the user got. NumberOfMissedRuns is the signal that does exist.
+    /// </remarks>
+    [ObservableProperty] private string _missedRunsWarning = "";
 
     public ScheduledMaintenanceViewModel(MaintenanceSchedulerService service)
     {
@@ -49,7 +75,18 @@ public sealed partial class ScheduledMaintenanceViewModel : ViewModelBase
     }
 
     partial void OnSelectedFrequencyChanged(MaintenanceFrequency value)
-        => IsWeekly = value == MaintenanceFrequency.Weekly;
+    {
+        IsWeekly = value == MaintenanceFrequency.Weekly;
+        OnPropertyChanged(nameof(PendingSummary));
+    }
+
+    // PendingSummary is computed from six of these, so each one has to announce it. A [NotifyPropertyChangedFor]
+    // on every field would say the same thing six times; one hook per field keeps it where the field is.
+    partial void OnSelectedDayChanged(DayOfWeek value) => OnPropertyChanged(nameof(PendingSummary));
+    partial void OnSelectedHourChanged(int value) => OnPropertyChanged(nameof(PendingSummary));
+    partial void OnSelectedMinuteChanged(int value) => OnPropertyChanged(nameof(PendingSummary));
+    partial void OnRunOnBatteryChanged(bool value) => OnPropertyChanged(nameof(PendingSummary));
+    partial void OnOnlyWhenIdleChanged(bool value) => OnPropertyChanged(nameof(PendingSummary));
 
     /// <summary>Gate for the async commands so a second click can't start an overlapping
     /// Save/Remove/Refresh while one is in flight (which would race IsBusy + the read-back).</summary>
@@ -66,7 +103,18 @@ public sealed partial class ScheduledMaintenanceViewModel : ViewModelBase
     }
 
     private MaintenanceSchedule BuildSchedule() =>
-        new(SelectedAction, SelectedFrequency, SelectedHour, SelectedMinute, SelectedDay);
+        new(SelectedAction, SelectedFrequency, SelectedHour, SelectedMinute, SelectedDay,
+            RunOnBattery, OnlyWhenIdle);
+
+    /// <summary>
+    /// What the schedule about to be saved will actually do, conditions included.
+    /// </summary>
+    /// <remarks>
+    /// Bound live in the Configure card, so ticking a condition shows its consequence in words before the
+    /// user commits — the tab previously promised the time unconditionally and never mentioned the policy
+    /// Windows would apply.
+    /// </remarks>
+    public string PendingSummary => BuildSchedule().Summary;
 
     [RelayCommand(CanExecute = nameof(NotBusy))]
     private async Task RefreshAsync()
@@ -91,12 +139,13 @@ public sealed partial class ScheduledMaintenanceViewModel : ViewModelBase
             LastRun = status.LastRun is { } lr ? lr.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) : "—";
             NextRun = status.NextRun is { } nr ? nr.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) : "—";
             LastResult = status.LastResultDescription ?? "";
+            MissedRunsWarning = status.MissedRunsWarning ?? "";
             StatusMessage = "A maintenance task is registered. You can update or remove it below.";
         }
         else
         {
             CurrentSummary = "No maintenance is scheduled yet.";
-            LastRun = NextRun = LastResult = "";
+            LastRun = NextRun = LastResult = MissedRunsWarning = "";
             StatusMessage = "Pick an action and time, then Save schedule to automate it.";
         }
         RemoveScheduleCommand.NotifyCanExecuteChanged();

--- a/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
+++ b/SysManager/SysManager/Views/ScheduledMaintenanceView.xaml
@@ -64,6 +64,16 @@
                         </StackPanel>
                     </Border>
                 </Grid>
+
+                <!-- Windows' own count of runs that did not happen. There is no LastTaskResult code for
+                     "skipped because the conditions were not met" — it just does not run — so without this
+                     a stale LAST RUN beside a confident NEXT RUN was the whole story. Collapses when the
+                     count is zero rather than showing a reassuring "0 missed", which would be noise. -->
+                <Border Style="{StaticResource CardInner}" Margin="0,12,0,0"
+                        Visibility="{Binding MissedRunsWarning, Converter={StaticResource FlexVis}}">
+                    <TextBlock Text="{Binding MissedRunsWarning}" FontSize="13" TextWrapping="Wrap"
+                               Foreground="{DynamicResource WarningText}"/>
+                </Border>
             </StackPanel>
         </Border>
 
@@ -108,7 +118,28 @@
                                   Width="70" Margin="0,4,0,0" AutomationProperties.Name="Minute"/>
                     </StackPanel>
                 </WrapPanel>
+
+                <!-- The conditions Windows applies, made visible and changeable. AllowStartIfOnBatteries
+                     defaults to FALSE in New-ScheduledTaskSettingsSet, so an unplugged laptop simply never
+                     ran the schedule while this tab showed a Next run time and promised "no need to remember
+                     it yourself" (#1578). Content is the label, so the accessible name leads with the same
+                     words — EveryLabelledControl_IsAnnouncedWithTheWordsPrintedOnIt holds that. -->
                 <WrapPanel Orientation="Horizontal" Margin="0,4,0,0">
+                    <CheckBox Content="Run even when on battery" IsChecked="{Binding RunOnBattery}"
+                              VerticalAlignment="Center" Margin="0,0,20,0"
+                              AutomationProperties.Name="Run even when on battery"
+                              ToolTip="On by default. With this off, Windows skips the run whenever the PC is unplugged — and it does not tell you it skipped, so the tab would show an old Last run beside a future Next run."/>
+                    <CheckBox Content="Only run when I'm not using the PC" IsChecked="{Binding OnlyWhenIdle}"
+                              VerticalAlignment="Center" Margin="0,0,20,0"
+                              AutomationProperties.Name="Only run when I'm not using the PC"
+                              ToolTip="Off by default. Waiting for the PC to be idle keeps maintenance out of your way, but on a machine that is always in use it can mean the schedule never runs at all."/>
+                </WrapPanel>
+
+                <!-- What the settings above add up to, in the same words the saved schedule will report. -->
+                <TextBlock Text="{Binding PendingSummary}" Style="{StaticResource Subtle}"
+                           TextWrapping="Wrap" Margin="0,10,0,0"/>
+
+                <WrapPanel Orientation="Horizontal" Margin="0,12,0,0">
                     <Button Content="Save schedule" Command="{Binding SaveScheduleCommand}"
                             Style="{StaticResource PrimaryButton}" Margin="0,0,8,0"
                             AutomationProperties.Name="Save schedule — the maintenance schedule"/>


### PR DESCRIPTION
Closes #1578

## The defect

`New-ScheduledTaskSettingsSet` leaves `AllowStartIfOnBatteries` at `$false`, and the registration inherited that default. On any laptop used unplugged, the Scheduled Maintenance tab showed a confident **Next run** time and the run was silently skipped — and Windows reports a skipped run as nothing at all: no error, no result code, just a **Last run** that never moves. The tab's own subtitle promises "no need to remember to do it yourself".

`-StartWhenAvailable` was already set, which made it worse rather than better: the run fired late, whenever the condition next cleared, so the observable symptom was maintenance happening at an unpredictable time instead of the one that was chosen.

## What changed

**Fixed** — the settings block opts in to starting on battery, and to continuing if the machine is unplugged mid-run, unless the user unticks it. The maintenance verbs this tab can schedule (`--cleanup`, `--purge-standby`) are cheap and non-destructive, so running them unplugged is what someone asking for automatic maintenance expects.

**Added**

- **"Only run when I'm not using the PC"** — offered, and OFF by default. Waiting for idle reintroduces the same never-ran failure on a machine that is always in use, so it is a choice rather than a default to discover.
- **The pending schedule spelled out in words**, conditions included ("Every day at 03:00, only while plugged in"), updating as the settings change — so the consequence of a tick is visible before it is committed.
- **Windows' own count of skipped runs**, shown only when it is not zero. `NumberOfMissedRuns` is the only signal Windows gives for a run its conditions blocked; a reassuring "0 missed" would be noise on a tab that already shows three status fields.
- **`ExecutionTimeLimit` capped at one hour**, so a wedged background run cannot sit in the scheduler forever. `[TimeSpan]::FromHours` rather than `New-TimeSpan`: the runner's runspace is `InitialSessionState.CreateDefault2`, which loads `Microsoft.PowerShell.Core` only, so a Utility cmdlet cannot be relied on there.

Only the restrictions appear in the summary sentence. "Even on battery" is the default and adds nothing to plan around; "only while plugged in" is the sentence that explains a run that never came.

## Security posture unchanged

The policy is splatted into the cmdlet from typed `[bool]` parameters, so it remains a whitelisted value and no free-form text reaches the scheduler. The task is still registered in the current user's context at `LIMITED` run level, still touches only `\SysManager\Scheduled Maintenance`, and the command is still built from the fixed `MaintenanceSchedule.CliArguments` whitelist.

## Verification

Four projects build Release at **0 errors / 0 warnings**; `dotnet format --verify-no-changes` clean on all four. Unit suite **5338 passing** (up from 5309), including the 29 added here.

Twelve mutations, each proved RED before the fix and GREEN after, restored byte-for-byte with a hash check:

| Mutation | Test that caught it |
|---|---|
| schedule no longer defaults to running on battery | `ByDefault_TheScheduleMayRunOnBatteryAndDoesNotWaitForIdle` (+ two pre-existing summary tests, correctly) |
| the tab no longer opens with the condition allowed | `Defaults_RunOnBatteryOn_IdleOff` |
| summary stops naming the plugged-in restriction | `Summary_NamesEveryConditionThatCanStopTheRun`, `PendingSummary_TracksTheTickedConditions` |
| policy never reaches the script parameters | `RegisterParameters_CarryThePowerAndIdlePolicy`, `SaveSchedule_SendsTheTickedConditionsToPowerShell` |
| flags applied unconditionally instead of behind their guard | `RegisterScript_AppliesTheBatteryFlagsOnlyWhenAsked` |
| status read drops the missed-run count | `GetStatusAsync_ReadsMissedRuns_FromEitherIntegralType` |
| warning fires when nothing was missed | `MissedRunsWarning_IsSilentWhenNothingWasMissed` |
| ticking a condition no longer refreshes the live summary | `EveryFieldThePendingSummaryReads_RaisesItWhenChanged` |
| either checkbox stops binding its condition | `EveryMaintenanceConditionTheScheduleCarries_HasACheckBoxInTheView` |
| script stops selecting the count / card re-pointed away from it | `EveryScheduledTaskFieldTheQueryFetches_IsBoundInTheView` |

Two of those live in the blocking architecture suite and pin the XAML side, which is where this repo's recurring defect hides:

- `EveryScheduledTaskFieldTheQueryFetches_IsBoundInTheView` is **widened** to cover this tab rather than copied into a second guard — it is the same question ("everything the query pays to fetch reaches the screen"), now asked of both tabs that read the Windows task store. Its vacuity floor and comment-stripping are unchanged.
- `EveryMaintenanceConditionTheScheduleCarries_HasACheckBoxInTheView` is new, and covers a gap the existing guards genuinely do not: `EveryViewModelProperty_IsShownOrRead` asks "shown or read", and both conditions **are** read — `BuildSchedule()` passes them straight into the record — so deleting a checkbox leaves it green while the condition freezes at its default. The population is derived from the record's own optional `bool` parameters, so a third condition fails until it has a control.

`RegisterParameters` was extracted as a pure `internal` helper specifically so the policy can be asserted without registering a real scheduled task on the machine running the tests.

## Deferred to the secondary workstation

The two new checkboxes and the summary line rendering at the tab's real width, the warning card appearing against a task with genuine missed runs, and an end-to-end register → unplug → confirm-it-still-fires pass. Everything asserted above is source- and substitute-level.
