### PR TITLE
feat: verify the Startup Manager's publisher against a certificate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -282,7 +282,25 @@ Key services:
   `\Windows\` excluded; toggled through `schtasks /Change`, so the same task the
   Task Scheduler tab owns). Enriches each entry from `ProcessDescriptionService`
   (plain-language description + `ProcessSafety`) keyed on the executable's base
-  name; unrecognised programs are left blank so the UI never guesses a safety.
+  name; unrecognised programs are left blank so the UI never guesses a safety. A second
+  post-pass, `VerifySignatures`, answers "who really made this" with a certificate rather
+  than `FileVersionInfo.CompanyName`, which is the string the `Publisher` column shows and
+  which any program can set to "Microsoft Corporation". It uses the shared
+  `Helpers/Authenticode` reader and chain validator with **`X509RevocationMode.Offline`** —
+  unlike the update and Ookla gates, which pass `Online`: this runs over every entry on the
+  machine, so an online build would mean a revocation request per file and, with no network,
+  a wait per file, in a tab the user just opened. Results are cached per resolved
+  executable path, since several entries pointing at one exe is normal. `ResolveExecutablePath`
+  is the single answer to "which file is this entry", shared with `ExtractPublisher`, so the
+  Publisher and the certificate can never describe different files.
+- `Helpers/Authenticode` — the two Authenticode operations, defined once: `ReadSigner`
+  (three-way `Signed`/`Unsigned`/`Unreadable`, never throws) and `ValidateChain` (one strict
+  policy — `ExcludeRoot`, `NoFlag`, fail-closed — with the revocation mode as a parameter).
+  Deliberately holds no policy about what an answer MEANS: an unsigned file is fatal for the
+  Ookla download and expected for our own build, so each caller keeps that decision. Two
+  calls rather than one because both fail-closed callers compare the subject BEFORE building
+  a chain, and a single "inspect" would add a revocation fetch on the path where the subject
+  already failed.
 - `DuplicateFileService` — three-pass duplicate finder (size grouping →
   partial hash pre-filter → full SHA-256). Read-only, never deletes.
 - `DiskAnalyzerService` — folder-level space breakdown with progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.85.0] - 2026-09-09
+
+The Startup Manager now tells you whether Windows can actually confirm who made each program that
+runs at boot. The Publisher column beside it has always come from the file's own version
+information — a label the program writes about itself, which anything can set to "Microsoft
+Corporation" — so it looked like a trust badge with nothing behind it. The new Signature column
+checks the file's certificate instead, and says "Verified", "Unsigned", or "Check failed" in as many
+words.
+
+### Added
+
+- **A Signature column in the Startup Manager**, checked against the file's certificate with the same
+  chain validation the in-app updater uses. Hovering it explains the result in a sentence — "Windows
+  can confirm this really comes from Google LLC" — rather than leaving you to interpret a badge.
+- **Unsigned is grey and says so kindly.** Most small utilities are unsigned, and so is SysManager
+  itself, so a warning colour on all of them would turn the column into noise you learn to ignore.
+  Amber is kept for a file that *is* signed and whose signature does not hold up, which is the one
+  case here worth a second look — and even then the label reads "Check failed" rather than accusing
+  the program, because an out-of-date certificate store on your PC produces the same result.
+- Entries whose command does not point at a readable file get no badge at all, instead of a grey
+  verdict on a program nothing was able to inspect.
+- The column sorts, so you can bring everything unverified to the top.
+
+### Changed
+
+- **The signature check runs offline**, against certificates already on your PC. Opening the tab
+  never waits on the network, and it behaves the same on a laptop with no connection. The trade is
+  deliberate: a certificate revoked in the last few days may still read as verified, which is the
+  right call for a column that informs and the wrong one for the update check, where the same code
+  still verifies online.
+
 ## [1.84.0] - 2026-09-09
 
 Scheduled maintenance now actually runs on a laptop that is not plugged in. Windows refuses to start a

--- a/README.md
+++ b/README.md
@@ -472,7 +472,20 @@ a confirmation before it runs:
 - Toggle on/off without deleting the original entry (same mechanism as Task Manager) — the disable
   flag is written to the location Windows actually reads for that kind of entry, so a disabled item
   really stays down
-- Sort by name, publisher, location, safety, status, or startup impact via clickable column headers
+- **A Signature column that says whether Windows can confirm the publisher.** The Publisher column
+  next to it comes from the file's own version info — a string any program can set to "Microsoft
+  Corporation" — so on its own it is a trust badge with nothing behind it. This checks the file's
+  certificate instead, using the same chain validation the in-app updater uses, and shows one of
+  three things: **Verified** ("Windows can confirm this really comes from Google LLC"), **Unsigned**,
+  or **Check failed**. Programs whose command doesn't point at a readable file get no badge at all
+  rather than a guess.
+  - **Unsigned is grey, not a warning.** Most small utilities are unsigned and so is SysManager
+    itself; the tooltip says so in as many words. Amber is reserved for a file that *is* signed and
+    whose signature does not hold up — the one case here worth a second look.
+  - The check runs offline, against certificates already on your PC, so opening the tab never waits
+    on the network.
+- Sort by name, publisher, location, safety, status, signature, or startup impact via clickable column
+  headers
 - Plain-language description for recognised programs (from the built-in database) instead
   of a raw command line, plus a Safety chip — Windows / Known app / Not recognised — so you
   can tell what an entry is before deciding whether to turn it off

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.84.x   | :white_check_mark: |
-| < 1.84   | :x:                |
+| 1.85.x   | :white_check_mark: |
+| < 1.85   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -6778,8 +6778,20 @@ public partial class ArchitectureTests
         var view = WithoutXamlComments(
             File.ReadAllText(Path.Combine(appDir, "Views", "StartupView.xaml")));
 
-        // What the user is entitled to see, because the scan pays to work it out.
-        string[] displayed = ["Name", "Command", "Location", "IsEnabled", "Publisher", "StatusText"];
+        // What the user is entitled to see, because the scan pays to work it out. Two lists, because the
+        // scan fills a StartupEntry in two ways and they carry different invariants.
+        //
+        // Set at construction, so required at EVERY site (see the per-site check below).
+        string[] displayedPerSite = ["Name", "Command", "Location", "IsEnabled", "Publisher", "StatusText"];
+        // Set by a post-pass over the finished list — EnrichWithDescriptions, ApplyApprovedState,
+        // VerifySignatures. One assignment covers every source, so "at every site" does not apply; they must
+        // still be bound.
+        //
+        // This half was the guard's blind spot: it parsed object initialisers only, so a field filled in by a
+        // post-pass was invisible to it. Description and Safety had been arriving that way since #1587, and
+        // Signature/SignatureDetail joined them — four fields the guard was written to cover and did not see.
+        string[] displayedPostPass = ["Description", "Safety", "Signature", "SignatureDetail"];
+        var displayed = displayedPerSite.Concat(displayedPostPass).ToArray();
         // Not display: these steer the toggle and the Open button. Demanding UI for them would push this
         // guard into asking for columns nobody wants, which is how the sibling guard's scope was drawn too.
         string[] logicOnly = ["Source", "RegistryKey", "ValueName", "TaskPath"];
@@ -6789,7 +6801,18 @@ public partial class ArchitectureTests
                 .Select(m => m.Groups[1].Value)
                 .ToHashSet(StringComparer.Ordinal))
             .ToList();
-        var assigned = new SortedSet<string>(perSite.SelectMany(s => s), StringComparer.Ordinal);
+        // The other half of "the scan fills this in": `entry.Field = …` in a pass over the finished list.
+        var postPass = new SortedSet<string>(
+            StartupPostPassAssignment().Matches(service).Select(m => m.Groups[1].Value),
+            StringComparer.Ordinal);
+        Assert.True(postPass.Count >= 5,
+            $"only {postPass.Count} post-pass StartupEntry assignments were parsed, out of 7 measured "
+            + "(Description, IsEnabled, Safety, Signature, SignatureDetail, Source, StatusText) — the "
+            + "detection is out of date, so the undecided check below reads a short list. Found: "
+            + string.Join(", ", postPass));
+
+        var assigned = new SortedSet<string>(
+            perSite.SelectMany(s => s).Concat(postPass), StringComparer.Ordinal);
 
         // Vacuity floor. If the construction sites are reshaped and this parses nothing, every check below
         // passes over an empty set. 3 sites, 10 distinct fields when measured.
@@ -6802,7 +6825,7 @@ public partial class ArchitectureTests
         // the tab would render blank for that one source only — which is the hardest kind of gap to notice,
         // because the other two sources look right.
         var partial = perSite
-            .Select((fields, i) => (Site: i + 1, Missing: displayed.Except(fields, StringComparer.Ordinal).ToList()))
+            .Select((fields, i) => (Site: i + 1, Missing: displayedPerSite.Except(fields, StringComparer.Ordinal).ToList()))
             .Where(x => x.Missing.Count > 0)
             .Select(x => $"construction site {x.Site} does not assign {string.Join(", ", x.Missing)}")
             .ToList();
@@ -6839,6 +6862,63 @@ public partial class ArchitectureTests
             "Location is bound somewhere in StartupView.xaml but not as a column value. It is also the "
             + "column's own tooltip, so the tooltip alone satisfies a bare check while the column is gone — "
             + "which is the state #1587 reported. Require the column.");
+
+        // The same trap, and the signature pill walks into it harder: Signature is bound five times in one
+        // template (background, border, dot, label) and SignatureDetail twice (tooltip and visibility), so
+        // the name-based check above stays green with any four of the five deleted. Measured by mutating
+        // exactly that — removing the label binding and removing the tooltip binding were both GREEN.
+        //
+        // What identifies the pill rather than a mention of it: the label converter, which nothing else in
+        // this view uses, and the detail as an actual tooltip. Delete the column and both go.
+        foreach (var (fragment, why) in new[]
+                 {
+                     ("Converter={StaticResource SigTrustText}",
+                      "the words the user reads — nothing else in this view uses that converter, so its "
+                      + "absence means the pill is gone"),
+                     ("ToolTip=\"{Binding SignatureDetail}\"",
+                      "the sentence explaining the pill; without it a coloured chip states a verdict and "
+                      + "never says what it means"),
+                 })
+        {
+            Assert.True(view.Contains(fragment, StringComparison.Ordinal),
+                $"StartupView.xaml no longer contains '{fragment}' — {why}. The scan still pays to verify "
+                + "every entry's certificate, so the work is being done and thrown away.");
+        }
+
+        // And that the pipeline actually runs the post-pass. Every VerifySignatures test calls it directly,
+        // so deleting the call from Scan() would leave all of them green while the column rendered nothing
+        // on a real machine — the same shape of gap as an unbound property, one level up.
+        var scan = SliceMethod(service, "private static IReadOnlyList<StartupEntry> Scan()");
+        foreach (var pass in new[] { "EnrichWithDescriptions(results)", "ApplyApprovedState(results)", "VerifySignatures(results)" })
+        {
+            Assert.Contains(pass, scan, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>An <c>entry.Property =</c> assignment, capturing the property name.</summary>
+    /// <remarks>
+    /// Scoped to the <c>entry</c> local the post-passes all use, rather than any member assignment, so an
+    /// unrelated object's property cannot enter the set.
+    /// </remarks>
+    [GeneratedRegex(@"\bentry\.([A-Z]\w+)\s*=(?!=)", RegexOptions.Compiled)]
+    private static partial Regex StartupPostPassAssignment();
+
+    /// <summary>
+    /// The body of a method, from its signature to the next member declaration at the same indent.
+    /// </summary>
+    private static string SliceMethod(string source, string signature)
+    {
+        var start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"'{signature}' not found — the slice would be empty and prove nothing");
+
+        // The next member at four-space indent ends the body; the file is one class, so this is unambiguous.
+        var end = source.IndexOf("\n    /// <summary>", start + signature.Length, StringComparison.Ordinal);
+        if (end < 0) end = source.IndexOf("\n    private", start + signature.Length, StringComparison.Ordinal);
+        Assert.True(end > start, $"could not find the end of '{signature}'");
+
+        var body = source[start..end];
+        Assert.True(body.Length > 200, $"the slice for '{signature}' is {body.Length} chars — not a method body");
+        return body;
     }
 
     /// <summary>

--- a/SysManager/SysManager.Tests/StartupSignatureTests.cs
+++ b/SysManager/SysManager.Tests/StartupSignatureTests.cs
@@ -1,0 +1,290 @@
+// SysManager · StartupSignatureTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for the Startup Manager's signature column — the honest version of the Publisher string.
+/// </summary>
+/// <remarks>
+/// <c>Publisher</c> is <c>FileVersionInfo.CompanyName</c>, which the file declares about itself and any
+/// program can set to "Microsoft Corporation". The column these tests cover answers the same question with
+/// a certificate instead.
+/// <para>What can be exercised end to end is everything except a genuinely signed file: path resolution,
+/// the unsigned and unreadable outcomes, the per-path cache, and the wording. A file signed by a publisher
+/// this test could choose needs a test certificate and signtool, so the <c>Verified</c> arm is covered at
+/// the palette level and by <see cref="AuthenticodeTests"/>, with the gap stated rather than hidden.</para>
+/// </remarks>
+public class StartupSignatureTests
+{
+    private static string WriteTempExe(byte[] bytes)
+    {
+        var path = Path.Combine(Path.GetTempPath(), "sysmgr_startupsig_" + Guid.NewGuid().ToString("N") + ".exe");
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    private static StartupEntry Entry(string command) => new() { Name = "test", Command = command };
+
+    // ── ResolveExecutablePath: which file an entry actually refers to ──
+
+    [Fact]
+    public void ResolveExecutablePath_PrefersTheWholeString_SoASpaceInThePathSurvives()
+    {
+        // The reason the full-string check comes first: "C:\Program Files\App\app.exe" has a space in the
+        // path, and truncating at the first space would resolve to "C:\Program" and find nothing. A real
+        // installer writes exactly this.
+        var dir = Path.Combine(Path.GetTempPath(), "sysmgr sig probe " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var exe = Path.Combine(dir, "app with spaces.exe");
+        File.WriteAllBytes(exe, [0x4D, 0x5A]);
+        try
+        {
+            Assert.Equal(exe, StartupService.ResolveExecutablePath(exe));
+            Assert.Equal(exe, StartupService.ResolveExecutablePath($"\"{exe}\""));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void ResolveExecutablePath_StripsArgumentsWhenTheWholeStringIsNotAFile()
+    {
+        var exe = WriteTempExe([0x4D, 0x5A]);
+        try
+        {
+            Assert.Equal(exe, StartupService.ResolveExecutablePath($"{exe} --background /silent"));
+            Assert.Equal(exe, StartupService.ResolveExecutablePath($"\"{exe}\" --background"));
+        }
+        finally { File.Delete(exe); }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("rundll32.exe shell32.dll,Control_RunDLL")]
+    [InlineData(@"C:\does\not\exist\ghost.exe")]
+    public void ResolveExecutablePath_ReturnsEmptyWhenNothingResolves(string command)
+        => Assert.Equal("", StartupService.ResolveExecutablePath(command));
+
+    // ── VerifySignatures: the three states, and the one that must stay silent ──
+
+    [Fact]
+    public void VerifySignatures_UnresolvableCommand_LeavesTheEntrySilent()
+    {
+        // Unknown must render nothing. SignatureDetail is what the pill's Visibility follows, so an empty
+        // detail is the mechanism, not an accident — a grey "unknown" pill would be a verdict on a program
+        // this scan never looked at.
+        var entry = Entry(@"C:\does\not\exist\ghost.exe --run");
+
+        StartupService.VerifySignatures([entry]);
+
+        Assert.Equal(SignatureTrust.Unknown, entry.Signature);
+        Assert.Equal("", entry.SignatureDetail);
+    }
+
+    [Fact]
+    public void VerifySignatures_UnsignedFile_ReadsAsOrdinaryRatherThanAlarming()
+    {
+        var exe = WriteTempExe([0x4D, 0x5A, 0x90, 0x00]);
+        try
+        {
+            var entry = Entry(exe);
+
+            StartupService.VerifySignatures([entry]);
+
+            Assert.Equal(SignatureTrust.Unsigned, entry.Signature);
+            // The copy carries the reassurance explicitly. Most entries on an ordinary machine land here,
+            // and a user who reads "unsigned" as "malware" turns off things she needs.
+            Assert.Contains("does not mean it is unsafe", entry.SignatureDetail, StringComparison.Ordinal);
+        }
+        finally { File.Delete(exe); }
+    }
+
+    [Fact]
+    public void VerifySignatures_FileWhoseSignatureCannotBeRead_IsFlagged()
+    {
+        // An empty file cannot be read as an image at all, which Authenticode.ReadSigner reports as
+        // Unreadable rather than Unsigned. The two must not collapse: one is the common case and the other
+        // is the only state in this column worth a second look.
+        var exe = WriteTempExe([]);
+        try
+        {
+            var entry = Entry(exe);
+
+            StartupService.VerifySignatures([entry]);
+
+            Assert.Equal(SignatureTrust.Invalid, entry.Signature);
+            Assert.Contains("could not read", entry.SignatureDetail, StringComparison.Ordinal);
+        }
+        finally { File.Delete(exe); }
+    }
+
+    [Fact]
+    public void VerifySignatures_SeveralEntriesOnOneExecutable_AllGetTheSameVerdict()
+    {
+        // An updater and its tray helper pointing at one exe is ordinary. The per-path cache is there
+        // because chain building is the expensive half; this pins that caching does not leave later
+        // entries blank, which is how a cache keyed on the wrong thing fails.
+        var exe = WriteTempExe([0x4D, 0x5A, 0x90, 0x00]);
+        try
+        {
+            var first = Entry(exe);
+            var second = Entry($"{exe} --tray");
+            var third = Entry($"\"{exe}\"");
+
+            StartupService.VerifySignatures([first, second, third]);
+
+            Assert.Equal(SignatureTrust.Unsigned, first.Signature);
+            Assert.Equal(SignatureTrust.Unsigned, second.Signature);
+            Assert.Equal(SignatureTrust.Unsigned, third.Signature);
+            Assert.Equal(first.SignatureDetail, third.SignatureDetail);
+        }
+        finally { File.Delete(exe); }
+    }
+
+    [Fact]
+    public void VerifySignatures_DoesNotTouchThePublisherString()
+    {
+        // Deliberately separate fields. A file whose declared company and whose certificate disagree is the
+        // case this column exists for, so overwriting one with the other would destroy the finding.
+        var exe = WriteTempExe([0x4D, 0x5A]);
+        try
+        {
+            var entry = Entry(exe);
+            entry.Publisher = "Microsoft Corporation";
+
+            StartupService.VerifySignatures([entry]);
+
+            Assert.Equal("Microsoft Corporation", entry.Publisher);
+            Assert.Equal(SignatureTrust.Unsigned, entry.Signature);
+        }
+        finally { File.Delete(exe); }
+    }
+
+    /// <summary>
+    /// The scan asks for OFFLINE revocation, and that is not a detail.
+    /// </summary>
+    /// <remarks>
+    /// The two fail-closed gates pass <c>Online</c> because each verifies one file at a moment when a
+    /// network request is acceptable — pinned by
+    /// <see cref="AuthenticodeTests.EveryFailClosedGate_AsksForOnlineRevocation"/>. This runs over every
+    /// startup entry on the machine, so <c>Online</c> here would mean a revocation fetch per file, and on a
+    /// machine with no network a wait per file, in a tab the user just opened. A local-first app does not do
+    /// that. Changing this compiles, passes every other test, and is only visible as a tab that takes
+    /// seconds to populate on a train — so it is asserted.
+    /// </remarks>
+    [Fact]
+    public void TheScan_AsksForOfflineRevocation_SoItDoesNotFetchPerFile()
+    {
+        var source = File.ReadAllText(ServiceSourcePath("StartupService.cs"));
+
+        var at = source.IndexOf("Authenticode.ValidateChain", StringComparison.Ordinal);
+        Assert.True(at >= 0, "StartupService no longer validates a chain — move this guard with the code");
+
+        var call = source[at..Math.Min(source.Length, at + 200)];
+        Assert.Contains("X509RevocationMode.Offline", call, StringComparison.Ordinal);
+        Assert.DoesNotContain("X509RevocationMode.Online", call, StringComparison.Ordinal);
+    }
+
+    // Walks up to the app project — source is not copied to the test output.
+    private static string ServiceSourcePath(string fileName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "Services")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);   // else the assertions above would silently test nothing
+        var path = Path.Combine(dir!.FullName, "SysManager", "Services", fileName);
+        Assert.True(File.Exists(path), $"{fileName} not found at {path}");
+        return path;
+    }
+
+    // ── CommonName: the words that end up in the tooltip ──
+
+    [Theory]
+    [InlineData("CN=Google LLC, O=Google LLC, L=Mountain View, S=California, C=US", "Google LLC")]
+    [InlineData("CN=Mozilla Corporation, OU=Firefox, C=US", "Mozilla Corporation")]
+    [InlineData("O=Some Org, CN=Trailing Name", "Trailing Name")]
+    [InlineData("CN=Only Name", "Only Name")]
+    [InlineData("cn=Lowercase Marker, C=US", "Lowercase Marker")]
+    public void CommonName_TakesJustTheCommonName(string subject, string expected)
+        => Assert.Equal(expected, StartupService.CommonName(subject));
+
+    [Fact]
+    public void CommonName_QuotedNameContainingAComma_IsKeptWhole()
+    {
+        // "Acme, Inc." is a real shape for a company name, and splitting on the comma would render
+        // "comes from Acme" — a different company.
+        Assert.Equal("Acme, Inc.",
+            StartupService.CommonName("CN=\"Acme, Inc.\", O=Acme, C=US"));
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("   ", "")]
+    [InlineData("O=No Common Name Here", "O=No Common Name Here")]
+    public void CommonName_WithoutAUsableCn_FallsBackWithoutInventing(string subject, string expected)
+        => Assert.Equal(expected, StartupService.CommonName(subject));
+
+    // ── The palette: what the user reads, and how loudly ──
+
+    [Theory]
+    [InlineData(SignatureTrust.Verified, "Verified")]
+    [InlineData(SignatureTrust.Unsigned, "Unsigned")]
+    [InlineData(SignatureTrust.Invalid, "Check failed")]
+    [InlineData(SignatureTrust.Unknown, "")]
+    public void Label_SaysWhatTheStateMeans(SignatureTrust trust, string expected)
+        => Assert.Equal(expected, SignatureTrustPalette.Label(trust));
+
+    [Fact]
+    public void Label_ForInvalid_DoesNotAccuse()
+    {
+        // "Check failed", not "Invalid" or "Untrusted". The file may be fine and the machine's certificate
+        // store out of date; what the user needs to know is that the answer did not come back.
+        var label = SignatureTrustPalette.Label(SignatureTrust.Invalid);
+
+        Assert.DoesNotContain("Invalid", label, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Untrusted", label, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Unsafe", label, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Unsigned is neutral grey and Invalid is the warning colour — not the other way round, and not both.
+    /// </summary>
+    /// <remarks>
+    /// The reasoning is <see cref="ProcessSafetyPalette"/>'s, about unrecognised processes: most startup
+    /// entries on an ordinary machine are unsigned, so tinting each of them amber would make the column
+    /// read as a list of problems and teach the user to ignore it. Asserted on the theme KEY rather than a
+    /// brush instance, because the resolved brush depends on whether a WPF Application exists.
+    /// </remarks>
+    [Fact]
+    public void ThePalette_KeepsUnsignedNeutral_AndWarnsOnlyOnAFailedCheck()
+    {
+        Assert.Null(SignatureTrustPalette.TextBrushKey(SignatureTrust.Unsigned).Key);
+        Assert.Null(SignatureTrustPalette.TextBrushKey(SignatureTrust.Unknown).Key);
+
+        Assert.Equal("SuccessText", SignatureTrustPalette.TextBrushKey(SignatureTrust.Verified).Key);
+        Assert.Equal("SuccessBgSubtle", SignatureTrustPalette.BackgroundBrushKey(SignatureTrust.Verified).Key);
+
+        Assert.Equal("WarningText", SignatureTrustPalette.TextBrushKey(SignatureTrust.Invalid).Key);
+        Assert.Equal("WarningBgSubtle", SignatureTrustPalette.BackgroundBrushKey(SignatureTrust.Invalid).Key);
+    }
+
+    [Fact]
+    public void ThePalette_AcceptsWhateverADataGridCellHandsIt()
+    {
+        // A recycling row can pass the enum, its name, or null. Falling through to Unknown keeps a stale
+        // cell blank rather than showing another row's verdict.
+        Assert.Equal("Verified", SignatureTrustPalette.Label("Verified"));
+        Assert.Equal("Verified", SignatureTrustPalette.Label("verified"));
+        Assert.Equal("", SignatureTrustPalette.Label(null));
+        Assert.Equal("", SignatureTrustPalette.Label("not an enum member"));
+        Assert.Equal("", SignatureTrustPalette.Label(42));
+    }
+}

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -31,6 +31,12 @@
             <h:ProcessSafetyToBackgroundConverter x:Key="ProcSafetyBg"/>
             <h:ProcessSafetyToTextConverter x:Key="ProcSafetyText"/>
             <h:ProcessSafetyToTooltipConverter x:Key="ProcSafetyTip"/>
+            <!-- Signature trust is its own scale: it answers "can Windows confirm who signed this",
+                 which is a different question from either provenance database above, and its neutral
+                 state (Unsigned) is the common case rather than the exception. -->
+            <h:SignatureTrustToBrushConverter x:Key="SigTrustBrush"/>
+            <h:SignatureTrustToBackgroundConverter x:Key="SigTrustBg"/>
+            <h:SignatureTrustToTextConverter x:Key="SigTrustText"/>
             <h:IntGreaterThanZeroConverter x:Key="GreaterThanZero"/>
             <h:EqualityConverter x:Key="IsEqual"/>
             <h:MaintenanceActionToTextConverter x:Key="MaintenanceActionText"/>

--- a/SysManager/SysManager/Helpers/ValueConverters.cs
+++ b/SysManager/SysManager/Helpers/ValueConverters.cs
@@ -411,3 +411,127 @@ public static class ProcessSafetyPalette
     private static bool Is(string? value, string name)
         => string.Equals(value, name, StringComparison.OrdinalIgnoreCase);
 }
+
+/// <summary>Maps <see cref="Models.SignatureTrust"/> to the pill's text and dot colour.</summary>
+public sealed class SignatureTrustToBrushConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => SignatureTrustPalette.ResolveText(value);
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>Maps <see cref="Models.SignatureTrust"/> to the pill's background tint.</summary>
+public sealed class SignatureTrustToBackgroundConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => SignatureTrustPalette.ResolveBackground(value);
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Maps <see cref="Models.SignatureTrust"/> to the words on the pill. The enum names are
+/// developer-facing; "Verified" / "Unsigned" / "Check failed" say what the value means to someone
+/// deciding whether to turn a startup entry off.
+/// </summary>
+public sealed class SignatureTrustToTextConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => SignatureTrustPalette.Label(value);
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// The colour and wording decisions for signature trust, in one place so the three converters cannot
+/// drift apart, and so the mapping is unit-testable without a WPF Application.
+/// </summary>
+/// <remarks>
+/// Shaped after <see cref="ProcessSafetyPalette"/> rather than invented: same key-plus-fallback pairs,
+/// same live-theme lookup, same reasoning about neutrality.
+/// </remarks>
+public static class SignatureTrustPalette
+{
+    // The same "no emphasis" pair the process chip uses for an unrecognised program, so an unsigned
+    // startup entry looks like ordinary de-emphasised text rather than a bespoke grey.
+    private static readonly SolidColorBrush NeutralText = Frozen(Color.FromRgb(0x7B, 0x83, 0x96));
+    private static readonly SolidColorBrush NeutralBg = Frozen(Color.FromArgb(0x20, 0x7B, 0x83, 0x96));
+    private static readonly SolidColorBrush VerifiedText = Frozen(Color.FromRgb(0x4A, 0xDE, 0x80));
+    private static readonly SolidColorBrush VerifiedBg = Frozen(Color.FromArgb(0x1A, 0x22, 0xC5, 0x5E));
+    private static readonly SolidColorBrush InvalidText = Frozen(Color.FromRgb(0xFB, 0xBF, 0x24));
+    private static readonly SolidColorBrush InvalidBg = Frozen(Color.FromArgb(0x1F, 0xF5, 0x9E, 0x0B));
+
+    private static SolidColorBrush Frozen(Color c)
+    {
+        var b = new SolidColorBrush(c);
+        b.Freeze();
+        return b;
+    }
+
+    /// <summary>
+    /// Theme resource key + hardcoded fallback for the pill's text/dot colour. A null key means the value
+    /// is intentionally theme-independent.
+    /// </summary>
+    /// <remarks>
+    /// <b>Unsigned is grey, not amber</b>, for the reason <see cref="ProcessSafetyPalette"/> gives about
+    /// unrecognised processes: most startup entries on an ordinary machine are unsigned, so an amber row
+    /// for each of them would make the whole column read as a list of problems and teach the user to stop
+    /// looking at it. Grey reads as "nothing to check", which is what it means. Amber is kept for
+    /// <see cref="Models.SignatureTrust.Invalid"/> — a file that IS signed and whose signature does not
+    /// hold up, which is the one state here worth a second look. Not red: red belongs to actions that
+    /// destroy something, and this column destroys nothing.
+    /// </remarks>
+    public static (string? Key, Brush Fallback) TextBrushKey(object? trust) => Trust(trust) switch
+    {
+        Models.SignatureTrust.Verified => ("SuccessText", VerifiedText),
+        Models.SignatureTrust.Invalid => ("WarningText", InvalidText),
+        _ => (null, NeutralText),
+    };
+
+    /// <summary>Theme resource key + hardcoded fallback for the pill's background tint.</summary>
+    public static (string? Key, Brush Fallback) BackgroundBrushKey(object? trust) => Trust(trust) switch
+    {
+        Models.SignatureTrust.Verified => ("SuccessBgSubtle", VerifiedBg),
+        Models.SignatureTrust.Invalid => ("WarningBgSubtle", InvalidBg),
+        _ => (null, NeutralBg),
+    };
+
+    /// <summary>The words on the pill. Empty for <see cref="Models.SignatureTrust.Unknown"/>.</summary>
+    /// <remarks>
+    /// "Check failed" rather than "Invalid": the file may be perfectly fine and the machine's certificate
+    /// store out of date, and the column must not accuse. What the user needs to know is that the answer
+    /// did not come back, which is what the tooltip then explains.
+    /// </remarks>
+    public static string Label(object? trust) => Trust(trust) switch
+    {
+        Models.SignatureTrust.Verified => "Verified",
+        Models.SignatureTrust.Unsigned => "Unsigned",
+        Models.SignatureTrust.Invalid => "Check failed",
+        _ => "",
+    };
+
+    public static Brush ResolveText(object? trust) => Live(TextBrushKey(trust));
+
+    public static Brush ResolveBackground(object? trust) => Live(BackgroundBrushKey(trust));
+
+    // Prefer the live theme brush (recomputed per preset by ThemeService.StatusPalette) so the pill stays
+    // legible on light themes; fall back to the frozen dark values when there is no Application, i.e.
+    // design-time and unit tests.
+    private static Brush Live((string? Key, Brush Fallback) spec)
+        => spec.Key is not null && Application.Current?.TryFindResource(spec.Key) is Brush b
+            ? b
+            : spec.Fallback;
+
+    // Accepts the enum, its name, or null, because a DataGrid cell can hand over any of the three while a
+    // row is being recycled.
+    private static Models.SignatureTrust Trust(object? value) => value switch
+    {
+        Models.SignatureTrust t => t,
+        string s when Enum.TryParse<Models.SignatureTrust>(s, ignoreCase: true, out var parsed) => parsed,
+        _ => Models.SignatureTrust.Unknown,
+    };
+}

--- a/SysManager/SysManager/Models/StartupEntry.cs
+++ b/SysManager/SysManager/Models/StartupEntry.cs
@@ -65,6 +65,33 @@ public sealed partial class StartupEntry : ObservableObject
     /// </summary>
     [ObservableProperty] private string _startupImpactDetail = "";
 
+    /// <summary>
+    /// Whether Windows can confirm who signed this entry's executable.
+    /// </summary>
+    /// <remarks>
+    /// The honest version of <see cref="Publisher"/>, which is <c>FileVersionInfo.CompanyName</c> — a string
+    /// the file itself declares and that any program can set to "Microsoft Corporation". So the tab was
+    /// handing over a trust signal carrying no trust. This is the same question answered by a certificate
+    /// instead, using the chain validation the update and Ookla gates already use.
+    /// <para><see cref="SignatureTrust.Unknown"/> renders nothing, deliberately: it means the command did
+    /// not resolve to a file this app could read, which is a statement about the scan and not about the
+    /// program.</para>
+    /// </remarks>
+    [ObservableProperty] private SignatureTrust _signature;
+
+    /// <summary>
+    /// The plain-language sentence behind <see cref="Signature"/>, for the pill's tooltip. Written for
+    /// someone deciding whether to turn an entry off, so "Unsigned" reads as ordinary rather than alarming.
+    /// </summary>
+    /// <remarks>
+    /// This carries the signer's name where there is one ("Windows can confirm this really comes from
+    /// Google LLC"), rather than a separate property for it. The comparison that matters — a file declaring
+    /// "Microsoft Corporation" in <see cref="Publisher"/> while its certificate says something else — is
+    /// already visible with the column beside this one, so a second field holding the same name would be
+    /// state nothing reads.
+    /// </remarks>
+    [ObservableProperty] private string _signatureDetail = "";
+
     /// <summary>Registry key path (for registry-based entries).</summary>
     public string RegistryKey { get; init; } = "";
 
@@ -73,6 +100,32 @@ public sealed partial class StartupEntry : ObservableObject
 
     /// <summary>Task Scheduler path (for scheduled task entries).</summary>
     public string TaskPath { get; init; } = "";
+}
+
+/// <summary>What a certificate check could establish about a startup entry's executable.</summary>
+public enum SignatureTrust
+{
+    /// <summary>
+    /// Nothing was checked — the command did not resolve to a readable file. Renders no pill at all: this
+    /// says something about the scan, not about the program, and a grey "unknown" chip would read as a
+    /// verdict.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// No embedded signature. Ordinary, not suspicious — most small utilities are unsigned, and so are
+    /// SysManager's own builds.
+    /// </summary>
+    Unsigned,
+
+    /// <summary>Signed, and the certificate's chain validated to a trusted root.</summary>
+    Verified,
+
+    /// <summary>
+    /// Signed, but the signature could not be confirmed — the chain failed to validate, or the signature
+    /// data itself could not be read. The one state here that deserves attention.
+    /// </summary>
+    Invalid,
 }
 
 public enum StartupSource

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -111,6 +111,10 @@ public sealed class StartupService
         // same way and there is one place to test.
         EnrichWithDescriptions(results);
 
+        // Answer "who really made this" with a certificate rather than a string the file declares about
+        // itself. Last, over the finished list, for the same reason as the enrichment above.
+        VerifySignatures(results);
+
         return results;
     }
 
@@ -693,13 +697,8 @@ public sealed class StartupService
     {
         try
         {
-            // Strip quotes and arguments
-            var path = command.Trim('"', ' ');
-            var spaceIdx = path.IndexOf(' ');
-            if (spaceIdx > 0 && !System.IO.File.Exists(path))
-                path = path[..spaceIdx].Trim('"');
-
-            if (System.IO.File.Exists(path))
+            var path = ResolveExecutablePath(command);
+            if (path.Length > 0)
             {
                 var vi = System.Diagnostics.FileVersionInfo.GetVersionInfo(path);
                 return vi.CompanyName ?? "";
@@ -710,5 +709,134 @@ public sealed class StartupService
         catch (UnauthorizedAccessException) { /* access denied */ }
         catch (System.Security.SecurityException) { /* security error */ }
         return "";
+    }
+
+    /// <summary>
+    /// The executable a registry command line actually runs, or empty when it does not resolve to a file
+    /// that exists.
+    /// </summary>
+    /// <remarks>
+    /// A Run value is a command line, not a path: it may be quoted, carry arguments, or both. The
+    /// full-string <c>File.Exists</c> is tried FIRST and deliberately — a program installed under
+    /// "C:\Program Files\Some App\app.exe" with no arguments has a space in the path itself, and truncating
+    /// at the first space would lose it.
+    /// <para><c>internal</c> and pure so the resolution is testable on its own. It used to be inline in
+    /// <see cref="ExtractPublisher"/>, which meant the signature check would have needed its own copy of
+    /// the same parsing — two answers to "which file is this entry" is exactly the kind of drift that ends
+    /// with a Publisher and a certificate describing different files.</para>
+    /// </remarks>
+    internal static string ResolveExecutablePath(string command)
+    {
+        if (string.IsNullOrWhiteSpace(command)) return "";
+
+        var path = command.Trim('"', ' ');
+        if (System.IO.File.Exists(path)) return path;
+
+        var spaceIdx = path.IndexOf(' ');
+        if (spaceIdx > 0)
+        {
+            path = path[..spaceIdx].Trim('"');
+            if (System.IO.File.Exists(path)) return path;
+        }
+
+        return "";
+    }
+
+    /// <summary>
+    /// Fills <see cref="StartupEntry.Signature"/> and <see cref="StartupEntry.SignatureDetail"/> for every
+    /// entry whose command resolves to a file.
+    /// </summary>
+    /// <remarks>
+    /// A post-pass over the finished list, like <see cref="EnrichWithDescriptions"/> and for the same
+    /// reason: every source (registry, startup folder, scheduled task) is enriched identically and there is
+    /// one place to test.
+    /// <para><b>Offline revocation, not online.</b> The two fail-closed gates verify one file at a moment
+    /// when a network request is acceptable. This runs over every startup entry on the machine, so an
+    /// online chain build would mean a revocation fetch per file — and on a machine with no network, a wait
+    /// per file. A local-first app does not do that to a tab the user just opened. The cost is that a
+    /// certificate revoked since the last CRL refresh still reads as verified, which is the right trade for
+    /// an informational column and the wrong one for an installer gate.</para>
+    /// <para>Results are cached per resolved path: several entries pointing at one executable is normal
+    /// (an updater and its tray helper), and chain building is the expensive part.</para>
+    /// </remarks>
+    internal static void VerifySignatures(IReadOnlyList<StartupEntry> entries)
+    {
+        Dictionary<string, (SignatureTrust Trust, string Detail)> cache =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in entries)
+        {
+            var path = ResolveExecutablePath(entry.Command);
+            if (path.Length == 0) continue;   // Unknown: nothing to say, so the pill does not render
+
+            if (!cache.TryGetValue(path, out var verdict))
+            {
+                verdict = Inspect(path);
+                cache[path] = verdict;
+            }
+
+            entry.Signature = verdict.Trust;
+            entry.SignatureDetail = verdict.Detail;
+        }
+    }
+
+    private static (SignatureTrust Trust, string Detail) Inspect(string path)
+    {
+        var (state, cert, hresult) = Helpers.Authenticode.ReadSigner(path);
+
+        if (state is Helpers.SignerState.Unsigned)
+            return (SignatureTrust.Unsigned,
+                "Nobody signed this file, so Windows cannot confirm who made it. That is normal for many "
+                + "small programs and does not mean it is unsafe — it just means there is nothing to check.");
+
+        if (state is Helpers.SignerState.Unreadable || cert is null)
+            return (SignatureTrust.Invalid,
+                $"This file carries signature data that Windows could not read (0x{hresult:X8}). A signed "
+                + "file whose signature will not open is worth a closer look.");
+
+        using (cert)
+        {
+            var signer = CommonName(cert.Subject);
+
+            if (!Helpers.Authenticode.ValidateChain(
+                    cert, System.Security.Cryptography.X509Certificates.X509RevocationMode.Offline, out var statuses))
+            {
+                Log.Debug("Startup entry signature chain did not validate for {Path}: {Status}",
+                    LogService.SanitizePath(path), statuses);
+                return (SignatureTrust.Invalid,
+                    $"This file says it comes from {signer}, but Windows could not confirm that "
+                    + $"({statuses}). Worth a closer look before you trust it.");
+            }
+
+            return (SignatureTrust.Verified,
+                $"Windows can confirm this really comes from {signer}.");
+        }
+    }
+
+    /// <summary>
+    /// The common name out of a certificate subject, or the whole subject when it carries no CN.
+    /// </summary>
+    /// <remarks>
+    /// A subject reads <c>CN=Google LLC, O=Google LLC, L=Mountain View, S=California, C=US</c>. The tooltip
+    /// says "comes from Google LLC", so only the CN belongs in it — the rest is correct and unreadable.
+    /// A quoted CN containing a comma keeps everything up to the closing quote.
+    /// </remarks>
+    internal static string CommonName(string subject)
+    {
+        if (string.IsNullOrWhiteSpace(subject)) return "";
+
+        const string marker = "CN=";
+        var at = subject.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (at < 0) return subject.Trim();
+
+        var rest = subject[(at + marker.Length)..].TrimStart();
+        if (rest.StartsWith('"'))
+        {
+            var close = rest.IndexOf('"', 1);
+            return close > 1 ? rest[1..close] : rest[1..].Trim();
+        }
+
+        var comma = rest.IndexOf(',');
+        return (comma >= 0 ? rest[..comma] : rest).Trim();
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.84.0</Version>
-    <FileVersion>1.84.0.0</FileVersion>
-    <AssemblyVersion>1.84.0.0</AssemblyVersion>
+    <Version>1.85.0</Version>
+    <FileVersion>1.85.0.0</FileVersion>
+    <AssemblyVersion>1.85.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -127,6 +127,38 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
+                    <!-- Whether Windows can confirm the Publisher beside it. Publisher is
+                         FileVersionInfo.CompanyName — a string the file declares about itself, which any
+                         program can set to "Microsoft Corporation" — so on its own it is a trust signal
+                         carrying no trust. This column answers the same question with a certificate.
+                         Placed immediately after Publisher so the claim and its verification are read
+                         together rather than a column apart.
+                         Chip structure copied from the Safety column below: same RadiusMd/6,3 border, same
+                         6px dot, same FontSize 11 SemiBold. Visibility follows SignatureDetail rather than
+                         the enum, because that string is non-empty in exactly the three states worth
+                         showing — an entry whose command did not resolve to a readable file gets no pill
+                         instead of a grey verdict it has not earned, matching how Safety collapses. -->
+                    <DataGridTemplateColumn Header="Signature" Width="110" MinWidth="100" SortMemberPath="Signature">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Border CornerRadius="{StaticResource RadiusMd}" Padding="6,3"
+                                        Background="{Binding Signature, Converter={StaticResource SigTrustBg}}"
+                                        BorderBrush="{Binding Signature, Converter={StaticResource SigTrustBg}}"
+                                        BorderThickness="1" HorizontalAlignment="Left"
+                                        ToolTip="{Binding SignatureDetail}"
+                                        Visibility="{Binding SignatureDetail, Converter={StaticResource FlexVis}}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <Ellipse Width="6" Height="6" VerticalAlignment="Center" Margin="0,0,4,0"
+                                                 Fill="{Binding Signature, Converter={StaticResource SigTrustBrush}}"/>
+                                        <TextBlock Text="{Binding Signature, Converter={StaticResource SigTrustText}}"
+                                                   FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center"
+                                                   Foreground="{Binding Signature, Converter={StaticResource SigTrustBrush}}"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+
                     <!-- Where the entry actually lives: a Run key and its hive, a Startup folder, or Task
                          Scheduler. StartupService has filled this in for every source since the tab shipped
                          and the unit tests assert it is never blank, but no column bound it (#1587) — so an


### PR DESCRIPTION
Closes #1511. Builds on #2215, which extracted the shared Authenticode reader and chain validator.

## The problem

`StartupEntry.Publisher` is `FileVersionInfo.CompanyName` — a string the file declares about itself. Any program can set it to "Microsoft Corporation". The tab was showing a trust signal that carries no trust, in the one column a non-technical user can actually act on: "is this from someone real, or did it just arrive?"

The mechanism to answer that properly was already in the repo, verifying the in-app updater and the Ookla download. It had never been pointed at the thing the user is actually reading.

## What ships

A **Signature** column immediately after Publisher, so the claim and its verification are read together:

| State | Shown | Colour | Tooltip |
|---|---|---|---|
| chain validated | **Verified** | green | "Windows can confirm this really comes from Google LLC." |
| no signature | **Unsigned** | **grey** | "Nobody signed this file… That is normal for many small programs and does not mean it is unsafe — it just means there is nothing to check." |
| signed, chain fails / signature unreadable | **Check failed** | amber | "This file says it comes from X, but Windows could not confirm that (…). Worth a closer look before you trust it." |
| command does not resolve to a readable file | **nothing** | — | — |

**Unsigned is grey and the copy is explicit that it is not an accusation.** Most small utilities are unsigned, and so is SysManager itself. A warning colour on all of them would make the column read as a list of problems and teach the user to ignore it — which is the reasoning `ProcessSafetyPalette` already documents for unrecognised processes, cited rather than reinvented. Amber is reserved for a file that *is* signed and whose signature does not hold up, and even then the label is "Check failed": an out-of-date certificate store on the user's own PC produces the same result, so the column must not name the program as the problem.

**No pill at all when nothing could be inspected.** That is a statement about the scan, not about the program, and a grey "unknown" chip would read as a verdict on a file this app never opened.

## Offline revocation, deliberately

The two fail-closed gates pass `X509RevocationMode.Online` — each verifies one file at a moment when a network request is fine. This runs over every startup entry on the machine, so `Online` here would mean a revocation fetch per file and, with no network, a wait per file, in a tab the user just opened. A local-first app does not do that.

The trade is stated in the changelog rather than buried: a certificate revoked in the last few days may still read as verified. That is the right call for a column that informs and the wrong one for the update gate, where the same code still verifies online. `TheScan_AsksForOfflineRevocation_SoItDoesNotFetchPerFile` pins this side; `AuthenticodeTests.EveryFailClosedGate_AsksForOnlineRevocation` pins the other.

## One answer to "which file is this entry"

`ResolveExecutablePath` was extracted from `ExtractPublisher` and is now shared with the verification, so the Publisher string and the certificate can never describe different files. It tries the whole string before splitting on a space, because `C:\Program Files\App\app.exe` has a space in the path itself — a mutation covers exactly that.

## A field written and then deleted before committing

`SignerName` was in the first draft. The detail sentence already names the signer, and the comparison that matters — a declared company and a certificate that disagree — is visible with the two columns side by side. A second field holding the same name would have been state nothing reads: the defect class fixed in #2194 an hour earlier, and there is no excuse for adding a fresh instance of it in the next PR.

## Two guard findings, both from mutating rather than reading

**`EveryStartupFieldTheScanFillsIn_IsBoundInTheViewOrDeclaredLogicOnly` only saw half the scan.** It parsed object initialisers, so any field arriving via a post-pass over the finished list was invisible to it — `Description` and `Safety` since #1587, and now these two. Widened to parse `entry.X =` as well, which surfaced **four** fields the guard was written to cover and had never seen. It also now asserts the pipeline still *calls* each post-pass: every behavioural test calls `VerifySignatures` directly, so deleting the call from `Scan()` would have left all of them green while the column rendered nothing on a real machine.

**Its binding check stayed GREEN with the pill deleted.** `Signature` is bound five times in one template (background, border, dot, label) and `SignatureDetail` twice (tooltip, visibility), so removing any one leaves the name present. That is the trap the guard already documents for `Location`, worse — and mutations 1 and 2 both came back green on the first run. Now pinned on the label converter, which nothing else in this view uses, and on the detail as an actual `ToolTip=`.

## Proof — 9 mutations, all RED in the named test, GREEN after

| Mutation | Caught by |
|---|---|
| the Signature column deleted from the view | `EveryStartupFieldTheScanFillsIn_…` |
| the tooltip stops binding the detail | same |
| the scan pipeline stops running the verification pass | same |
| an unresolvable command gets a verdict instead of staying silent | `VerifySignatures_UnresolvableCommand_LeavesTheEntrySilent` |
| an unreadable signature reported as merely unsigned | `VerifySignatures_FileWhoseSignatureCannotBeRead_IsFlagged` |
| path resolution splits on the first space first | `ResolveExecutablePath_PrefersTheWholeString_…` |
| the scan asks for online revocation | `TheScan_AsksForOfflineRevocation_…` |
| a quoted common name containing a comma is truncated | `CommonName_QuotedNameContainingAComma_IsKeptWhole` |
| unsigned tinted like a warning | `ThePalette_KeepsUnsignedNeutral_AndWarnsOnlyOnAFailedCheck` |

Three source files restored byte-for-byte with a SHA256 check after every run; tree re-verified green at the end.

## Uniformity

Pill structure copied from the Safety column in this same view — same `RadiusMd` border at `6,3`, same 6px dot with `Margin="0,0,4,0"`, same `FontSize="11" FontWeight="SemiBold"`, same `HorizontalAlignment="Left"`, visibility collapsing the whole chip. The converter trio follows `ProcessSafety*` exactly: theme-key-plus-frozen-fallback pairs, the same `Live()` lookup so the pill stays legible on light themes, registered in `App.xaml` beside the other two families with a comment saying why it is a third scale rather than a reuse.

## Verification

Four projects build Release at **0 errors / 0 warnings**; `dotnet format --verify-no-changes` clean on all four. Unit suite **5375 passing** (28 added). Protocol I run with real greps: no debug code, no generic catch, author headers on all seven touched code files, leak scan over the diff plus the new test file — all 47 patterns, 0 hits.

Version bumped to 1.85.0; CHANGELOG, README, ARCHITECTURE and SECURITY updated in this PR.

## Deferred to the secondary workstation

How the three pills actually look in the grid at real width, against a machine with a genuine mix of signed and unsigned startup entries — and specifically whether a real **Verified** row renders as intended, which no unit test here can produce without a code-signing certificate.
