### PR TITLE
ci: say which kind of failure the non-blocking suites hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,9 +519,25 @@ jobs:
       # 'success', so a `conclusion == 'failure'` check never fires and the failure is
       # masked entirely. `outcome` reflects the real step result before continue-on-error
       # is applied.
+      # WHICH kind of failure, not just that there was one. See the integration job's copy of this step
+      # for the run that made it necessary; the same wording covered both cases there and sent a reader
+      # looking for a broken test that did not exist.
       - name: Annotate UI test failures
-        if: steps.ui-tests.outcome == 'failure'
-        run: echo "::warning::UI automation tests failed — review the ui-test-results artifact for details."
+        if: ${{ steps.ui-tests.outcome == 'failure' && !cancelled() }}
+        shell: bash
+        run: |
+          report=TestResults/ui-results.trx
+          if [ ! -s "$report" ]; then
+            echo "::warning::The UI run failed and wrote no TRX, so not even the test count is known. Review the ui-test-results artifact."
+            exit 0
+          fi
+          cases=$({ grep -o "<UnitTestResult " "$report" || true; } | wc -l | tr -d ' ')
+          passed=$({ grep -o '<UnitTestResult [^>]*outcome="Passed"' "$report" || true; } | wc -l | tr -d ' ')
+          if [ "$passed" -lt "$cases" ]; then
+            echo "::warning::$((cases - passed)) of $cases UI tests did not pass. This job is non-blocking, so the merge is not gated; the failure is still real. Review the ui-test-results artifact."
+          else
+            echo "::warning::All $cases UI tests PASSED and the run still exited non-zero, so this is an infrastructure or teardown failure rather than a test failure. Do not go looking for a broken test. Review the ui-test-results artifact."
+          fi
 
       # A test that FAILS is a warning here, on purpose. A test that is never RUN is an error, and the
       # two are not the same finding: a failure means the job worked and found something, while a
@@ -636,9 +652,33 @@ jobs:
 
       # `outcome`, NOT `conclusion`: continue-on-error forces the step's conclusion to 'success', so a
       # conclusion check never fires and the failure is masked completely. Same trap as ui-tests.
+      #
+      # And WHICH kind of failure, because this step used to say "Integration tests failed" for both of
+      # them. On 2026-09-09 it said exactly that on a run where all 625 tests PASSED and the hang-dump
+      # extension's own DisposeAsync threw during teardown (#2195), and again forty minutes later on a run
+      # where one test genuinely failed (#2206). Identical wording, opposite meanings: the first sends a
+      # reader hunting a broken test that does not exist, and once that has happened the annotation stops
+      # being believed for the second. The TRX knows the difference — read it rather than guessing.
+      #
+      # `grep -o … | wc -l`, never `grep -c`: the TRX puts every <UnitTestResult> on one line, so a line
+      # count returns 1 for a suite of 625. The outcome match is scoped inside the element because
+      # <ResultSummary> carries an `outcome` attribute of its own.
       - name: Annotate integration test failures
-        if: steps.integration-tests.outcome == 'failure'
-        run: echo "::warning::Integration tests failed — review the integration-test-results artifact. This job is non-blocking, so the merge is not gated; the failure is still real."
+        if: ${{ steps.integration-tests.outcome == 'failure' && !cancelled() }}
+        shell: bash
+        run: |
+          report=TestResults/integration-results.trx
+          if [ ! -s "$report" ]; then
+            echo "::warning::The integration run failed and wrote no TRX, so not even the test count is known. Review the integration-test-results artifact."
+            exit 0
+          fi
+          cases=$({ grep -o "<UnitTestResult " "$report" || true; } | wc -l | tr -d ' ')
+          passed=$({ grep -o '<UnitTestResult [^>]*outcome="Passed"' "$report" || true; } | wc -l | tr -d ' ')
+          if [ "$passed" -lt "$cases" ]; then
+            echo "::warning::$((cases - passed)) of $cases integration tests did not pass. This job is non-blocking, so the merge is not gated; the failure is still real. Review the integration-test-results artifact."
+          else
+            echo "::warning::All $cases integration tests PASSED and the run still exited non-zero, so this is an infrastructure or teardown failure rather than a test failure (see issue #2195). Do not go looking for a broken test. Review the integration-test-results artifact."
+          fi
 
       # Same reasoning as "Verify the UI suite actually ran" above, including why the floor is counted
       # here rather than passed to the runner: a failure is a warning, an empty or collapsed run is an


### PR DESCRIPTION
Addresses the third bullet of #2195's Expected behavior. The other two — establishing what triggered the dump, and making the threshold proportionate — need the dump analysed and stay open there.

## The problem, seen twice in forty minutes

Both non-blocking suites annotated a failure with one fixed sentence. On 2026-09-09 the integration one fired twice, for opposite reasons:

| Run | What actually happened | What the annotation said |
|---|---|---|
| [34366942691](https://github.com/laurentiu021/SystemManager/actions/runs/34366942691) (#2211) | all **625 tests passed**; the hang-dump extension's own `DisposeAsync` threw a `TimeoutException` during teardown (#2195) | "Integration tests failed — review the artifact" |
| [34373161300](https://github.com/laurentiu021/SystemManager/actions/runs/34373161300) (#2213) | **1 test genuinely failed** — `RunAsync_SupportsCancellation`, cancellation had no effect at 31.07 s (#2206) | "Integration tests failed — review the artifact" |

That ordering is the damage, not the wording. The first message sends a reader hunting a broken test that does not exist; once that has happened, the annotation stops being believed — and since `continue-on-error` forces the job's *conclusion* to `success`, **the annotation is the only signal there is.** The check row reads `pass` in both cases. A warning that cannot be trusted is worse than no warning, because the row already looks fine.

## What changed

Both steps now read the TRX and say which case it is:

- `N of M integration tests did not pass.` — a real failure, with a count.
- `All M integration tests PASSED and the run still exited non-zero, so this is an infrastructure or teardown failure rather than a test failure (see issue #2195). Do not go looking for a broken test.`
- A missing or empty TRX gets its own line, rather than dividing by a count nobody has.

Two details are commented where the code is, because both look redundant right up until they silently report `1`:

- **`grep -o … | wc -l`, never `grep -c`.** The TRX writer puts every `<UnitTestResult>` on one line, so a line count returns `1` for a suite of 625. The sibling "Verify the suite actually ran" steps already avoid this; the annotation had to as well.
- **The outcome match is scoped inside the element** (`<UnitTestResult [^>]*outcome="Passed"`) because `<ResultSummary>` carries an `outcome` attribute of its own and would otherwise be counted as a test.

Comparing `passed` against `cases` rather than grepping for `outcome="Failed"` is deliberate: it covers `Failed`, `Error`, `Timeout` and `Aborted` without depending on which spelling a given run produces.

`!cancelled()` was added to both `if:` conditions, matching the sibling verification steps — a cancelled job should not emit a diagnosis of itself.

## Verification

The step body was extracted verbatim and run against three real TRX files produced by the same xUnit v3 writer CI uses:

| Case | Output |
|---|---|
| all 28 passing (the #2195 shape) | `All 28 integration tests PASSED and the run still exited non-zero…` |
| one `outcome` flipped to `Failed` (the #2206 shape) | `1 of 28 integration tests did not pass.` |
| TRX absent | `…wrote no TRX, so not even the test count is known.` |

And the trap the comment names, on the same file: `grep -c` → **1**, `grep -o … | wc -l` → **28**.

The four load-bearing lines are byte-identical between the probe and both copies in `ci.yml`, so what was tested is what ships. The workflow was re-parsed after editing — 4 jobs, all steps intact.

Applied to the UI job too: same wording, same reason, and fixing only the one that had misfired would leave the other waiting its turn.

No release: `ci:` does not bump. No CHANGELOG entry — nothing here is visible to someone using the app.

## Not fixed here

This makes the failure legible; it does not stop it happening. `--hangdump-timeout 5m` against a suite that runs 6–8 minutes normally and 24 on a slow runner is still the underlying config question, and the 181 MB dump from the #2195 run is still in that run's artifact until 2026-09-23 if anyone wants to trace what the process was doing. Both stay on #2195.
