### PR TITLE
docs: give every tab its own README section, and a guard that keeps it that way

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,29 +281,7 @@ Edit Windows environment variables without the cramped built-in dialog:
 - **Tray shortcut** — a "Volume mixer" item in the system-tray menu opens the app straight
   to this tab
 
-### Network monitor
-- Live ping across multiple targets overlaid on a single latency chart
-- Auto-verdict that tells you in plain English whether packet loss is local,
-  at your ISP, or at the far-end service
-- **Presets for gamers & streamers**:
-  - Global (Google, Cloudflare, your router)
-  - **CS2 Europe** — Valve matchmaking relays (Vienna, Luxembourg, Warsaw, EU West/Central/East)
-  - **FACEIT Europe** — competitive CS2 servers in DE, NL, UK
-  - **PUBG Europe** — EU matchmaking cloud regions (Frankfurt, Ireland, London)
-  - **Streaming** — YouTube, Twitch, Cloudflare
-- Auto-traceroute on a configurable interval (30 s – 10 min)
-- Speed tests: HTTP (Cloudflare) and the official Ookla CLI (auto-downloaded)
-  with persistent history (last 20 results per engine) for tracking service
-  degradation over time
-- Every speed result comes with a plain-English verdict — what that speed is
-  actually enough for (video calls, HD, 4K, several devices at once) rather than
-  just a number — plus one line comparing it with your previous test on the same
-  engine
-- Jitter, loss %, and average ping per target rolled up into health pills
-- **Network repair tools**: DNS flush, Winsock reset, TCP/IP reset with
-  confirmation dialogs and admin checks
-
-### System logs (Windows Event Log, friendly)
+### System Logs (Windows Event Log, friendly)
 - Browse System, Application, Security, and Setup logs
 - Each event gets a plain-English explanation and recommended next steps
 - Filter by severity and time range, plus full-text search
@@ -313,7 +291,7 @@ Edit Windows environment variables without the cramped built-in dialog:
 - The Security log requires administrator rights. Without them the page says so
   outright rather than showing an empty list that looks like "no events"
 
-### System report
+### System Report
 - One-click, read-only snapshot of the whole machine: OS, CPU, memory
   (with per-slot module detail), GPU, motherboard, storage health, and active
   network adapters
@@ -324,7 +302,7 @@ Edit Windows environment variables without the cramped built-in dialog:
 - Fully local: nothing on the system is changed and the report is written only
   to the file you choose — nothing leaves the machine
 
-### System health
+### System Health
 - OS / CPU / RAM / storage overview
 - SMART data per disk: temperature, wear %, power-on hours, read/write errors
 - Colour-coded verdict per drive
@@ -450,13 +428,13 @@ a confirmation before it runs:
 - Sort by name, ID, version, or source via clickable column headers
 - Select all or individual packages, bulk upgrade with per-package status
 
-### Cleanup (fast)
+### Quick Cleanup
 - Clear TEMP folders
 - Empty the Recycle Bin
 - Run `SFC /scannow` and `DISM /RestoreHealth` in the background — keep
   using the app while they grind
 
-### Deep cleanup (safe)
+### Deep Cleanup
 - **Scan-first**: every category is discovered with size + file count
   before a single byte is deleted. You pick what goes.
 - **System buckets**: NVIDIA / AMD / Intel installer leftovers, Windows
@@ -524,7 +502,7 @@ a confirmation before it runs:
 - Search/filter across all features
 - Requires administrator privileges for modifications
 
-### Duplicate File Finder
+### Duplicate Finder
 - Three-pass scan: group by size, partial-hash pre-filter, then full SHA-256
 - Duplicate groups sorted by wasted space (descending)
 - Preset folders or custom folder selection
@@ -719,6 +697,73 @@ a confirmation before it runs:
 - Progress tracking per-item with cancel support
 - Skips junction points and symbolic links (prevents symlink attacks)
 - Confirmation dialog before irreversible shred
+
+### Ping
+- **Says WHERE the problem is, not just that there is one.** Targets are tagged by role —
+  your gateway, public DNS, game servers, streaming services — and the verdict names the
+  layer: "Problem on your local network", "Problem at your ISP or upstream", "It's the game
+  server, not you", "Streaming service is slow", or "Multiple layers affected". This is the
+  point of the tab: "my internet is bad" is not actionable, "your router is fine, your ISP
+  is not" is.
+- **Watches several hosts at once**, each with its own live latency, average, jitter and
+  loss, and its own colour on the shared chart
+- **Five presets for gamers and streamers**, plus your own: type a hostname or IP to add a
+  target, and only the ones you added carry a remove button
+  - **Global** — Google DNS, Cloudflare, Quad9, google.com
+  - **CS2 Europe** — Valve matchmaking relays (Vienna, Luxembourg, Warsaw, EU West/Central/East)
+  - **FACEIT Europe** — competitive CS2 servers in DE, NL, UK
+  - **PUBG Europe** — the EU matchmaking cloud regions (Frankfurt, Ireland, London)
+  - **Streaming** — YouTube, Twitch, Cloudflare, to correlate buffering with the network
+- **Your gateway is detected and added automatically**, so the first thing the chart can
+  tell you apart is your own network from everything beyond it
+- **Live latency chart** with a pickable window (1, 5, 10 or 15 minutes) and a pingable
+  interval, default once per second
+- Headline numbers across all targets: average ping, worst loss, worst jitter
+- Start, Stop and Clear are separate, and the status line confirms what Clear did
+
+### Traceroute
+- **Traces every ping target on a loop**, so you can see which hop the latency appears at
+  rather than only that the destination is slow — interval 30 s to 10 min, default 60 s
+- **Latency per hop, charted**, alongside the hop table (number, address, ms)
+- **One-off trace to any host** you type, with its own status line and a Cancel button
+- Shares its targets and its start/stop state with the Ping tab, because it is the same
+  monitor answering a different question
+
+### Speed Test
+- **Two engines, and it explains why they disagree.** Ookla measures raw TCP throughput to
+  a nearby server (closest to what you pay your ISP for); the HTTP test measures through
+  Cloudflare's CDN (closer to real browsing, usually lower). The tab says this on screen
+  rather than leaving you to wonder which number is "wrong".
+- **A verdict, not just numbers** — each result says what that speed is actually enough for
+  ("Comfortable for HD streaming on one or two devices, and for video calls", "Handles 4K
+  streaming and several devices at once") plus one line comparing it with your previous test
+  on the same engine, so a slow day is visible as a slow day rather than a number you have
+  to interpret
+- **Pick the Ookla server** or leave it on Auto (nearest): Bucharest, London, Frankfurt,
+  Amsterdam, Paris, New York
+- **Separate persistent history per engine**, the last 20 results each — date, download,
+  upload, ping and server — clearable on its own, because comparing an HTTP run against an
+  Ookla run is not a comparison
+- Progress bar with a time-remaining estimate and a Cancel button; the Ookla CLI is
+  downloaded on first run
+- Only one engine runs at a time, so the two cards can never show conflicting progress
+
+### Network Repair
+- **Three fixes, each explained before you press it** — what it does, whether it is safe,
+  whether it needs a reboot, and what kind of breakage it is for:
+  - **Flush DNS Cache** — clears the local resolver cache for stale entries. Safe, instant,
+    no reboot.
+  - **Reset Winsock Catalog** — resets the socket API that every networked app uses, for
+    damage from broken VPN drivers, malware or corrupted LSP providers. Admin + reboot.
+  - **Reset TCP/IP Stack** — rebuilds the TCP/IP registry keys from Windows defaults. The
+    last resort, and labelled as one: it discards custom IP configuration, routes and
+    adapter settings. Admin + reboot.
+- **Admin elevation banner** stating exactly which of the three need elevation and what
+  unlocks once you restart elevated
+- **A reboot warning appears only after a fix that actually needs one**, rather than
+  standing on screen permanently
+- Each of the three is confirmed before it runs, and the buttons disable while a repair is
+  in flight so two resets cannot overlap
 
 ### DNS & Hosts
 - **DNS Preset Switching** — one-click DNS change: plain resolvers (Google,
@@ -1039,6 +1084,24 @@ offers, "rate us" prompts:
   install or a deep cleanup progresses, and shows a moving bar for the tabs that know
   they are working but not how far along. It follows the tab you have open, and it
   goes blank when the job finishes rather than sitting at an empty bar
+
+### About
+- **Version, build, license and source** in one place, with the update controls beside them
+  rather than buried in a settings page
+- **What's new, pulled live from GitHub** — every release with its version, date and full
+  changelog, and a badge marking the one you are running, so you can see what you skipped
+  without leaving the app
+- **Go back to the previous version** — the build you updated from is kept, and this button
+  restores it. It appears only when that build is actually on disk, and refuses with a
+  reason rather than half-doing it when the swap would not be safe.
+- **Export or copy a full system report**, and a separate "Copy environment info" for
+  pasting into a bug report
+- **Report a problem** and **Ask a question** open the right GitHub page directly; **View
+  license** and **What's new** open the licence and the changelog
+- **The startup version check is a checkbox here** — "Check GitHub for a new version when
+  SysManager starts" — and switching it off does not disable the **Check for updates**
+  button, which still works on demand. What that check does and does not send is described
+  under [Privacy](#privacy).
 
 ### Updates (for SysManager itself)
 - Auto-check on startup against the GitHub Releases API, plus a manual

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -3519,6 +3519,58 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Every tab has a README section headed with its own name.
+    /// </summary>
+    /// <remarks>
+    /// "Every implemented feature MUST have its own README section" is a house rule that nothing enforced,
+    /// and it had drifted two ways at once.
+    /// <para><b>Four tabs shared one section.</b> Ping, Traceroute, Speed Test and Network Repair were
+    /// described together under a heading called "Network monitor" — a name no tab has, in a different part
+    /// of the reference from the other Network tab. Searching the README for "Speed Test" found the
+    /// screenshot gallery and a parenthetical list, and nothing that said what the tab does. Its Ookla
+    /// server picker, its per-engine history and its verdict copy were undocumented, and the shared section
+    /// had gone stale in a way a combined heading hides: it credited the Global preset with "your router",
+    /// which the preset does not contain — the gateway is detected and added separately.</para>
+    /// <para><b>Three headings named the tab something else.</b> "Cleanup (fast)" for Quick Cleanup, "Deep
+    /// cleanup (safe)" for Deep Cleanup, "Duplicate File Finder" for Duplicate Finder — and a reader
+    /// searching the sidebar name found nothing. The issue templates had the same defect and are pinned by
+    /// <see cref="EveryIssueTemplateTabList_OffersTheRealTabs"/>; this is the same question asked of the
+    /// README, which is where a prospective user looks first.</para>
+    /// <para>The heading must CONTAIN the label rather than equal it, so a descriptive qualifier stays
+    /// allowed ("Windows Update (Windows Update Agent COM API)", "Gaming Profile 🔬"). Matching is
+    /// case-sensitive on purpose: "System health" is not what the sidebar says, and a reader scanning for
+    /// the tab they are looking at should find its name written the same way.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryTab_HasItsOwnReadmeSection()
+    {
+        var labels = SidebarTabLabels();
+        Assert.True(labels.Count >= 50,
+            $"only {labels.Count} tab labels were parsed from MainWindowViewModel — the guard is vacuous");
+
+        var headings = File.ReadAllLines(Path.Combine(FindRepoRoot(), "README.md"))
+            .Where(l => l.StartsWith("### ", StringComparison.Ordinal))
+            .Select(l => l[4..].Trim())
+            .ToList();
+
+        // Vacuity floor: 75 today. A README whose headings stopped parsing would pass an empty loop.
+        Assert.True(headings.Count >= 60,
+            $"only {headings.Count} '###' headings were read from README.md, out of 75 measured — the "
+            + "guard is no longer reading the feature reference, so a pass proves nothing");
+
+        var undocumented = labels
+            .Where(label => !headings.Any(h => h.Contains(label, StringComparison.Ordinal)))
+            .OrderBy(l => l, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(undocumented.Count == 0,
+            $"{undocumented.Count} of the {labels.Count} tabs have no README section headed with their own "
+            + "name. A tab a reader cannot find in the README is a tab they will not know exists, and a "
+            + "heading that renames it is the same problem with extra steps:\n  "
+            + string.Join("\n  ", undocumented));
+    }
+
+    /// <summary>
     /// The version field of an issue template must not pin an example release. Both templates showed
     /// <c>0.12.x</c> — roughly 130 releases stale — so a reporter copying the placeholder filed against
     /// a version that never shipped, in the field used for triage. Writing today's number in only resets


### PR DESCRIPTION
## The drift

"Every implemented feature MUST have its own README section" is a house rule nothing enforced, and it had drifted two ways at once.

**Four tabs shared one section.** Ping, Traceroute, Speed Test and Network Repair were described together under a heading called **Network monitor** — a name no tab has, placed in a different part of the feature reference from DNS & Hosts, the other Network tab. Searching the README for "Speed Test" found the screenshot gallery and a parenthetical list, and nothing that said what the tab does.

What was undocumented as a result, all of it shipped:

- the Ping verdict that names **which layer** is at fault ("Problem on your local network", "It's the game server, not you", "Streaming service is slow") rather than just "something is wrong"
- the gateway being detected and added as a target on its own, which is what lets the chart tell your network apart from everything beyond it
- the chart window options (1/5/10/15 min) and the ping interval
- the auto-trace interval range (30 s – 10 min) and the one-off manual trace
- the Ookla server picker, the per-engine 20-result history, and the verdict copy that says what a speed is *enough for*
- Network Repair's per-fix explanations, its confirmations, and the reboot warning that appears only after a fix that needs one

The shared section had also gone stale in a way a combined heading hides: it credited the **Global** preset with "your router", which that preset does not contain — the gateway is added separately, by detection.

**Six headings named their tab something else.** `Cleanup (fast)`, `Deep cleanup (safe)`, `Duplicate File Finder`, `System health`, `System report`, `System logs` — a reader searching the sidebar name found nothing. And the **About** tab had no section at all.

## What changed

- Four new sections — Ping, Traceroute, Speed Test, Network Repair — written from current source, placed next to DNS & Hosts so all five Network tabs sit together. The `### Network monitor` aggregate is **removed**, not left behind to duplicate them.
- A new **About** section: version/build/licence, the live release-notes list with a badge on the version you are running, "Go back to the previous version", the report/copy actions, and the startup-check checkbox (pointing at Privacy for what that check sends, rather than restating it).
- Six headings now carry the tab label verbatim. Descriptive qualifiers stay where they earn their place — `Windows Update (Windows Update Agent COM API)`, `System Logs (Windows Event Log, friendly)`.

Every fact above was re-derived this session: `TargetPresets.All`, `NetworkSharedState.WindowOptions`/`TraceIntervalOptions`, `HealthAnalyzer`'s headlines verbatim, `SpeedTestViewModel.OoklaServerOptions`, `SpeedTestHistoryService.MaxPerEngine`, `SpeedVerdictAnalyzer`'s copy, and `NetworkRepairViewModel`'s three `Confirm` calls.

## The guard

`EveryTab_HasItsOwnReadmeSection` — every sidebar label must appear inside a `###` heading, case-sensitively, with a vacuity floor on both populations (58 labels, 75 headings today). It reuses the existing `SidebarTabLabels()` helper rather than adding parallel machinery, and it is the README counterpart of `EveryIssueTemplateTabList_OffersTheRealTabs`, which pins the same question for the issue templates.

Case-sensitivity is deliberate: "System health" is not what the sidebar says, and a reader scanning for the tab in front of them should find its name written the same way.

**Proof — five mutations, each RED with the right message, GREEN after, `README.md` restored byte-for-byte with a hash check each time:**

| Mutation | Guard's message |
|---|---|
| Ping folded back under "Network monitor" | names `Ping` |
| Quick Cleanup renamed back to "Cleanup (fast)" | names `Quick Cleanup` |
| System Health heading lowercased | names `System Health` |
| About retitled to "Version info" | names `About` |
| all 75 `###` headings demoted to `####` | "no longer reading the feature reference" (vacuity floor) |

## Verification

Four projects build Release at **0 errors / 0 warnings**; `dotnet format --verify-no-changes` clean on all four. Unit suite **5339 passing**. Leak scan over the diff: all 47 patterns from `leak-terms.txt`, 0 hits (one draft phrasing tripped a pattern and was rewritten to the neutral wording the section previously used).

No release: `docs:` does not bump.

## Not in this PR

The screenshot drift, which is the larger finding from the same audit: all 43 shipped screenshots date from the `v1.51.x` refresh, and every view they show has visible changes since. Recapture is secondary-workstation work, so it needs its own PR.
