### PR TITLE
test: make the unreachable-property guards answer for the declaring type

### DIFF
--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -3170,10 +3170,12 @@ public partial class ArchitectureTests
         var appDir = FindAppProjectDir();
         var modelsDir = Path.Combine(appDir, "Models");
 
-        var xaml = string.Join('\n', Directory
+        // Comments stripped: a comment that merely NAMES a property would otherwise credit it as bound,
+        // and this codebase comments heavily enough that the risk is real rather than theoretical.
+        var xaml = XmlComment().Replace(string.Join('\n', Directory
             .EnumerateFiles(appDir, "*.xaml", SearchOption.AllDirectories)
             .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
-            .Select(File.ReadAllText));
+            .Select(File.ReadAllText)), string.Empty);
 
         var sources = Directory
             .EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories)
@@ -3194,7 +3196,7 @@ public partial class ArchitectureTests
                 var property = char.ToUpperInvariant(field[0]) + field[1..];
                 checkedProperties++;
 
-                if (xaml.Contains(property, StringComparison.Ordinal)) continue;
+                if (Regex.IsMatch(xaml, $@"\b{Regex.Escape(property)}\b")) continue;
                 if (Regex.IsMatch(source, $@"\b{Regex.Escape(property)}\b")) continue;
 
                 // Require the declaring type's name in the same file, so a same-named property on another
@@ -3239,6 +3241,25 @@ public partial class ArchitectureTests
     /// <para>Scope is <c>[ObservableProperty]</c> fields. A plain property is the same defect —
     /// <c>ReleaseNote.Url</c> was one, and <c>DriveTarget.Display</c> another — but has no generated-name
     /// convention to key on, so those stay a review judgement.</para>
+    /// <para><b>Name-only matching was not enough, and the hole had a live instance (#2194).</b> Both
+    /// criteria used to be answered by a bare name: <c>xaml.Contains(property)</c> over every view
+    /// concatenated, and a read anywhere in any <c>.cs</c> file. Neither knew which TYPE the hit belonged
+    /// to, so a same-named member on an unrelated type made a property look reachable.
+    /// <c>ResourceHistoryViewModel.SampleCount</c> was assigned on every reload and read by nothing, and
+    /// this guard passed it because <c>HealthAnalyzer</c> declares a <c>SampleCount</c> of its own — a
+    /// record parameter on the ping-metrics type, read as <c>m.SampleCount</c> — which the global search
+    /// credited here. Two changes close it: the XAML side matches on a word boundary with comments
+    /// stripped, and the C# side requires the read to sit in a file that also names the declaring type,
+    /// copied from <see cref="EveryModelProperty_IsEitherWrittenOrShown"/> rather than reinvented.</para>
+    /// <para>The word boundary is load-bearing on its own: <c>Contains</c> credits any property whose name
+    /// is a substring of some other identifier, and <c>StartupView.xaml</c> carries
+    /// <c>OpenFileLocationCommand</c> — enough to make a hypothetical <c>FileLocation</c> look bound. That
+    /// exact shape is what hid <c>StartupEntry.Location</c> until a per-tab guard caught it (#1587).</para>
+    /// <para><b>What is still not checked:</b> which type a <c>{Binding}</c> belongs to. A
+    /// <c>{Binding Location}</c> in <c>ContextMenuView</c> counts for every type that owns a
+    /// <c>Location</c>, because resolving each view's item type across 65 views is a separate piece of work
+    /// with its own false-positive risk on templated and nested bindings. So this narrows the hole rather
+    /// than closing it, and a name owned by two types still needs a per-tab guard.</para>
     /// </remarks>
     [Fact]
     public void EveryViewModelProperty_IsShownOrRead()
@@ -3246,10 +3267,12 @@ public partial class ArchitectureTests
         var appDir = FindAppProjectDir();
         var viewModelsDir = Path.Combine(appDir, "ViewModels");
 
-        var xaml = string.Join('\n', Directory
+        // Comments stripped: a comment that merely NAMES a property would otherwise credit it as bound,
+        // and this codebase comments heavily enough that the risk is real rather than theoretical.
+        var xaml = XmlComment().Replace(string.Join('\n', Directory
             .EnumerateFiles(appDir, "*.xaml", SearchOption.AllDirectories)
             .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
-            .Select(File.ReadAllText));
+            .Select(File.ReadAllText)), string.Empty);
 
         var sources = Directory
             .EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories)
@@ -3261,14 +3284,25 @@ public partial class ArchitectureTests
 
         foreach (var (path, source) in sources.Where(kv => kv.Key.StartsWith(viewModelsDir, StringComparison.Ordinal)))
         {
+            var typeName = TypeDeclaration().Match(source).Groups[1].Value;
+
             foreach (var m in ObservablePropertyField().Matches(source).Cast<Match>())
             {
                 var field = m.Groups[1].Value;
                 var property = char.ToUpperInvariant(field[0]) + field[1..];
                 inspected++;
 
-                if (xaml.Contains(property, StringComparison.Ordinal)) continue;
-                if (sources.Values.Any(text => IsReadSomewhere(text, property))) continue;
+                if (Regex.IsMatch(xaml, $@"\b{Regex.Escape(property)}\b")) continue;
+
+                // The read must sit in a file that also names the declaring type. Copied from
+                // EveryModelProperty_IsEitherWrittenOrShown below rather than reinvented: without it,
+                // HealthAnalyzer's own SampleCount — a record parameter on an unrelated ping-metrics type,
+                // read as m.SampleCount — credited ResourceHistoryViewModel.SampleCount, which nothing read.
+                if (typeName.Length > 0
+                    && sources.Any(kv => kv.Value.Contains(typeName, StringComparison.Ordinal)
+                                         && IsReadSomewhere(kv.Value, property))) continue;
+                if (typeName.Length == 0
+                    && sources.Values.Any(text => IsReadSomewhere(text, property))) continue;
 
                 unreachable.Add($"{Path.GetFileNameWithoutExtension(path)}.{property}");
             }

--- a/SysManager/SysManager.Tests/ResourceHistoryViewModelTests.cs
+++ b/SysManager/SysManager.Tests/ResourceHistoryViewModelTests.cs
@@ -138,7 +138,9 @@ public class ResourceHistoryViewModelReloadTests : IDisposable
     public async Task ARedundantRefreshOnTheSameRangeStillShowsThatRange()
     {
         // The gate drops nothing user-visible: a second reload for the already-selected range still
-        // ends on that range, with its samples counted, and releases the progress bar.
+        // ends on that range, reporting its sample count on screen, and releases the progress bar.
+        // Asserted through StatusMessage rather than a counter property, because the status line is
+        // what the tab actually shows — a field holding the same number proves only that the code ran.
         var now = DateTime.Now;
         using var service = SeededService(
             new ResourceSample(now.AddMinutes(-20), 10, 20, null, null, null),
@@ -150,7 +152,7 @@ public class ResourceHistoryViewModelReloadTests : IDisposable
         await vm.ReloadCommand.ExecuteAsync(null);
         await vm.ReloadCommand.ExecuteAsync(null);   // a redundant Refresh on the same range
 
-        Assert.Equal(2, vm.SampleCount);
+        Assert.Contains("Showing 2 sample(s)", vm.StatusMessage, StringComparison.Ordinal);
         Assert.True(vm.HasData);
         Assert.False(vm.IsBusy);   // the gate released, so the progress bar cleared
     }
@@ -163,7 +165,6 @@ public class ResourceHistoryViewModelReloadTests : IDisposable
         await vm.InitializationComplete;
 
         Assert.False(vm.HasData);
-        Assert.Equal(0, vm.SampleCount);
         Assert.Contains("No history yet", vm.StatusMessage);
     }
 

--- a/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
@@ -49,7 +49,6 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
 
     [ObservableProperty] private HistoryRange _selectedRange;
     [ObservableProperty] private int _retentionDays;
-    [ObservableProperty] private int _sampleCount;
     [ObservableProperty] private bool _hasData;
     [ObservableProperty] private bool _hasTemperatureData;
     [ObservableProperty] private string _summary = "";
@@ -171,7 +170,6 @@ public sealed partial class ResourceHistoryViewModel : ViewModelBase
             _cpuTempBuffer.ReplaceWith(points.Select(p => new DateTimePoint(p.Timestamp, p.CpuTempC)));
             _gpuTempBuffer.ReplaceWith(points.Select(p => new DateTimePoint(p.Timestamp, p.GpuTempC)));
 
-            SampleCount = _loaded.Count;
             HasData = _loaded.Count > 0;
             // The temperature chart is meaningful only if at least one sample carries a temp
             // reading (sensors/admin dependent); otherwise show its empty state, not a blank.


### PR DESCRIPTION
Closes #2194

## The hole

`EveryViewModelProperty_IsShownOrRead` and `EveryModelProperty_IsEitherWrittenOrShown` both answered a property **name** — against every view concatenated into one string, and against every `.cs` file. Neither knew which *type* the binding or the read belonged to, so a same-named member on an unrelated type made a property look reachable.

These two guards exist for this repo's most persistent defect class: state that is implemented, assigned at several sites, unit-tested, and bound by nothing. The compiler cannot see it and a view-model test cannot either, because the test reads the property exactly the way the missing binding would have. A guard with a name-shaped hole in it is the last line that was supposed to catch that.

## It had a live instance

`ResourceHistoryViewModel.SampleCount` — assigned on every reload, read by nothing. No XAML bound it; no code consulted it. The guard passed it because `HealthAnalyzer` declares a `SampleCount` of its own (a record parameter on the ping-metrics type, read as `m.SampleCount`), and the global name search credited that here.

Two unit tests asserted on it. That is precisely the shape the guard's own failure message warns about: *"a test that reads one is not coverage, it is the reason the defect survives."*

**Deleted rather than bound.** The line immediately after its assignment already puts the same number on screen:

```csharp
HasData = _loaded.Count > 0;
…
StatusMessage = HasData
    ? $"Showing {_loaded.Count} sample(s) over {SelectedRange.Label.ToLowerInvariant()}."
    : "No history yet — samples are recorded every 10 seconds while the app runs.";
```

`SampleCount` held `_loaded.Count`; `StatusMessage` shows `_loaded.Count`. Binding the property would print one number twice. The two tests now assert on `StatusMessage`, which is strictly stronger — it proves the count reached the status line rather than a field.

## Two tightenings, both from the issue's own proposal

1. **Word-boundary XAML matching, comments stripped, in both guards.** `Contains` credits any property whose name is a substring of another identifier, and `StartupView.xaml` carries `OpenFileLocationCommand` — enough to make a hypothetical `FileLocation` look bound. That exact shape is what hid `StartupEntry.Location` until a per-tab guard caught it (#1587).
2. **A declaring-type requirement on the C# side of the view-model guard**, copied from its sibling rather than reinvented. The sibling has documented this trap since it was written ("`FriendlyEventEntry` also has a `UserName`"); the view-model guard simply never got it.

## Measured before committing, not after

Applying both tightenings to current source and running the real guards flagged **exactly one property out of 446 inspected** in `ViewModels/`, and **nothing out of 187** in `Models/`. That mattered before deciding to do it: a tightening that lands with forty violations gets suppressed instead of fixed. This one lands with the single real defect, which is why it could ship together with the fix.

## What is deliberately not done

Step 3 from the issue — resolving each view's item type so a `{Binding Location}` counts only for the type that owns a `Location` — is **not** in this PR. It needs its own measurement pass across 65 views and carries real false-positive risk on templated and nested bindings. The guard's doc comment now states that limit explicitly, so the next person knows a name owned by two types still needs a per-tab guard rather than assuming this one covers it.

## Proof

Four cases. Each tightening is proved twice: the new criterion must catch the defect **and** the criterion as it shipped must miss it — a tightening that changes nothing observable is not a fix.

| Case | Guard | Result |
|---|---|---|
| A1 — `SampleCount` re-added | tightened | **RED**, names `ResourceHistoryViewModel.SampleCount` |
| A2 — `SampleCount` re-added | type requirement reverted | **GREEN** (the hole) |
| B1 — an unbound `FileLocation` added | tightened | **RED**, names `ResourceHistoryViewModel.FileLocation` |
| B2 — same | `xaml.Contains` restored | **GREEN** (`OpenFileLocationCommand` satisfies it) |

The B2 revert is scoped to this guard's body, because the word-boundary line is shared with the sibling and reverting both would prove something about a test this PR is not asking about. Both source files restored byte-for-byte with a SHA256 check after every run; the tree re-verified green at the end.

## Verification

Four projects build Release at **0 errors / 0 warnings**; `dotnet format --verify-no-changes` clean on all four. Unit suite **5340 passing**. Leak scan over the diff: all 47 patterns from `leak-terms.txt`, 0 hits.

No release: `test:` does not bump.

## Follow-up, filed separately rather than folded in

The read-only sweep behind #2194 also named five `Models/` properties that a stronger criterion questions — `BatteryInfo.EstimatedRuntimeMinutes`, `DiskHealthReport.TemperatureMaxC`, `DiskHealthReport.StartStopCount`, `FriendlyEventEntry.UserName`, `WindowsFeature.RequiresReboot`. None of them fails the tightened guard as shipped here, so they are a separate question about each property's own merits, not part of this fix.
