### PR TITLE
docs: stop the screenshot gallery promising shots it does not contain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1226,7 +1226,7 @@ offers, "rate us" prompts:
 </details>
 
 <details>
-<summary><strong>📊 Monitor</strong> — Resource History · New App Alerts · File Lock · Settings Watchdog · Bandwidth</summary>
+<summary><strong>📊 Monitor</strong> — Resource History · New App Alerts · File Lock · Settings Watchdog</summary>
 <br>
 <p>
 <a href="docs/screenshots/19-resource-history.png"><img src="docs/screenshots/19-resource-history.png" width="280" alt="Resource History"></a>&nbsp;
@@ -1254,11 +1254,13 @@ previous one showed the tab while it was a placeholder, which no longer reflects
 </details>
 
 <details>
-<summary><strong>💾 Storage</strong> — Disk Analyzer · Duplicate Finder</summary>
+<summary><strong>💾 Storage</strong> — Disk Analyzer</summary>
 <br>
 <p>
 <a href="docs/screenshots/29-disk-analyzer.png"><img src="docs/screenshots/29-disk-analyzer.png" width="280" alt="Disk Analyzer"></a>
 </p>
+<p><em>Duplicate Finder is implemented and has no screenshot yet — a shot of it would be a list
+of real file paths, which needs redacting before it can ship.</em></p>
 </details>
 
 <details>

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -3571,6 +3571,68 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// A screenshot gallery group may only name tabs it actually shows a picture of.
+    /// </summary>
+    /// <remarks>
+    /// Each <c>&lt;details&gt;</c> block in the README's Screenshots section carries a summary line listing
+    /// the tabs inside it, and the reader decides whether to expand it from that line alone. Two groups
+    /// promised a shot they did not contain: <b>Storage</b> listed "Disk Analyzer · Duplicate Finder" over a
+    /// single image, and <b>Monitor</b> listed "… · Bandwidth" over four.
+    /// <para>The Monitor one is instructive: it became false when the Bandwidth Monitor screenshot was
+    /// deleted for showing the tab while it was still a placeholder. Deleting the image was right; the
+    /// summary above it was left promising it, so removing one stale thing created another. A count is the
+    /// cheapest possible check and it holds that line.</para>
+    /// <para>Counted, not name-matched. The summary abbreviates deliberately — "Bandwidth" for Bandwidth
+    /// Monitor, "Repair" for Network Repair, "Logs" for System Logs — and demanding the full label would
+    /// force a rewrite of eleven honest summaries to catch two dishonest ones. A group that shows N images
+    /// may name N tabs; disclosing an absent one in prose underneath is fine, and is what both fixed groups
+    /// now do.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryScreenshotGroupSummary_NamesOnlyWhatItShows()
+    {
+        var readme = File.ReadAllText(Path.Combine(FindRepoRoot(), "README.md"));
+        var groups = GalleryGroup().Matches(readme).ToList();
+
+        // Vacuity floor: 11 collapsible groups today, one per nav group that has any screenshot. A markup
+        // change that stopped the blocks parsing would otherwise pass an empty loop.
+        Assert.True(groups.Count >= 10,
+            $"only {groups.Count} screenshot groups parsed from README.md, out of 11 measured — the guard "
+            + "is no longer reading the gallery, so a pass proves nothing");
+
+        var overpromised = new List<string>();
+        foreach (var group in groups)
+        {
+            var title = group.Groups["title"].Value.Trim();
+            var promised = group.Groups["promised"].Value
+                .Split('·', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Length;
+            var shown = ScreenshotReference().Matches(group.Groups["body"].Value)
+                .Select(m => m.Groups[1].Value)
+                .Distinct(StringComparer.Ordinal)
+                .Count();
+
+            if (promised > shown)
+                overpromised.Add($"{title}: names {promised} tabs, shows {shown} image(s)");
+        }
+
+        Assert.True(overpromised.Count == 0,
+            "these gallery groups name a tab they show no picture of, so the summary line a reader decides "
+            + "from is a promise the block does not keep. Trim the summary and disclose the gap in prose "
+            + $"underneath, or add the shot:\n  {string.Join("\n  ", overpromised)}");
+    }
+
+    /// <summary>One collapsible screenshot group: its title, its promised tab list, and its body.</summary>
+    [GeneratedRegex(@"<summary><strong>(?<title>.+?)</strong>\s*—\s*(?<promised>.+?)</summary>"
+        + @"(?<body>.*?)</details>",
+        RegexOptions.Compiled | RegexOptions.Singleline)]
+    private static partial Regex GalleryGroup();
+
+    /// <summary>A screenshot path, capturing the file stem.</summary>
+    [GeneratedRegex(@"docs/screenshots/([0-9A-Za-z-]+)\.png", RegexOptions.Compiled)]
+    private static partial Regex ScreenshotReference();
+
+    /// <summary>
     /// The version field of an issue template must not pin an example release. Both templates showed
     /// <c>0.12.x</c> — roughly 130 releases stale — so a reporter copying the placeholder filed against
     /// a version that never shipped, in the field used for triage. Writing today's number in only resets

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -7,10 +7,18 @@ conventions below so they render cleanly in the README.
 ## File naming
 
 Use zero-padded numbers so the file list stays in the same order as the
-nav on the left rail. The current set is captured against the live app and
-covers most tabs; the number matches the tab's position in the sidebar, so
-a few numbers are intentionally skipped (work-in-progress tabs, or tabs whose
-live data couldn't be shared even after redaction — see Privacy check below).
+nav on the left rail. The number matches the tab's position in the sidebar, so
+the missing numbers name the uncovered tabs exactly.
+
+43 of the 58 tabs have a shot. The 15 without one are Bandwidth Monitor,
+Camera/Mic/Location, Context Menu, DNS & Hosts, Duplicate Finder, Edge/OneDrive
+Remover, Environment Variables, Legacy Panels, Notification Blocker, Process
+Manager, Services, Startup Manager, Task Scheduler, Uninstaller and Volume
+Control. One of those — Notification Blocker — is still marked as a preview tab.
+The other fourteen are list-heavy pages: a usable shot of them is a screenful of
+real service names, installed programs, file paths or environment values, and the
+redaction cost is the reason they are not here yet (see Privacy check below).
+None of the fifteen is missing because the tab is unfinished.
 
 A short animated tour also lives under [`docs/gifs/`](../gifs/)
 (`feature-tour.gif`, `cleanup-tools.gif`) and is embedded at the top of the
@@ -24,10 +32,14 @@ each image is a column of text with an empty margin beside it. 1.76.2 replaced e
 collapsed group's subtitle — a truncated list of page names — with a written two-line
 description. 1.76.3 then gave the administrator strip at the top of 31 pages a single
 geometry, so where a shot shows that strip its corners and height are also out of date.
-Nothing else in the shots is stale.
 
-The whole set wants retaking in one pass rather than piecemeal, so that the rail matches
-across all of them. Until then treat the sidebar in every image as out of date.
+The pages themselves are out of date too, and by more than the rail. The whole set was
+captured in one pass at 1.51.x, and every view it shows has changed since — the diffs are
+heaviest on Dashboard, System Logs, App Updates, Windows Update and Gaming Profile, which
+have gained whole cards, columns and controls rather than just moved. Recapture in
+descending order of that, so the shots a visitor sees first stop misrepresenting the app
+soonest, but retake the rail-only ones in the same pass so the sidebar matches across all
+of them. Until then treat every image as showing an older build, not just an older rail.
 
 ## Format and size
 


### PR DESCRIPTION
Second half of the docs audit that produced #2210. This one is the screenshot inventory's own claims about itself — all fixable without a capture, so it does not wait on the secondary workstation.

## Two groups promised a shot they did not contain

| Group | Summary said | Images shown |
|---|---|---|
| 💾 Storage | Disk Analyzer · Duplicate Finder | 1 |
| 📊 Monitor | … · Settings Watchdog · Bandwidth | 4 |

The summary line is what a reader decides whether to expand the block from, so both were promises the block did not keep.

The Monitor one shows how this happens. It became false when the Bandwidth Monitor screenshot was deleted for showing the tab while it was still a placeholder (#1659). Deleting the image was right — the summary above it was left promising it, so removing one stale thing created another.

Both summaries now name only what they show, and each discloses the gap in prose underneath rather than dropping the tab silently.

## `docs/screenshots/README.md` was wrong about its own contents, twice

**"work-in-progress tabs, or tabs whose live data couldn't be shared"** as the reason for the missing numbers. Re-derived: of the 15 tabs with no shot, exactly **one** (Notification Blocker) is marked as a preview tab. The other fourteen are list-heavy pages — Services, Startup Manager, Uninstaller, Environment Variables, Process Manager, Task Scheduler and the rest — where a usable shot is a screenful of real service names, installed programs, file paths or environment values, and the redaction cost is the actual reason. The file now names all fifteen and says which reason applies, so nobody reads a gap as an unfinished feature.

(#1664 called the WIP half "factually false since v1.56.0 closed the last WIP tab". That is now stale in the other direction — seven tabs carry `inDevelopment: true` today. The clause was misleading because it explains 1 of 15 gaps, not because no preview tabs exist.)

**"Nothing else in the shots is stale"**, written beside a list of sidebar-only changes from 1.76.1–1.76.3. Measured against the views themselves, that is not true: the whole set was captured in one pass at `v1.51.x` (`ad46e067`), and every view it shows has changed since. Ranked by the changes a viewer would actually notice — new controls, cards, columns, changed copy — as opposed to accessibility names and tooltips:

| Screenshot | Tab | Visible-change markers |
|---|---|---|
| 01-dashboard | Dashboard | 56 |
| 52-system-logs | System Logs | 35 |
| 36-app-updates | App Updates | 24 |
| 03-windows-update | Windows Update | 23 |
| 13-gaming-profile | Gaming Profile | 21 |
| 37-bulk-installer | Bulk Installer | 20 |

The section now says the pages are out of date and not just the rail, and gives the recapture order.

## The guard

`EveryScreenshotGroupSummary_NamesOnlyWhatItShows` — a group may name at most as many tabs as it shows images, with a vacuity floor on the block count (11 today).

Counted rather than name-matched on purpose: the summaries abbreviate deliberately ("Repair" for Network Repair, "Logs" for System Logs, "Battery" for Battery Health), so demanding the full label would force a rewrite of eleven honest summaries to catch two dishonest ones. A group that shows N images may name N tabs, and disclosing an absent one in prose underneath stays allowed — which is what both fixed groups now do.

**Proof — four mutations, each RED with the right message, GREEN after, `README.md` restored byte-for-byte with a hash check each time:**

| Mutation | Guard's message |
|---|---|
| Storage promises Duplicate Finder again | `Storage: names 2 tabs, shows 1 image(s)` |
| Monitor promises Bandwidth again | `names 5 tabs, shows 4 image(s)` |
| an image deleted, its summary kept | `names 4 tabs, shows 3 image(s)` |
| all 12 `</details>` broken | "no longer reading the gallery" (vacuity floor) |

## Verification

Four projects build Release at **0 errors / 0 warnings**; `dotnet format --verify-no-changes` clean on all four. Unit suite **5340 passing**. Leak scan over the diff: all 47 patterns from `leak-terms.txt`, 0 hits.

No release: `docs:` does not bump.

## Related issues

- #1659 — its premise is resolved: the placeholder image is gone and the group carries an honest note. This PR fixes the summary line that deletion left behind.
- #1664 — its two secondary defects are fixed here (the gallery overpromise and the stale rationale). Its main body of work, the 15 missing captures, is untouched and still needs the secondary workstation.
