### PR TITLE
refactor: define the Authenticode chain policy once

### DIFF
--- a/SysManager/SysManager.Tests/AuthenticodeTests.cs
+++ b/SysManager/SysManager.Tests/AuthenticodeTests.cs
@@ -1,0 +1,186 @@
+// SysManager · AuthenticodeTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using SysManager.Helpers;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="Authenticode"/>, the shared signer-certificate reader and chain validator.
+/// </summary>
+/// <remarks>
+/// The chain policy used to be written out twice — once in <c>SpeedTestService.VerifyOoklaSignature</c> for
+/// a third-party download and once in <c>UpdateService.VerifyAuthenticode</c> for our own installer. Two
+/// copies of a security policy drift in the way that matters least visibly: a weakened revocation mode in
+/// one of them changes the posture while every test stays green, because nothing compares them.
+/// <para>What can be asserted by execution here is the three-way split
+/// <see cref="Authenticode.ReadSigner"/> returns, which is the part both callers depend on and disagree
+/// about. Chain validation itself needs a genuinely signed file with a controllable publisher — a test
+/// certificate and signtool, which this project does not have — so that half is pinned against the source,
+/// with the limitation stated rather than papered over.</para>
+/// </remarks>
+public class AuthenticodeTests
+{
+    private static string WriteTempFile(byte[] bytes)
+    {
+        var path = Path.Combine(Path.GetTempPath(), "sysmgr_authcode_" + Guid.NewGuid().ToString("N") + ".bin");
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    // ── ReadSigner: the three-way split the two callers disagree about ──
+
+    [Fact]
+    public void ReadSigner_FileWithNoSignature_ReportsUnsigned()
+    {
+        // CRYPT_E_NO_MATCH, not null and not a generic failure. Conflating this with a read error is the
+        // bug that once made the in-app updater reject every unsigned build it downloaded.
+        var path = WriteTempFile("not a signed PE, just bytes"u8.ToArray());
+        try
+        {
+            var (state, cert, _) = Authenticode.ReadSigner(path);
+
+            Assert.Equal(SignerState.Unsigned, state);
+            Assert.Null(cert);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadSigner_PeLikeHeaderWithoutASignatureDirectory_ReportsUnsigned()
+    {
+        // Bytes that begin like a PE but carry no signature directory: still "no signature", not a
+        // malformed-file error. This is the shape of a real unsigned build.
+        var bytes = new byte[512];
+        bytes[0] = (byte)'M';
+        bytes[1] = (byte)'Z';
+        var path = WriteTempFile(bytes);
+        try
+        {
+            Assert.Equal(SignerState.Unsigned, Authenticode.ReadSigner(path).State);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadSigner_EmptyFile_ReportsUnreadable_NotUnsigned()
+    {
+        // An empty file cannot be read as an image at all, and surfaces as a different HResult. The
+        // distinction is load-bearing: UpdateService accepts Unsigned and rejects Unreadable, so
+        // collapsing the two would make it accept a file it cannot parse.
+        var path = WriteTempFile([]);
+        try
+        {
+            var (state, cert, hresult) = Authenticode.ReadSigner(path);
+
+            Assert.Equal(SignerState.Unreadable, state);
+            Assert.Null(cert);
+            Assert.NotEqual(0, hresult);   // the caller logs this, so it must not be lost
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadSigner_MissingFile_ReportsUnreadable_AndDoesNotThrow()
+    {
+        // Never throws is part of the contract: the Startup Manager will call this per entry while
+        // scanning, where a path that has been uninstalled since the registry value was written is
+        // ordinary rather than exceptional.
+        var path = Path.Combine(Path.GetTempPath(), "sysmgr_authcode_absent_" + Guid.NewGuid().ToString("N") + ".bin");
+
+        var (state, cert, _) = Authenticode.ReadSigner(path);
+
+        Assert.Equal(SignerState.Unreadable, state);
+        Assert.Null(cert);
+    }
+
+    // ── ValidateChain: the policy, pinned against the source ──
+
+    /// <summary>
+    /// The one chain policy this app uses is the strict one, and it fails closed.
+    /// </summary>
+    /// <remarks>
+    /// Asserted against the source rather than by execution, deliberately and with the reason stated:
+    /// producing a signed binary whose chain can be made to fail on demand needs a test certificate and
+    /// signtool. What CAN be checked mechanically is that the policy is the strict one — revocation
+    /// honoured, root excluded from it, no verification flags relaxed — and that a failed build returns
+    /// false rather than falling through.
+    /// <para>This guard replaces the equivalent assertions that used to live inside
+    /// <c>UpdateServiceAuthenticodeTests.VerifyAuthenticode_PinsThePublisherAndBuildsAChain</c>, which went
+    /// RED the moment the chain build moved out of that method — correctly, and it is the reason this one
+    /// exists rather than the assertions simply being dropped.</para>
+    /// </remarks>
+    [Fact]
+    public void ValidateChain_UsesTheStrictPolicy_AndFailsClosed()
+    {
+        var method = HelperMethodSource("internal static bool ValidateChain");
+
+        Assert.Contains("chain.ChainPolicy.RevocationMode = revocation", method, StringComparison.Ordinal);
+        Assert.Contains("X509RevocationFlag.ExcludeRoot", method, StringComparison.Ordinal);
+        Assert.Contains("X509VerificationFlags.NoFlag", method, StringComparison.Ordinal);
+        Assert.Contains("chain.Build(certificate)", method, StringComparison.Ordinal);
+        Assert.Contains("return false", method, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Both fail-closed gates ask for online revocation, and the helper does not decide that for them.
+    /// </summary>
+    /// <remarks>
+    /// The revocation mode is a parameter precisely so a scan of many files can pass <c>Offline</c> without
+    /// a network request per file. That flexibility is also the way the strict callers could be weakened
+    /// invisibly — passing <c>NoCheck</c> compiles, runs, and silently stops checking revocation on the
+    /// installer we download and the third-party binary we execute. So the call sites are pinned, not just
+    /// the helper.
+    /// </remarks>
+    [Theory]
+    [InlineData("UpdateService.cs")]
+    [InlineData("SpeedTestService.cs")]
+    public void EveryFailClosedGate_AsksForOnlineRevocation(string serviceFile)
+    {
+        var source = File.ReadAllText(ServiceSourcePath(serviceFile));
+
+        var at = source.IndexOf("Authenticode.ValidateChain", StringComparison.Ordinal);
+        Assert.True(at >= 0,
+            $"{serviceFile} no longer calls Authenticode.ValidateChain — if the verification moved, move "
+            + "this guard with it rather than deleting it");
+
+        // The mode sits in the same call, which spans a wrapped line; take enough to cover it and no more.
+        var call = source[at..Math.Min(source.Length, at + 220)];
+        Assert.Contains("X509RevocationMode.Online", call, StringComparison.Ordinal);
+    }
+
+    private static string HelperMethodSource(string signature)
+    {
+        var source = File.ReadAllText(Path.Combine(AppProjectDir(), "Helpers", "Authenticode.cs"));
+        var start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"'{signature}' not found in Helpers/Authenticode.cs — this test would "
+            + "otherwise assert nothing at all");
+
+        // To the end of the file: ValidateChain is the last member, and a slice that ran to a marker the
+        // file no longer contains would silently be empty.
+        var method = source[start..];
+        Assert.True(method.Length > 200, $"the slice from '{signature}' is {method.Length} chars — not a method body");
+        return method;
+    }
+
+    private static string ServiceSourcePath(string fileName)
+    {
+        var path = Path.Combine(AppProjectDir(), "Services", fileName);
+        Assert.True(File.Exists(path), $"{fileName} not found at {path}");
+        return path;
+    }
+
+    // Walks up to the app project — source is not copied to the test output.
+    private static string AppProjectDir()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "Services")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);   // else every assertion above would silently test nothing
+        return Path.Combine(dir!.FullName, "SysManager");
+    }
+}

--- a/SysManager/SysManager.Tests/UpdateServiceAuthenticodeTests.cs
+++ b/SysManager/SysManager.Tests/UpdateServiceAuthenticodeTests.cs
@@ -129,13 +129,20 @@ public class UpdateServiceAuthenticodeTests
     }
 
     [Fact]
-    public void VerifyAuthenticode_PinsThePublisherAndBuildsAChain()
+    public void VerifyAuthenticode_PinsThePublisherAndValidatesTheChain()
     {
         // Asserted against the source rather than by execution, deliberately and with the limitation
         // stated: producing a genuinely signed binary with a controllable publisher needs a test
         // certificate and signtool, which this unit-test project does not have. What CAN be checked
         // mechanically is that the signed branch does both things the Ookla path does — compare
         // against the pin AND validate the chain. Either one alone is bypassable.
+        //
+        // The chain build now lives in Helpers/Authenticode, shared with the Ookla gate, so what is
+        // asserted here is the DELEGATION and the pin; the policy inside it is pinned by
+        // AuthenticodeTests.ValidateChain_UsesTheStrictPolicy_AndFailsClosed, and the fact that this
+        // caller asks for online revocation by AuthenticodeTests.EveryFailClosedGate_AsksForOnlineRevocation.
+        // This test going red when the build moved out is exactly what it is for — the assertions were
+        // moved with the code rather than dropped.
         var source = File.ReadAllText(ServiceSourcePath("UpdateService.cs"));
         var start = source.IndexOf("public static bool VerifyAuthenticode", StringComparison.Ordinal);
         Assert.True(start >= 0, "VerifyAuthenticode not found — this test would otherwise assert nothing");
@@ -143,11 +150,14 @@ public class UpdateServiceAuthenticodeTests
         Assert.True(end > start, "method boundary not found");
         var method = source[start..end];
 
-        Assert.Contains("ExpectedSignerSubject", method);          // the pin is consulted
-        Assert.Contains("X509Chain", method);                      // the chain is built
-        Assert.Contains("X509RevocationMode.Online", method);      // revocation is checked
-        Assert.Contains("chain.Build(cert)", method);
-        Assert.Contains("return false", method);                   // and it fails closed
+        // The COMPARISON, not the bare name. `ExpectedSignerSubject` also appears a few lines above, in
+        // the `.Length == 0` branch that handles "nothing to pin against yet" — so a check for the name
+        // alone stayed GREEN when the subject comparison itself was replaced with a constant. Found by
+        // mutating exactly that: the pin can be removed while the constant is still mentioned twice.
+        Assert.Contains("cert.Subject.Contains(ExpectedSignerSubject", method, StringComparison.Ordinal);
+        Assert.Contains("Helpers.Authenticode.ValidateChain", method, StringComparison.Ordinal);
+        Assert.Contains("X509RevocationMode.Online", method, StringComparison.Ordinal);
+        Assert.Contains("return false", method, StringComparison.Ordinal);   // and it fails closed
     }
 
     [Fact]

--- a/SysManager/SysManager/Helpers/Authenticode.cs
+++ b/SysManager/SysManager/Helpers/Authenticode.cs
@@ -1,0 +1,120 @@
+// SysManager · Authenticode
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace SysManager.Helpers;
+
+/// <summary>Why a file has no usable signer certificate, or that it has one.</summary>
+internal enum SignerState
+{
+    /// <summary>An embedded Authenticode signature was found and its signer certificate read.</summary>
+    Signed,
+
+    /// <summary>
+    /// No embedded signature at all. Not an error by itself — most small utilities are unsigned, and
+    /// SysManager's own builds are too.
+    /// </summary>
+    Unsigned,
+
+    /// <summary>
+    /// Signature data is present but could not be read, or the file is not a readable image at all
+    /// (an empty file surfaces here rather than as <see cref="Unsigned"/>). Suspect, not neutral.
+    /// </summary>
+    Unreadable,
+}
+
+/// <summary>
+/// The two Authenticode operations this app performs, defined once: reading a file's signer
+/// certificate, and validating that certificate's chain under a single policy.
+/// </summary>
+/// <remarks>
+/// Extracted because the chain policy was written out twice — in
+/// <c>SpeedTestService.VerifyOoklaSignature</c> for a third-party download and in
+/// <c>UpdateService.VerifyAuthenticode</c> for our own installer — and the two copies are the kind that
+/// drift silently: a weakened revocation mode in one of them changes a security posture while every test
+/// stays green. The Startup Manager needs the same reading for a third purpose, which would have made it
+/// three.
+/// <para><b>What is deliberately NOT shared: the policy that decides what the answer MEANS.</b> The two
+/// existing callers disagree on the most important case — an unsigned file is fatal for the Ookla binary
+/// and expected for our own — and they disagree on whether to throw or return false. Folding those
+/// together is how a fail-closed gate quietly becomes permissive, so each caller keeps its own decision
+/// and this type answers only the mechanical question.</para>
+/// <para><b>Why two calls rather than one.</b> Both callers check the certificate's subject BEFORE
+/// building the chain, and building a chain with online revocation makes a network request. A single
+/// "inspect" call would therefore have to build the chain first, adding a revocation fetch on exactly the
+/// path where the subject already failed. Keeping the steps separate preserves both the ordering and the
+/// absence of that request.</para>
+/// </remarks>
+internal static class Authenticode
+{
+    /// <summary>
+    /// <c>CRYPT_E_NO_MATCH</c> — what <see cref="X509Certificate.CreateFromSignedFile"/> throws for a
+    /// file with no embedded signature. It does not return null, and treating the exception as a generic
+    /// failure is what once made the in-app updater reject every unsigned build it downloaded.
+    /// </summary>
+    private const int CryptENoMatch = unchecked((int)0x80092009);
+
+    /// <summary>
+    /// Reads the signer certificate embedded in <paramref name="filePath"/>. Never throws: the caller
+    /// decides what an absent or unreadable signature means.
+    /// </summary>
+    /// <returns>
+    /// The state, the certificate when <see cref="SignerState.Signed"/> (the caller owns and must dispose
+    /// it), and the HResult behind an <see cref="SignerState.Unreadable"/> result for logging.
+    /// </returns>
+    internal static (SignerState State, X509Certificate2? Certificate, int HResult) ReadSigner(string filePath)
+    {
+        try
+        {
+#pragma warning disable SYSLIB0057 // CreateFromSignedFile is obsolete — no direct replacement for Authenticode verification
+            var signer = X509Certificate.CreateFromSignedFile(filePath);
+#pragma warning restore SYSLIB0057
+            return (SignerState.Signed, new X509Certificate2(signer), 0);
+        }
+        catch (CryptographicException ex) when (ex.HResult == CryptENoMatch)
+        {
+            return (SignerState.Unsigned, null, ex.HResult);
+        }
+        catch (CryptographicException ex)
+        {
+            return (SignerState.Unreadable, null, ex.HResult);
+        }
+    }
+
+    /// <summary>
+    /// Builds <paramref name="certificate"/>'s chain to a trusted root and reports whether it validated.
+    /// </summary>
+    /// <param name="revocation">
+    /// <c>Online</c> for the two fail-closed gates, which verify one file at a moment when a network
+    /// request is acceptable. Anything scanning many files, or running on the assumption that the machine
+    /// may be offline, passes <c>Offline</c> — a local-first app must not make a revocation request per
+    /// file and must not hang when there is no network.
+    /// </param>
+    /// <param name="statuses">
+    /// The comma-separated chain statuses when validation fails, for the caller's log. Empty on success.
+    /// </param>
+    /// <remarks>
+    /// The subject of a certificate is forgeable — anyone can issue a self-signed certificate carrying any
+    /// subject string — so a subject comparison is meaningless without this. Both fail-closed callers
+    /// treat a failure here as a rejection.
+    /// </remarks>
+    internal static bool ValidateChain(X509Certificate2 certificate, X509RevocationMode revocation, out string statuses)
+    {
+        using var chain = new X509Chain();
+        chain.ChainPolicy.RevocationMode = revocation;
+        chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
+        chain.ChainPolicy.VerificationFlags = X509VerificationFlags.NoFlag;
+
+        if (chain.Build(certificate))
+        {
+            statuses = "";
+            return true;
+        }
+
+        statuses = string.Join(", ", chain.ChainStatus.Select(s => s.Status.ToString()));
+        return false;
+    }
+}

--- a/SysManager/SysManager/Services/SpeedTestService.cs
+++ b/SysManager/SysManager/Services/SpeedTestService.cs
@@ -521,13 +521,20 @@ public sealed class SpeedTestService
     /// </remarks>
     private static void VerifyOoklaSignature(string exe)
     {
-        try
+        // Reading the certificate and validating its chain live in Helpers/Authenticode, so the policy
+        // below is the only thing this method owns. Unsigned and unreadable are treated alike here and
+        // deliberately NOT in UpdateService: an unsigned third-party download is a rejection, while an
+        // unsigned SysManager build is the normal case.
+        var (state, cert, hresult) = Helpers.Authenticode.ReadSigner(exe);
+        if (state is not Helpers.SignerState.Signed || cert is null)
         {
-#pragma warning disable SYSLIB0057 // CreateFromSignedFile is obsolete — no direct replacement for Authenticode verification
-            var signer = System.Security.Cryptography.X509Certificates.X509Certificate.CreateFromSignedFile(exe);
-#pragma warning restore SYSLIB0057
-            using var cert = new System.Security.Cryptography.X509Certificates.X509Certificate2(signer);
+            Log.Warning("Ookla speedtest.exe has no valid Authenticode signature (0x{HResult:X8})", hresult);
+            throw new InvalidOperationException(
+                "Ookla speedtest.exe has no valid Authenticode signature. Binary deleted for security.");
+        }
 
+        using (cert)
+        {
             if (!cert.Subject.Contains("Ookla", StringComparison.OrdinalIgnoreCase))
             {
                 Log.Warning("Ookla speedtest.exe Authenticode subject mismatch: {Subject}", cert.Subject);
@@ -535,27 +542,18 @@ public sealed class SpeedTestService
                     $"Ookla speedtest.exe failed Authenticode verification (subject: {cert.Subject}). Binary deleted for security.");
             }
 
-            // Subject alone is forgeable (anyone can issue a self-signed "Ookla" cert),
-            // so also build and validate the full certificate chain to a trusted root,
-            // with online revocation. Fail closed if the chain does not validate.
-            using var chain = new System.Security.Cryptography.X509Certificates.X509Chain();
-            chain.ChainPolicy.RevocationMode = System.Security.Cryptography.X509Certificates.X509RevocationMode.Online;
-            chain.ChainPolicy.RevocationFlag = System.Security.Cryptography.X509Certificates.X509RevocationFlag.ExcludeRoot;
-            chain.ChainPolicy.VerificationFlags = System.Security.Cryptography.X509Certificates.X509VerificationFlags.NoFlag;
-            if (!chain.Build(cert))
+            // Subject alone is forgeable (anyone can issue a self-signed "Ookla" cert), so also validate
+            // the full certificate chain to a trusted root, with online revocation. Fail closed if it
+            // does not validate. Checked AFTER the subject, so a mismatch costs no revocation request.
+            if (!Helpers.Authenticode.ValidateChain(
+                    cert, System.Security.Cryptography.X509Certificates.X509RevocationMode.Online, out var statuses))
             {
-                var statuses = string.Join(", ", chain.ChainStatus.Select(s => s.Status.ToString()));
                 Log.Warning("Ookla speedtest.exe certificate chain did not validate: {Status}", statuses);
                 throw new InvalidOperationException(
                     $"Ookla speedtest.exe certificate chain failed validation ({statuses}). Binary deleted for security.");
             }
+
             Log.Information("Ookla speedtest.exe Authenticode chain verified: {Subject}", cert.Subject);
-        }
-        catch (System.Security.Cryptography.CryptographicException ex)
-        {
-            Log.Warning(ex, "Ookla speedtest.exe has no valid Authenticode signature");
-            throw new InvalidOperationException(
-                "Ookla speedtest.exe has no valid Authenticode signature. Binary deleted for security.", ex);
         }
     }
 

--- a/SysManager/SysManager/Services/UpdateService.cs
+++ b/SysManager/SysManager/Services/UpdateService.cs
@@ -407,13 +407,6 @@ public sealed class UpdateService
         }
     }
 
-    // CryptographicException HResult raised by CreateFromSignedFile when the file
-    // carries NO embedded Authenticode signature at all. On .NET this surfaces as
-    // CRYPT_E_NO_MATCH (0x80092009) — "Cannot find the requested object". SysManager's
-    // own builds are unsigned (no code-signing certificate yet), so this is the normal,
-    // expected case and must NOT be treated as tampering.
-    private const int CryptENoMatch = unchecked((int)0x80092009);
-
     /// <summary>
     /// The publisher this app's own signed builds must carry, once a code-signing certificate
     /// exists. EMPTY means "not signing yet", which keeps the signed branch permissive exactly as
@@ -450,17 +443,29 @@ public sealed class UpdateService
     /// </remarks>
     public static bool VerifyAuthenticode(string filePath)
     {
-        try
-        {
-#pragma warning disable SYSLIB0057 // CreateFromSignedFile is obsolete
-            var signer = System.Security.Cryptography.X509Certificates.X509Certificate
-                .CreateFromSignedFile(filePath);
-#pragma warning restore SYSLIB0057
-            // A non-null cert means an embedded Authenticode signature was found and its
-            // signer certificate could be read. (Unsigned files throw below rather than
-            // returning null, so this branch is the signed case.)
-            using var cert = new System.Security.Cryptography.X509Certificates.X509Certificate2(signer);
+        // Reading the certificate and validating its chain live in Helpers/Authenticode. The three-way
+        // split it returns is the whole reason this method can be permissive about one case and closed
+        // about the other: an absent signature is expected here, while unreadable signature data is not.
+        var (state, cert, hresult) = Helpers.Authenticode.ReadSigner(filePath);
 
+        if (state is Helpers.SignerState.Unsigned)
+        {
+            // No embedded signature — expected for SysManager's unsigned builds. Allow it;
+            // integrity is already guaranteed by the SHA256 verification step.
+            Serilog.Log.Information("Update binary has no Authenticode signature (expected for unsigned builds)");
+            return true;
+        }
+
+        if (state is Helpers.SignerState.Unreadable || cert is null)
+        {
+            // Signature data present but could not be read/parsed — treat as suspect.
+            Serilog.Log.Warning("Update binary Authenticode signature could not be read (HResult 0x{HResult:X8}): {File}",
+                hresult, LogService.SanitizePath(filePath));
+            return false;
+        }
+
+        using (cert)
+        {
             if (ExpectedSignerSubject.Length == 0)
             {
                 // No certificate of our own yet, so there is nothing to compare against. Allowing a
@@ -481,35 +486,17 @@ public sealed class UpdateService
             }
 
             // Subject alone is forgeable — anyone can issue a self-signed certificate carrying any
-            // subject string — so validate the whole chain to a trusted root, with online
-            // revocation, and fail closed. Same policy as VerifyOoklaSignature.
-            using var chain = new System.Security.Cryptography.X509Certificates.X509Chain();
-            chain.ChainPolicy.RevocationMode = System.Security.Cryptography.X509Certificates.X509RevocationMode.Online;
-            chain.ChainPolicy.RevocationFlag = System.Security.Cryptography.X509Certificates.X509RevocationFlag.ExcludeRoot;
-            chain.ChainPolicy.VerificationFlags = System.Security.Cryptography.X509Certificates.X509VerificationFlags.NoFlag;
-            if (!chain.Build(cert))
+            // subject string — so validate the whole chain to a trusted root, with online revocation, and
+            // fail closed. Same policy as VerifyOoklaSignature, which is now the same code.
+            if (!Helpers.Authenticode.ValidateChain(
+                    cert, System.Security.Cryptography.X509Certificates.X509RevocationMode.Online, out var statuses))
             {
-                var statuses = string.Join(", ", chain.ChainStatus.Select(s => s.Status.ToString()));
                 Serilog.Log.Warning("Update binary certificate chain did not validate: {Status}", statuses);
                 return false;
             }
 
             Serilog.Log.Information("Update binary Authenticode chain verified: {Subject}", cert.Subject);
             return true;
-        }
-        catch (System.Security.Cryptography.CryptographicException ex) when (ex.HResult == CryptENoMatch)
-        {
-            // No embedded signature — expected for SysManager's unsigned builds. Allow it;
-            // integrity is already guaranteed by the SHA256 verification step.
-            Serilog.Log.Information("Update binary has no Authenticode signature (expected for unsigned builds)");
-            return true;
-        }
-        catch (System.Security.Cryptography.CryptographicException ex)
-        {
-            // Signature data present but could not be read/parsed — treat as suspect.
-            Serilog.Log.Warning(ex, "Update binary Authenticode signature could not be read (HResult 0x{HResult:X8}): {File}",
-                ex.HResult, LogService.SanitizePath(filePath));
-            return false;
         }
     }
 


### PR DESCRIPTION
Groundwork for #1511, which needs Authenticode reading for a third purpose — the Startup Manager's Publisher column, where the string shown today is `FileVersionInfo.CompanyName` and any program can set it to "Microsoft Corporation". That feature follows separately; this PR is the part that must not be bundled with it.

## The duplication

The chain policy was written out twice:

- `SpeedTestService.VerifyOoklaSignature` — a third-party binary we download and then execute
- `UpdateService.VerifyAuthenticode` — our own installer

Two copies of a security policy drift in the way that shows least. A weakened revocation mode in one of them changes the posture while every test stays green, because nothing compares them. `UpdateService`'s own remarks already noted that keeping the two "symmetric is the point" — symmetric by hand, which is a thing that stays true only while someone remembers.

`Helpers/Authenticode` now owns the two mechanical operations: `ReadSigner` and `ValidateChain`. **Behaviour is identical, and the 8 existing `UpdateService` tests were not touched** — they are the primary evidence for that.

## What is deliberately not shared

**The policy that decides what the answer MEANS.** The two callers disagree on the case that matters most:

| | unsigned file | on failure |
|---|---|---|
| Ookla gate | **fatal** — reject and delete the binary | throws |
| Update gate | **expected** — SysManager ships unsigned | returns bool |

Folding those together is how a fail-closed gate quietly becomes permissive. So `ReadSigner` returns a three-way state (`Signed` / `Unsigned` / `Unreadable`) and each caller keeps its own decision. The `Unsigned` vs `Unreadable` split is load-bearing rather than tidy: `UpdateService` accepts one and rejects the other, and an empty file surfaces as `Unreadable`.

**Two calls rather than one**, for a reason worth stating: both callers compare the certificate's subject *before* building the chain, and an online chain build makes a network request. A single "inspect" call would have to build first, adding a revocation fetch on exactly the path where the subject had already failed.

**The revocation mode is a parameter** so a scan of many files can pass `Offline` — a local-first app must not make a request per file, nor hang when there is no network. That flexibility is also how the strict callers could be weakened invisibly, since passing `NoCheck` compiles and runs, so both call sites are pinned by a test rather than only the helper.

## The guard did its job, and then the proof found a gap in it

`VerifyAuthenticode_PinsThePublisherAndBuildsAChain` went **RED** the moment the chain build left the method. That is precisely what a source-text guard is for, and it is the reason its assertions were *moved* rather than dropped:

| Assertion | Now lives in |
|---|---|
| the strict chain policy, fails closed | `AuthenticodeTests.ValidateChain_UsesTheStrictPolicy_AndFailsClosed` |
| each gate asks for **online** revocation | `AuthenticodeTests.EveryFailClosedGate_AsksForOnlineRevocation` (covers the Ookla gate too, which never had a source guard) |
| the publisher pin is consulted, and delegation happens | `UpdateServiceAuthenticodeTests.VerifyAuthenticode_PinsThePublisherAndValidatesTheChain` |

Net coverage is higher than before, not lower — the Ookla path was previously unguarded at source level.

**And mutation 8 came back GREEN on the first run.** The old guard asserted `Contains("ExpectedSignerSubject")`, and that constant also appears a few lines above in the `.Length == 0` branch that handles "nothing to pin against yet" — so replacing the subject comparison itself with a constant left the guard passing. It now asserts the comparison shape, `cert.Subject.Contains(ExpectedSignerSubject`, and the mutation is red. A pre-existing hole in a security guard, found by mutating the thing the guard claims to protect.

## Proof — 8 mutations, all RED in the named test, GREEN after

| Mutation | Caught by |
|---|---|
| `RevocationFlag = ExcludeRoot` removed | `ValidateChain_UsesTheStrictPolicy_AndFailsClosed` |
| `VerificationFlags` relaxed to `IgnoreNotTimeValid` | same |
| `chain.Build(certificate)` no longer called | same |
| unsigned collapsed into unreadable | **6 tests**, including the four that pin the original updater bug |
| updater downgraded to `NoCheck` revocation | `EveryFailClosedGate_AsksForOnlineRevocation` + the pin guard |
| Ookla gate downgraded to `NoCheck` | `EveryFailClosedGate_AsksForOnlineRevocation` |
| an unreadable signature accepted | `VerifyAuthenticode_EmptyFile_ReturnsFalse` |
| the publisher pin no longer consulted | `VerifyAuthenticode_PinsThePublisherAndValidatesTheChain` |

Three source files restored byte-for-byte with a SHA256 check after every run; the tree re-verified green at the end.

Worth noting for anyone writing a mutation proof in this repo: three of the eight had to be rewritten because the obvious mutation (`if (true)`, an early `return`) trips `CS0162 Unreachable code` and this project treats warnings as errors. A mutation must compile to prove anything.

## New behavioural tests

`ReadSigner` gets four execution tests — no signature, a PE-like header with no signature directory, an empty file (must report `Unreadable`, not `Unsigned`), and a missing file (must not throw, because the Startup scan will call this per entry where an uninstalled path is ordinary). Chain validation itself needs a signed binary with a controllable publisher — a test certificate and signtool, which this project does not have — so that half is pinned against the source with the limitation stated rather than papered over.

## Verification

Four projects build Release at **0 errors / 0 warnings**; `dotnet format --verify-no-changes` clean on all four. Unit suite **5347 passing**. Leak scan over the diff plus both new files: all 47 patterns from `leak-terms.txt`, 0 hits.

No behaviour change, so no version bump and no CHANGELOG entry. `refactor:` does not release.
