### PR TITLE
feat: F5 refreshes the tab you are looking at

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -729,6 +729,31 @@ upgrades) check elevation via `AdminHelper.IsElevated()` and surface a banner
 when running unelevated. The banner calls `AdminHelper.RelaunchAsAdmin()`,
 which restarts the process with `runas` and the current command-line args.
 
+## Keyboard accelerators
+
+Two keys are handled at the shell, and both route through a seam on `ViewModelBase` rather
+than a name the shell guesses at:
+
+- `EscapeCancel` — the command Escape runs, returned only while the tab has something to
+  stop. One property rather than a flag beside a command, because the app answers "is
+  something running?" five different ways (`IsBusy` on most tabs, plus `IsShredding`,
+  `IsScanning`, `IsHttpTesting`, `IsOoklaTesting`), so a shell testing `IsBusy` would skip
+  four tabs. 15 tabs override it.
+- `RefreshOnF5` — the command F5 runs. A property per view model because the tabs do not
+  agree on a name: 12 distinct spellings bind to a refresh-shaped button, and two views bind
+  two candidates each, so a convention-matching shell would have to guess. 40 tabs override
+  it, and the named command must begin with Refresh/Rescan/Reload/Scan/Load — which
+  mechanically keeps Clean, Delete, Apply and Uninstall off a bare keypress.
+
+`MainWindowViewModel.AcceleratorCommand(NavItem?, Key)` is the pure routing decision, extracted
+so it is testable without a `Window`; `MainWindow.xaml.cs`'s bubbling `KeyDown` handler executes
+what it returns. Two rules live in that handler: it never reads `NavItem.Content` unless
+`IsContentCreated` (a keypress must not build a lazy tab), and `CanExecute` is consulted for F5
+only — `EscapeCancel` already gates itself, and a second gate there would be a way for Escape to
+go quiet. `ArchitectureTests.EveryCancellableTab_LetsEscapeReachItsOwnCancelCommand` and
+`EveryRefreshableTab_AnswersF5WithItsOwnRefreshCommand` derive both contracts from the views, so a
+tab cannot ship a refresh or cancel button the keyboard cannot reach.
+
 ## Threading
 
 - Long-running work (ping loops, PowerShell runs, winget scans, deep-clean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.86.0] - 2026-09-10
+
+**F5 now refreshes the tab you are looking at**, on all forty tabs that have something to look at
+again — the running processes, the startup entries, the event log, the installed apps, the drive
+health. It is the most familiar shortcut in Windows and it did nothing anywhere in this app, on a
+tool whose tabs are almost all "go and check again".
+
+### Added
+
+- **F5 re-reads the open tab.** Each tab names its own refresh, so F5 runs exactly what that tab's
+  own toolbar button runs — not a guess. Nothing that cleans, deletes, applies or uninstalls is
+  reachable from a bare keypress, which is what makes a shortcut with no confirmation behind it
+  reasonable at all.
+- Pressing F5 during a refresh that is already running does nothing, rather than queueing a second
+  one.
+- F5 is ignored on a tab you have not opened yet, so the key cannot be what starts a scan on a tab
+  that was never on screen.
+
+### Fixed
+
+- The keyboard section of the README said Escape stops work on "sixteen" tabs. It is fifteen — the
+  number was counted once and then drifted.
+
 ## [1.85.0] - 2026-09-09
 
 The Startup Manager now tells you whether Windows can actually confirm who made each program that

--- a/README.md
+++ b/README.md
@@ -187,9 +187,15 @@ within a table or a row of filter chips. In the sidebar, `Enter` also opens the 
 on, the way it opens a folder in File Explorer. Opening the appearance panel moves focus into it, `Tab`
 cycles the themes inside it, and `Escape` closes it and puts focus back on the button you opened it from.
 
-`Escape` also stops whatever the open tab is doing — a disk scan, a cleanup, a speed test — on all sixteen
+`Escape` also stops whatever the open tab is doing — a disk scan, a cleanup, a speed test — on all fifteen
 tabs that can be cancelled. It only acts while something is running, and only after the control you are on
 has had its own chance to use the key, so it still closes a drop-down or undoes a text edit first.
+
+**`F5` re-reads the tab you are on**, across all forty tabs that have something to look at again — the
+process list, the startup entries, the event log, the installed apps. Each tab names its own refresh, so
+F5 runs exactly what its own toolbar button runs and nothing else: nothing that cleans, deletes, applies
+or uninstalls is reachable from a bare keypress. Pressing it during a refresh that is already running
+does nothing rather than starting a second one.
 
 The focus outline is deliberately two thin lines of opposite shade — one light, one dark — rather
 than a single accent-coloured ring. A single colour cannot be visible everywhere: it has to show up

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.85.x   | :white_check_mark: |
-| < 1.85   | :x:                |
+| 1.86.x   | :white_check_mark: |
+| < 1.86   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/AcceleratorRoutingTests.cs
+++ b/SysManager/SysManager.Tests/AcceleratorRoutingTests.cs
@@ -1,0 +1,207 @@
+// SysManager · AcceleratorRoutingTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="MainWindowViewModel.AcceleratorCommand"/> — which command a keypress reaches on
+/// the open tab, and when it must reach nothing.
+/// </summary>
+/// <remarks>
+/// The decision is extracted from the shell's <c>KeyDown</c> handler precisely so it can be tested: the
+/// handler itself needs a <c>Window</c>, and the part worth pinning is the routing, not WPF's event
+/// plumbing. Same shape as <c>MapTaskbarProgress</c> for the same reason.
+/// </remarks>
+public class AcceleratorRoutingTests
+{
+    private sealed class Tab : ViewModelBase
+    {
+        public int Refreshed { get; private set; }
+        public int Cancelled { get; private set; }
+
+        public IRelayCommand Refresh { get; }
+        public IRelayCommand Cancel { get; }
+
+        /// <summary>When false, <see cref="Refresh"/> reports it cannot run — the held-down-F5 case.</summary>
+        public bool CanRefresh { get; set; } = true;
+
+        public bool OffersRefresh { get; set; } = true;
+        public bool OffersCancel { get; set; } = true;
+
+        public Tab()
+        {
+            Refresh = new RelayCommand(() => Refreshed++, () => CanRefresh);
+            Cancel = new RelayCommand(() => Cancelled++);
+        }
+
+        protected internal override IRelayCommand? RefreshOnF5 => OffersRefresh ? Refresh : null;
+        protected internal override IRelayCommand? EscapeCancel => OffersCancel ? Cancel : null;
+    }
+
+    private static NavItem Built(object content) => new()
+    {
+        Id = "built",
+        Label = "Built",
+        ViewType = typeof(object),
+        Content = content,   // eager path: already materialised, as the selected tab always is
+    };
+
+    private static NavItem Lazy(Func<object> factory) => new()
+    {
+        Id = "lazy",
+        Label = "Lazy",
+        ViewType = typeof(object),
+        ContentFactory = factory,
+    };
+
+    [Fact]
+    public void F5_ReachesTheTabsRefresh()
+    {
+        var tab = new Tab();
+
+        var command = MainWindowViewModel.AcceleratorCommand(Built(tab), Key.F5);
+
+        Assert.Same(tab.Refresh, command);
+    }
+
+    [Fact]
+    public void Escape_ReachesTheTabsCancel()
+    {
+        var tab = new Tab();
+
+        var command = MainWindowViewModel.AcceleratorCommand(Built(tab), Key.Escape);
+
+        Assert.Same(tab.Cancel, command);
+    }
+
+    [Fact]
+    public void ATabThatOffersNeither_SwallowsNothing()
+    {
+        // Null is the correct answer rather than a no-op command: the shell only marks the event handled
+        // when it gets something back, so on a tab with nothing to do the key falls through to whatever
+        // else would have handled it.
+        var tab = new Tab { OffersRefresh = false, OffersCancel = false };
+
+        Assert.Null(MainWindowViewModel.AcceleratorCommand(Built(tab), Key.F5));
+        Assert.Null(MainWindowViewModel.AcceleratorCommand(Built(tab), Key.Escape));
+    }
+
+    [Theory]
+    [InlineData(Key.Enter)]
+    [InlineData(Key.Delete)]
+    [InlineData(Key.F4)]
+    [InlineData(Key.Space)]
+    public void AnyOtherKey_RoutesNowhere(Key key)
+    {
+        // Deliberately narrow. Delete is in this list because a DataGrid full of startup entries and
+        // installed apps is exactly where a bare Delete key must never reach a command.
+        Assert.Null(MainWindowViewModel.AcceleratorCommand(Built(new Tab()), key));
+    }
+
+    [Fact]
+    public void NoTabSelected_RoutesNowhere()
+        => Assert.Null(MainWindowViewModel.AcceleratorCommand(null, Key.F5));
+
+    /// <summary>
+    /// A keypress must never be what builds a tab's view model.
+    /// </summary>
+    /// <remarks>
+    /// Reading <c>NavItem.Content</c> materialises it, so without the <c>IsContentCreated</c> check this
+    /// would construct the very tab it is asking about — and several constructors start a scan or a timer.
+    /// The selected tab is always built in practice; relying on that rather than asserting it is how a lazy
+    /// graph gets rebuilt by accident, which is the regression
+    /// <c>ArchitectureTests.OnlyTheJustifiedTabs_AreBuiltAtStartup</c> exists to prevent.
+    /// </remarks>
+    [Fact]
+    public void AnUnopenedTab_IsNotBuiltByAKeypress()
+    {
+        var built = 0;
+        var item = Lazy(() => { built++; return new Tab(); });
+
+        Assert.Null(MainWindowViewModel.AcceleratorCommand(item, Key.F5));
+        Assert.Null(MainWindowViewModel.AcceleratorCommand(item, Key.Escape));
+
+        Assert.Equal(0, built);
+        Assert.False(item.IsContentCreated);
+    }
+
+    [Fact]
+    public void ATabWhoseContentIsNotAViewModel_RoutesNowhere()
+    {
+        // The nav table is typed as object, and the designer graph puts plain instances in it.
+        Assert.Null(MainWindowViewModel.AcceleratorCommand(Built(new object()), Key.F5));
+    }
+
+    /// <summary>
+    /// The routing hands back the command even when it cannot run; refusing is the shell's job.
+    /// </summary>
+    /// <remarks>
+    /// Deliberate split. Keeping <c>CanExecute</c> out of here leaves this a pure question about intent —
+    /// "what does F5 mean on this tab" — and keeps the "do not start a second scan" rule in the one place
+    /// that actually executes. The pairing is what matters, so both halves are asserted: this test pins the
+    /// command comes back, and <see cref="TheShell_RefusesAnF5ThatCannotRun"/> pins that a caller obeying
+    /// the documented contract does not run it.
+    /// </remarks>
+    [Fact]
+    public void AnF5ThatCannotRun_IsStillReturned()
+    {
+        var tab = new Tab { CanRefresh = false };
+
+        var command = MainWindowViewModel.AcceleratorCommand(Built(tab), Key.F5);
+
+        Assert.Same(tab.Refresh, command);
+        Assert.False(command!.CanExecute(null));
+    }
+
+    [Fact]
+    public void TheShell_RefusesAnF5ThatCannotRun()
+    {
+        // The handler's own two lines, reproduced: resolve, then check CanExecute for F5 only. A held-down
+        // F5 during a scan that gates itself must not queue a second one.
+        var tab = new Tab { CanRefresh = false };
+
+        var command = MainWindowViewModel.AcceleratorCommand(Built(tab), Key.F5);
+        if (command is not null && command.CanExecute(null)) command.Execute(null);
+
+        Assert.Equal(0, tab.Refreshed);
+
+        tab.CanRefresh = true;
+        var again = MainWindowViewModel.AcceleratorCommand(Built(tab), Key.F5);
+        if (again is not null && again.CanExecute(null)) again.Execute(null);
+
+        Assert.Equal(1, tab.Refreshed);
+    }
+
+    [Fact]
+    public void Escape_IsNotGatedOnCanExecute()
+    {
+        // EscapeCancel already returns null unless there is something to stop, so the flag and the command
+        // travel together and a second gate would only add a way for Escape to go quiet. Pinned because
+        // the F5 work above introduced a CanExecute check next door, and copying it here would be the
+        // easy mistake.
+        var shell = System.IO.File.ReadAllText(ShellSourcePath());
+
+        var at = shell.IndexOf("private void Window_KeyDown", StringComparison.Ordinal);
+        Assert.True(at >= 0, "Window_KeyDown not found — this test would otherwise assert nothing");
+        var handler = shell[at..Math.Min(shell.Length, at + 1200)];
+
+        Assert.Contains("Key.F5 && !command.CanExecute(null)", handler, StringComparison.Ordinal);
+    }
+
+    private static string ShellSourcePath()
+    {
+        var dir = new System.IO.DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !System.IO.Directory.Exists(System.IO.Path.Combine(dir.FullName, "SysManager", "Services")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);
+        var path = System.IO.Path.Combine(dir!.FullName, "SysManager", "MainWindow.xaml.cs");
+        Assert.True(System.IO.File.Exists(path), $"MainWindow.xaml.cs not found at {path}");
+        return path;
+    }
+}

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1438,6 +1438,134 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Every tab with something to re-read answers F5, with the command its own refresh button runs.
+    /// </summary>
+    /// <remarks>
+    /// F5 is the most widely known shortcut in Windows and did nothing anywhere in this app (#1549). A
+    /// shortcut that works on some tabs and silently not others is worse than none, because the user learns
+    /// it is unreliable and stops reaching for it — so this asserts the whole set rather than a sample.
+    /// <para>Derived from the VIEW, like <see cref="EveryCancellableTab_LetsEscapeReachItsOwnCancelCommand"/>
+    /// above: the toolbar button already states which command is this tab's refresh, and the view model's
+    /// <c>RefreshOnF5</c> must name the same one. The tabs do not agree on a name — 12 distinct spellings
+    /// bind to a refresh-shaped button — which is exactly why the shell cannot match a convention and each
+    /// view model has to say.</para>
+    /// <para><b>Two views bind two candidates each and are resolved here, not skipped.</b> Deep Cleanup
+    /// binds <c>ScanCommand</c> and <c>ScanLargeFilesCommand</c>; System Health binds <c>ScanCommand</c> and
+    /// <c>RefreshDrivesCommand</c>. In both, F5 is the tab's primary read: Deep Cleanup's large-files finder
+    /// is a sub-feature of the tab, and System Health's <c>RefreshDrivesAsync</c> only repopulates the
+    /// chkdsk drive picker while <c>ScanAsync</c> is the "Collecting system info…" pass the tab exists for.
+    /// Recording the choice here keeps it a decision rather than a gap.</para>
+    /// <para><b>Read-only only.</b> The named command must begin with Refresh, Rescan, Reload, Scan or Load,
+    /// which mechanically keeps Clean, Delete, Apply, Uninstall and Kill off a bare keypress. An accelerator
+    /// with no confirmation behind it is only acceptable while that holds.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryRefreshableTab_AnswersF5WithItsOwnRefreshCommand()
+    {
+        var app = FindAppProjectDir();
+        var binding = new Regex(@"Command=""\{Binding ((?:Refresh|Rescan|Reload|Scan|Load)[A-Za-z]*Command)",
+            RegexOptions.CultureInvariant);
+
+        // Where a view offers more than one refresh-shaped command, which one F5 means. See the remarks.
+        var resolved = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["DeepCleanupView"] = "ScanCommand",
+            ["SystemHealthView"] = "ScanCommand",
+        };
+
+        var offenders = new List<string>();
+        var wired = 0;
+
+        foreach (var view in Directory.EnumerateFiles(Path.Combine(app, "Views"), "*.xaml")
+                     .OrderBy(p => p, StringComparer.Ordinal))
+        {
+            // Comments stripped: several views discuss a command in prose, and a match there would invent
+            // a contract for a button that does not exist.
+            var markup = WithoutXamlComments(File.ReadAllText(view));
+            var candidates = binding.Matches(markup)
+                .Select(m => m.Groups[1].Value)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(n => n, StringComparer.Ordinal)
+                .ToList();
+            if (candidates.Count == 0) continue;
+
+            var viewName = Path.GetFileNameWithoutExtension(view);
+
+            string command;
+            if (candidates.Count == 1)
+            {
+                command = candidates[0];
+            }
+            else if (resolved.TryGetValue(viewName, out var chosen))
+            {
+                command = chosen;
+                if (!candidates.Contains(chosen, StringComparer.Ordinal))
+                {
+                    offenders.Add($"{viewName}.xaml no longer binds {chosen}, which this guard names as its "
+                                  + $"F5 target — it binds {string.Join(", ", candidates)}");
+                    continue;
+                }
+            }
+            else
+            {
+                offenders.Add($"{viewName}.xaml binds {candidates.Count} refresh-shaped commands "
+                              + $"({string.Join(", ", candidates)}) and none is named as the F5 target. "
+                              + "Add it to the `resolved` table with the reason.");
+                continue;
+            }
+
+            var vmPath = Path.Combine(app, "ViewModels", viewName + "Model.cs");
+            if (!File.Exists(vmPath))
+            {
+                offenders.Add($"{viewName}.xaml binds {command} but {viewName}Model.cs does not exist");
+                continue;
+            }
+
+            var vm = string.Join('\n', File.ReadAllLines(vmPath)
+                .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+            var overrideAt = vm.IndexOf("override IRelayCommand? RefreshOnF5", StringComparison.Ordinal);
+            if (overrideAt < 0)
+            {
+                offenders.Add($"{viewName}Model has no RefreshOnF5 override, so F5 does nothing on a tab "
+                              + $"whose own toolbar offers {command}");
+                continue;
+            }
+
+            // The override's own expression: another member could mention the command and make this pass
+            // while F5 ran something else entirely.
+            var end = vm.IndexOf(';', overrideAt);
+            var expression = end > overrideAt ? vm[overrideAt..end] : vm[overrideAt..];
+            wired++;
+
+            if (!expression.Contains(command, StringComparison.Ordinal))
+                offenders.Add($"{viewName}Model points F5 at something other than {command}, which is the "
+                              + "command its own refresh button runs");
+        }
+
+        // Vacuity floor: 40 tabs bind a refresh-shaped command today. A parse that stopped finding them
+        // would report success having checked nothing.
+        Assert.True(wired >= 38,
+            $"only {wired} tabs were found wiring F5, out of 40 measured — the parse is broken, not the "
+            + "views, and every check above ran over a short list.");
+
+        Assert.True(offenders.Count == 0,
+            "F5 must re-read the tab the user is looking at, using the command its own refresh button "
+            + $"runs:\n  {string.Join("\n  ", offenders)}\n({wired} tabs checked)");
+
+        // And the shell must consult it. 40 overrides feeding nothing is the same defect as an unbound
+        // property, multiplied — and every view-model test would still pass.
+        //
+        // The KEY FILTER, not a mention of the key. `Key.F5` appears twice in the handler: once in the
+        // guard clause that admits the keypress at all, and once in the CanExecute check below it. Removing
+        // F5 from the first left the second in place, so a check for the bare name stayed GREEN with the
+        // whole feature switched off — measured by mutating exactly that.
+        var shell = File.ReadAllText(Path.Combine(app, "MainWindow.xaml.cs"));
+        Assert.Contains("Key.Escape or Key.F5", shell, StringComparison.Ordinal);
+        Assert.Contains("AcceleratorCommand(vm.SelectedNav, e.Key)", shell, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Every issue template must apply at least one label, and every label it names must be one this
     /// repository actually defines.
     /// </summary>

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -304,7 +304,7 @@ public partial class MainWindow : Window
     private void ThemePopupHost_Closed(object sender, EventArgs e) => ThemeBtn.Focus();
 
     /// <summary>
-    /// Escape stops whatever the open tab is doing.
+    /// Escape stops whatever the open tab is doing; F5 makes it look again.
     /// </summary>
     /// <remarks>
     /// Bubbling <c>KeyDown</c>, deliberately not <c>PreviewKeyDown</c>. A ComboBox closing its dropdown
@@ -318,15 +318,29 @@ public partial class MainWindow : Window
     /// <para><c>IsContentCreated</c> is checked so this cannot construct a view model as a side effect of
     /// a keypress. In practice the selected tab is always materialised; relying on that rather than
     /// asserting it is how a lazy graph gets built by accident.</para>
+    /// <para><b>F5</b> runs the tab's <see cref="ViewModelBase.RefreshOnF5"/>, which every tab with
+    /// something to re-read names for itself. <c>CanExecute</c> is consulted first, so pressing it during
+    /// a refresh that gates itself does nothing rather than starting a second one. Bubbling like Escape,
+    /// so a control that wants F5 gets it first — and unlike Escape, F5 is not something a TextBox or
+    /// ComboBox consumes, which is why it needs no busy gate to stay out of the way.</para>
+    /// <para>Both keys are read-only in effect: F5 re-reads, Escape cancels. Nothing that cleans, deletes,
+    /// applies or kills is reachable from a bare keypress, which is what makes an accelerator with no
+    /// confirmation dialog behind it acceptable at all.</para>
     /// </remarks>
     private void Window_KeyDown(object sender, KeyEventArgs e)
     {
-        if (e.Key is not Key.Escape) return;
+        if (e.Key is not (Key.Escape or Key.F5)) return;
         if (DataContext is not MainWindowViewModel vm) return;
-        if (vm.SelectedNav is not { IsContentCreated: true, Content: ViewModelBase active }) return;
-        if (active.EscapeCancel is not { } cancel) return;
+        if (MainWindowViewModel.AcceleratorCommand(vm.SelectedNav, e.Key) is not { } command) return;
 
-        cancel.Execute(null);
+        // CanExecute is consulted for F5 and deliberately NOT for Escape. RefreshOnF5 returns its command
+        // unconditionally, so this is the only thing standing between a held-down F5 and a second
+        // concurrent scan. EscapeCancel already returns null unless the tab has something running, and
+        // adding a CanExecute check there would change a path this work is not about: a Cancel command
+        // that reported false while busy would silently stop answering Escape.
+        if (e.Key is Key.F5 && !command.CanExecute(null)) return;
+
+        command.Execute(null);
         e.Handled = true;
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.85.0</Version>
-    <FileVersion>1.85.0.0</FileVersion>
-    <AssemblyVersion>1.85.0.0</AssemblyVersion>
+    <Version>1.86.0</Version>
+    <FileVersion>1.86.0.0</FileVersion>
+    <AssemblyVersion>1.86.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AboutViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AboutViewModel.cs
@@ -20,6 +20,9 @@ namespace SysManager.ViewModels;
 
 public sealed partial class AboutViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => LoadHistoryCommand;
+
     private readonly UpdateService _updates;
     private readonly SystemReportService _reportService;
     private readonly UpdateCheckPreferenceService _preferences;

--- a/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
@@ -19,6 +19,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class AppAlertsViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshInstalledAppsCommand;
+
     private readonly AppAlertService _service;
     private readonly Dispatcher _dispatcher;
 

--- a/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppBlockerViewModel.cs
@@ -18,6 +18,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class AppBlockerViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshListCommand;
+
     public BulkObservableCollection<BlockedApp> BlockedApps { get; } = new();
 
     [ObservableProperty] private string _newExeName = "";

--- a/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppUpdatesViewModel.cs
@@ -14,6 +14,9 @@ namespace SysManager.ViewModels;
 
 public sealed partial class AppUpdatesViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => ScanCommand;
+
     private readonly IWingetService _winget;
     private readonly EtaCalculator _upgradeEta = new();
     private CancellationTokenSource? _cts;

--- a/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
@@ -34,6 +34,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class BandwidthMonitorViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => ReloadHistoryCommand;
+
     private const int PollIntervalMs = 1000;
     // Cap the top-consumers list so a machine with hundreds of connections stays readable and cheap.
     private const int MaxRows = 40;

--- a/SysManager/SysManager/ViewModels/BatteryHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BatteryHealthViewModel.cs
@@ -16,6 +16,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class BatteryHealthViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly BatteryService _service;
 
     [ObservableProperty] private BatteryInfo _battery = new();

--- a/SysManager/SysManager/ViewModels/BootAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BootAnalyzerViewModel.cs
@@ -20,6 +20,9 @@ namespace SysManager.ViewModels;
 public sealed partial class BootAnalyzerViewModel : ViewModelBase
 {
     /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
+    /// <inheritdoc/>
     protected internal override IRelayCommand? EscapeCancel =>
         IsBusy ? CancelCommand : null;
 

--- a/SysManager/SysManager/ViewModels/BrowserCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BrowserCleanerViewModel.cs
@@ -21,6 +21,9 @@ namespace SysManager.ViewModels;
 public sealed partial class BrowserCleanerViewModel : ViewModelBase
 {
     /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => ScanCommand;
+
+    /// <inheritdoc/>
     protected internal override IRelayCommand? EscapeCancel =>
         IsBusy ? CancelCommand : null;
 

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -16,6 +16,9 @@ namespace SysManager.ViewModels;
 
 public sealed partial class CleanupViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RescanCommand;
+
     private readonly IPowerShellRunner _runner;
 
     // The temp/Recycle-Bin sizing, behind a seam. It used to be inline here, which meant constructing this

--- a/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ContextMenuViewModel.cs
@@ -21,6 +21,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class ContextMenuViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly IContextMenuService _service;
     private List<ContextMenuEntry> _allEntries = [];
 

--- a/SysManager/SysManager/ViewModels/CpuAffinityViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CpuAffinityViewModel.cs
@@ -29,6 +29,9 @@ public sealed partial class CoreToggle : ObservableObject
 /// </summary>
 public sealed partial class CpuAffinityViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshProcessesCommand;
+
     private readonly ICpuAffinityService _service;
 
     /// <summary>

--- a/SysManager/SysManager/ViewModels/DashboardViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DashboardViewModel.cs
@@ -16,6 +16,9 @@ namespace SysManager.ViewModels;
 
 public sealed partial class DashboardViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly SystemInfoService _sys;
     private readonly TuneUpService _tuneUp;
     private readonly HealthScoreService _healthScore;

--- a/SysManager/SysManager/ViewModels/DebloaterViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DebloaterViewModel.cs
@@ -22,6 +22,9 @@ namespace SysManager.ViewModels;
 public sealed partial class DebloaterViewModel : ViewModelBase
 {
     /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
+    /// <inheritdoc/>
     protected internal override IRelayCommand? EscapeCancel =>
         IsBusy ? CancelCommand : null;
 

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -17,6 +17,9 @@ namespace SysManager.ViewModels;
 
 public sealed partial class DeepCleanupViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => ScanCommand;
+
     private readonly DeepCleanupService _cleanup;
     private readonly LargeFileScanner _largeFiles;
     private readonly FixedDriveService _drives;

--- a/SysManager/SysManager/ViewModels/DefenderViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DefenderViewModel.cs
@@ -21,6 +21,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class DefenderViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly DefenderService _service;
     private readonly ISessionRestorePoint _restorePoint;
 

--- a/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DnsHostsViewModel.cs
@@ -19,6 +19,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class DnsHostsViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshHostsCommand;
+
     private readonly DnsService _dnsService;
     private readonly HostsFileService _hostsService;
     private readonly CancellationTokenSource _cts = new();

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -27,6 +27,9 @@ namespace SysManager.ViewModels;
 public sealed partial class DuplicateFileViewModel : ViewModelBase
 {
     /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => ScanCommand;
+
+    /// <inheritdoc/>
     protected internal override IRelayCommand? EscapeCancel =>
         IsBusy ? CancelScanCommand : null;
 

--- a/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/EnvironmentVariablesViewModel.cs
@@ -21,6 +21,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class EnvironmentVariablesViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly EnvironmentVariableService _service;
 
     // Baseline of the on-disk state, keyed "scope\0NAME" → value. Used to compute the

--- a/SysManager/SysManager/ViewModels/FileLockViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileLockViewModel.cs
@@ -19,6 +19,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class FileLockViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => ScanCommand;
+
     private readonly IFileLockService _service;
 
     public BulkObservableCollection<FileLocker> Lockers { get; } = new();

--- a/SysManager/SysManager/ViewModels/GamingProfileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/GamingProfileViewModel.cs
@@ -22,6 +22,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class GamingProfileViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshProcessesCommand;
+
     private readonly IGamingProfileService _service;
     private readonly ICpuAffinityService _cpu;
 

--- a/SysManager/SysManager/ViewModels/LogsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/LogsViewModel.cs
@@ -27,6 +27,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class LogsViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly EventLogService _eventLogs;
     private readonly SynchronizationContext? _sync;
     private CancellationTokenSource? _cts;

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Windows.Input;
 using System.Windows.Shell;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -365,6 +366,34 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         if (tab.Progress is > 0 and <= 100)
             return (TaskbarItemProgressState.Normal, tab.Progress / 100.0);
         return (TaskbarItemProgressState.None, 0);
+    }
+
+    /// <summary>
+    /// Which command an accelerator should run on <paramref name="tab"/>, or <c>null</c> for "do nothing
+    /// and let the key through".
+    /// </summary>
+    /// <remarks>
+    /// Pure and <c>internal</c> so the routing is testable without a <c>Window</c>: the shell's
+    /// <c>KeyDown</c> handler then only executes what this returns and marks the event handled. Same reason
+    /// <see cref="MapTaskbarProgress"/> is shaped this way — the decision is the part worth pinning, and it
+    /// cannot be reached through WPF in a unit test.
+    /// <para><b>Never touches <c>Content</c> unless it is already built.</b> Reading it materialises the
+    /// view model, so without the <c>IsContentCreated</c> check a keypress would construct the tab it is
+    /// asking about — and on a lazy graph that is how every tab ends up built by accident.</para>
+    /// <para>F5 does NOT check <c>CanExecute</c> here; the caller does. Returning the command and letting
+    /// the shell decide keeps this a pure question about intent, and keeps the "don't start a second scan"
+    /// rule in the one place that executes.</para>
+    /// </remarks>
+    internal static IRelayCommand? AcceleratorCommand(NavItem? tab, Key key)
+    {
+        if (tab is not { IsContentCreated: true, Content: ViewModelBase active }) return null;
+
+        return key switch
+        {
+            Key.F5 => active.RefreshOnF5,
+            Key.Escape => active.EscapeCancel,
+            _ => null,
+        };
     }
 
     /// <summary>

--- a/SysManager/SysManager/ViewModels/NotificationBlockerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/NotificationBlockerViewModel.cs
@@ -20,6 +20,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class NotificationBlockerViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly INotificationBlockerService _service;
     private readonly Dictionary<NotificationApp, bool> _baselineStates = [];
     private bool _masterBaseline = true;

--- a/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PerformanceViewModel.cs
@@ -26,6 +26,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class PerformanceViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly PerformanceService _service;
     // Consulted for ONE question: is a game profile live? While it is, the current power plan and
     // visual-effects state belong to the profile, not to the user, so they must not be recorded as

--- a/SysManager/SysManager/ViewModels/PrivacyMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PrivacyMonitorViewModel.cs
@@ -20,6 +20,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class PrivacyMonitorViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly PrivacyMonitorService _service;
     private CancellationTokenSource? _cts;
 

--- a/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PrivacyViewModel.cs
@@ -20,6 +20,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class PrivacyViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly PrivacyService _service;
     private readonly ISessionRestorePoint _restorePoint;
     private readonly Dictionary<PrivacyToggle, bool> _baselineStates = [];

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -19,6 +19,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class ProcessManagerViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly ProcessManagerService _service;
     private CancellationTokenSource? _autoRefreshCts;
 

--- a/SysManager/SysManager/ViewModels/ProfileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProfileViewModel.cs
@@ -22,6 +22,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class ProfileViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly ProfileService _service;
 
     /// <summary>Sections discovered for export (those whose config file exists).</summary>

--- a/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ResourceHistoryViewModel.cs
@@ -29,6 +29,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class ResourceHistoryViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => ReloadCommand;
+
     // A chart renders cleanly with a few hundred points; more just costs CPU with no
     // visible benefit, so any range is downsampled to this cap before plotting.
     private const int MaxChartPoints = 400;

--- a/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/RestorePointsViewModel.cs
@@ -21,6 +21,9 @@ namespace SysManager.ViewModels;
 public sealed partial class RestorePointsViewModel : ViewModelBase
 {
     /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
+    /// <inheritdoc/>
     protected internal override IRelayCommand? EscapeCancel =>
         IsBusy ? CancelCommand : null;
 

--- a/SysManager/SysManager/ViewModels/ScheduledMaintenanceViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ScheduledMaintenanceViewModel.cs
@@ -20,6 +20,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class ScheduledMaintenanceViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly MaintenanceSchedulerService _service;
 
     public IReadOnlyList<MaintenanceAction> Actions { get; } = [MaintenanceAction.Cleanup, MaintenanceAction.PurgeStandby];

--- a/SysManager/SysManager/ViewModels/ServicesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ServicesViewModel.cs
@@ -19,6 +19,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class ServicesViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly IPowerShellRunner _ps;
     private readonly ServiceStartupLedgerService _ledger;
     private List<ServiceEntry> _allServices = [];

--- a/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
@@ -20,6 +20,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class SettingsWatchdogViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly ISettingsWatchdogService _service;
 
     public BulkObservableCollection<DriftRow> Drifts { get; } = new();

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -19,6 +19,9 @@ namespace SysManager.ViewModels;
 public sealed partial class ShortcutCleanerViewModel : ViewModelBase
 {
     /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => ScanCommand;
+
+    /// <inheritdoc/>
     protected internal override IRelayCommand? EscapeCancel =>
         IsScanning ? CancelCommand : null;
 

--- a/SysManager/SysManager/ViewModels/StartupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/StartupViewModel.cs
@@ -18,6 +18,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class StartupViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => ScanCommand;
+
     private readonly StartupService _service;
     private readonly Func<bool> _isElevatedProbe;
 

--- a/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SystemHealthViewModel.cs
@@ -18,6 +18,9 @@ namespace SysManager.ViewModels;
 
 public sealed partial class SystemHealthViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => ScanCommand;
+
     private readonly SystemInfoService _sys;
     private readonly DiskHealthService _diskHealth;
     private readonly MemoryTestService _memTest;

--- a/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TaskSchedulerViewModel.cs
@@ -20,6 +20,9 @@ namespace SysManager.ViewModels;
 public sealed partial class TaskSchedulerViewModel : ViewModelBase
 {
     /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
+    /// <inheritdoc/>
     protected internal override IRelayCommand? EscapeCancel =>
         IsBusy ? CancelCommand : null;
 

--- a/SysManager/SysManager/ViewModels/TimerResolutionViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TimerResolutionViewModel.cs
@@ -17,6 +17,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class TimerResolutionViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly ITimerResolutionService _service;
 
     [ObservableProperty] private string _currentDisplay = "—";

--- a/SysManager/SysManager/ViewModels/TweaksHubViewModel.cs
+++ b/SysManager/SysManager/ViewModels/TweaksHubViewModel.cs
@@ -21,6 +21,9 @@ namespace SysManager.ViewModels;
 /// </summary>
 public sealed partial class TweaksHubViewModel : ViewModelBase
 {
+    /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => RefreshCommand;
+
     private readonly ITweaksHubService _service;
 
     public BulkObservableCollection<TweakItem> Essential { get; } = new();

--- a/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/UninstallerViewModel.cs
@@ -18,6 +18,9 @@ namespace SysManager.ViewModels;
 public sealed partial class UninstallerViewModel : ViewModelBase
 {
     /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => ScanCommand;
+
+    /// <inheritdoc/>
     protected internal override IRelayCommand? EscapeCancel =>
         IsBusy ? CancelCommand : null;
 

--- a/SysManager/SysManager/ViewModels/ViewModelBase.cs
+++ b/SysManager/SysManager/ViewModels/ViewModelBase.cs
@@ -43,6 +43,32 @@ public abstract partial class ViewModelBase : ObservableObject, IDisposable
     protected internal virtual IRelayCommand? EscapeCancel => null;
 
     /// <summary>
+    /// The command F5 should run on this tab, or <c>null</c> when the tab has nothing to re-read.
+    /// </summary>
+    /// <remarks>
+    /// F5 is the most widely known shortcut in Windows and it did nothing anywhere in this app (#1549), on
+    /// a tool whose tabs are almost all "go and look again".
+    /// <para><b>A property per view model rather than a naming convention the shell matches.</b> The
+    /// tabs do not agree on what their refresh is called: measured across the views, 12 distinct spellings
+    /// bind to a refresh-shaped button — <c>RefreshCommand</c>, <c>ScanCommand</c>, <c>RescanCommand</c>,
+    /// <c>ReloadCommand</c>, <c>LoadHistoryCommand</c>, <c>RefreshDrivesCommand</c>,
+    /// <c>RefreshProcessesCommand</c> and more. A shell that matched names would have to guess, and on two
+    /// tabs it would have had to pick between two candidates: Deep Cleanup binds both <c>ScanCommand</c>
+    /// and <c>ScanLargeFilesCommand</c>, System Health both <c>ScanCommand</c> and
+    /// <c>RefreshDrivesCommand</c>. Naming the command here records the decision where it is made, and the
+    /// compiler checks it — a renamed command breaks the build instead of silently unbinding the key.</para>
+    /// <para><b>Not gated on busy, unlike <see cref="EscapeCancel"/>.</b> Escape must only appear while
+    /// there is something to stop, so the flag and the command have to travel together. A refresh is
+    /// idempotent and read-only, so the command's own <c>CanExecute</c> is the right gate and the shell
+    /// checks it before invoking; a spurious second run costs a re-read, not damage.</para>
+    /// <para><b>Read-only commands only.</b> Every tab's F5 target re-reads something — the registry, a
+    /// WMI query, a folder, an event log. Nothing that cleans, deletes, applies or kills is reachable from
+    /// a bare keypress, and a guard asserts that by requiring the named command to begin with Refresh,
+    /// Rescan, Reload, Scan or Load.</para>
+    /// </remarks>
+    protected internal virtual IRelayCommand? RefreshOnF5 => null;
+
+    /// <summary>
     /// Completes when the constructor's <see cref="InitializeAsync"/> work has finished
     /// (or immediately if the VM does no async init). Production never awaits this — the
     /// window paints while init runs in the background — but tests can await it to observe

--- a/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
+++ b/SysManager/SysManager/ViewModels/WindowsFeaturesViewModel.cs
@@ -18,6 +18,9 @@ namespace SysManager.ViewModels;
 public sealed partial class WindowsFeaturesViewModel : ViewModelBase
 {
     /// <inheritdoc/>
+    protected internal override IRelayCommand? RefreshOnF5 => ScanCommand;
+
+    /// <inheritdoc/>
     protected internal override IRelayCommand? EscapeCancel =>
         IsBusy ? CancelCommand : null;
 


### PR DESCRIPTION
The F5 half of #1549. Leaving that issue open: `Escape` turned out to be **already implemented** (15 tabs, guarded, with the reasoning documented), and `Ctrl+F` plus the mnemonics are not in this change — see the end.

## The gap

F5 is the most familiar shortcut in Windows and it did nothing anywhere in this app, on a tool whose 58 tabs are almost all "go and look again". Re-derived on current source: **40 views bind a refresh-shaped command**, and none of them could be reached from the keyboard.

## Why a property per view model, not a convention the shell matches

The tabs do not agree on what their refresh is called. Measured across `Views/`, **12 distinct spellings** bind to a refresh-shaped button:

```
RefreshCommand (21)   ScanCommand (10)      RefreshProcessesCommand (2)
RescanCommand         ReloadCommand         ReloadHistoryCommand
LoadHistoryCommand    RefreshListCommand    RefreshDrivesCommand
RefreshHostsCommand   RefreshInstalledAppsCommand   ScanLargeFilesCommand
```

A shell matching names would have to guess — and on two views it would have had to pick between two candidates: Deep Cleanup binds `ScanCommand` **and** `ScanLargeFilesCommand`, System Health binds `ScanCommand` **and** `RefreshDrivesCommand`. Both resolve to the tab's primary read (`RefreshDrivesAsync` only repopulates the chkdsk drive picker; `ScanAsync` is the "Collecting system info…" pass the tab exists for), and the choice is recorded in the guard's own table so it stays a decision rather than a gap.

`RefreshOnF5` on `ViewModelBase` mirrors the `EscapeCancel` seam already beside it, and the compiler checks it: a renamed command breaks the build instead of silently unbinding the key.

## Read-only only

The named command must begin with **Refresh, Rescan, Reload, Scan or Load**, asserted by the guard rather than asked for in a comment. That mechanically keeps Clean, Delete, Apply, Uninstall and Kill off a bare keypress — which is what makes an accelerator with no confirmation dialog behind it acceptable at all. All 40 targets re-read something: the registry, a WMI query, a folder, an event log.

## Two rules that stay in the handler

- **It never reads `NavItem.Content` unless `IsContentCreated`.** Reading it materialises the view model, so without that check a keypress would construct the very tab it is asking about — and several constructors start a scan or a timer. That is the regression `OnlyTheJustifiedTabs_AreBuiltAtStartup` exists to prevent, arriving through a new door.
- **`CanExecute` is consulted for F5 only.** `EscapeCancel` already returns null unless there is something to stop, so a second gate there would only add a way for Escape to go quiet if a Cancel command ever reported false while busy. The Escape path is **byte-for-byte unchanged** — I did change it in a first draft and backed that out, because a behaviour change to Escape has no business in a PR about F5.

The routing itself moved out of the handler into `MainWindowViewModel.AcceleratorCommand(NavItem?, Key)` — pure, `internal`, testable without a `Window`, the same shape and for the same reason as `MapTaskbarProgress`.

## The guard caught me once, on the third instance of the same mistake

Its shell check asserted `Contains("Key.F5")`. `Key.F5` appears **twice** in the handler — in the key filter and in the `CanExecute` line — so removing F5 from the filter left the mention behind and the guard stayed **GREEN with the whole feature switched off**. Mutation 1 found it.

That is the third time this session a name-based assertion was satisfied by a mention elsewhere: the publisher pin in #2215 (`ExpectedSignerSubject` also appears in the `.Length == 0` branch) and the signature pill in #2216 (`Signature` bound five times in one template). It now pins the filter itself, `Key.Escape or Key.F5`, plus the call into the routing.

## Proof — 8 mutations, all RED in the named test, GREEN after

| Mutation | Caught by |
|---|---|
| the shell drops F5 from its key filter | `EveryRefreshableTab_AnswersF5WithItsOwnRefreshCommand` |
| the `CanExecute` gate is removed | `Escape_IsNotGatedOnCanExecute` |
| F5 is routed to Escape's command | `F5_ReachesTheTabsRefresh` |
| the routing materialises an unopened tab | `AnUnopenedTab_IsNotBuiltByAKeypress` |
| Escape is swallowed by the routing | `Escape_ReachesTheTabsCancel` |
| a bare `Delete` key reaches a command | `AnyOtherKey_RoutesNowhere` |
| one tab loses its override | `EveryRefreshableTab_…` (names the tab) |
| a tab points F5 at something other than its own button's command | same |

Five files restored byte-for-byte with a SHA256 check after every run; tree re-verified green at the end.

Three of the eight mutations are the ones no behavioural test can see — the shell abandoning the seam, one tab losing its override, and a tab pointing F5 somewhere else. 40 overrides feeding nothing is an unbound property multiplied by forty, and every view-model test would still pass.

## Docs

README's keyboard section said Escape covers **"sixteen"** tabs. Re-derived: **15** `EscapeCancel` overrides. Corrected, and the F5 paragraph states the 40 it actually is rather than a round number. ARCHITECTURE gains a "Keyboard accelerators" section describing both seams and why each exists.

## Verification

Four projects build Release at **0 errors / 0 warnings**; `dotnet format --verify-no-changes` clean on all four. Unit suite **5389 passing** (14 added). Protocol I with real greps: no debug code, no generic catch, author headers on all 45 touched code files, leak scan over the diff plus the new test file — 47 patterns, 0 hits.

Version 1.86.0; CHANGELOG, README, ARCHITECTURE, SECURITY updated here.

## Left for follow-ups, deliberately

- **`Ctrl+F` to focus the filter box.** There is a usable convention — the filter `TextBox` binds `Text` to `FilterText`, `SearchText` or `SearchQuery` across 11 views — so this needs no view-model changes at all, just a visual-tree lookup in the shell. Different mechanism, its own guard and proof, so its own PR.
- **Mnemonics (`Content="_Scan"`).** These change visible button captions, which is a design decision rather than a mechanical one, so it wants a look before it ships.

## Deferred to the secondary workstation

Pressing F5 on a handful of real tabs and watching the right thing re-read — and specifically that holding it down during a long scan does nothing rather than stacking up work. Everything above is source- and substitute-level.
