### PR TITLE
feat: Ctrl+F jumps to the open tab's search box

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -745,6 +745,17 @@ than a name the shell guesses at:
   it, and the named command must begin with Refresh/Rescan/Reload/Scan/Load — which
   mechanically keeps Clean, Delete, Apply and Uninstall off a bare keypress.
 
+`Ctrl+F` is the third, and takes no seam at all: `Helpers/FilterBoxes` walks the visual tree under
+`ContentHost` — the element the shell binds the live tab into — for the first `TextBox` whose `Text`
+binds one of four property names (`FilterText`, `SearchText`, `SearchQuery`, `Filter`), then focuses
+and selects it. Focusing a control is a View concern, so routing it through a view model would have
+put UI manipulation where the MVVM rules forbid it, and 12 tabs already state which box is the filter
+by what it binds. The list was measured rather than assumed: three names looked complete until a scan
+of every `TextBox` announced as a filter or search box found Task Scheduler binding plain `Filter`.
+`ArchitectureTests.EveryFilterBox_BindsANameCtrlFRecognises` holds it against the views in both
+directions, using the ACCESSIBLE NAME as the independent test of "is this a filter box" so the check
+is not circular.
+
 `MainWindowViewModel.AcceleratorCommand(NavItem?, Key)` is the pure routing decision, extracted
 so it is testable without a `Window`; `MainWindow.xaml.cs`'s bubbling `KeyDown` handler executes
 what it returns. Two rules live in that handler: it never reads `NavItem.Content` unless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.87.0] - 2026-09-10
+
+**Ctrl+F now jumps to the search box.** On the twelve tabs that have one — processes, services,
+installed apps, the event log, Windows features, scheduled tasks and the rest — Ctrl+F puts the caret
+in it and selects whatever is already typed, so you can replace the search straight away. The same
+thing the key does in a browser.
+
+### Added
+
+- **Ctrl+F focuses the open tab's search box**, and selects the existing text so a second press
+  replaces the search rather than appending to it.
+- On a tab with nothing to filter it does nothing at all, rather than moving the caret somewhere
+  unexpected — and the keypress is left for anything else that wants it.
+- A search box inside a section the tab is currently hiding is skipped, so the caret cannot end up
+  somewhere off screen.
+
 ## [1.86.0] - 2026-09-10
 
 **F5 now refreshes the tab you are looking at**, on all forty tabs that have something to look at

--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ F5 runs exactly what its own toolbar button runs and nothing else: nothing that 
 or uninstalls is reachable from a bare keypress. Pressing it during a refresh that is already running
 does nothing rather than starting a second one.
 
+**`Ctrl+F` jumps to the search box** on the twelve tabs that have one, and selects whatever is already
+typed there so you can replace it straight away — the same thing the key does in a browser. On a tab with
+nothing to filter it does nothing at all, rather than moving your caret somewhere unexpected.
+
 The focus outline is deliberately two thin lines of opposite shade — one light, one dark — rather
 than a single accent-coloured ring. A single colour cannot be visible everywhere: it has to show up
 on a purple primary button, a red delete button, a grey secondary button and a plain card, and any

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.86.x   | :white_check_mark: |
-| < 1.86   | :x:                |
+| 1.87.x   | :white_check_mark: |
+| < 1.87   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -1566,6 +1566,109 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Every filter or search box binds a property name Ctrl+F recognises.
+    /// </summary>
+    /// <remarks>
+    /// Ctrl+F finds the open tab's filter box by what the box binds, because 12 tabs already state it that
+    /// way and inventing a marker attribute would have meant touching 12 views to say something they
+    /// already said. The cost of keying on an existing convention is that the convention has to be held.
+    /// <para><b>The list was measured and the first attempt was short.</b> <c>FilterText</c>,
+    /// <c>SearchText</c> and <c>SearchQuery</c> looked like the whole set; scanning every <c>TextBox</c>
+    /// whose accessible name mentions filtering or search found a twelfth tab, Task Scheduler, binding plain
+    /// <c>Filter</c>. Ctrl+F would have silently done nothing there — and a shortcut that works on eleven
+    /// tabs out of twelve is worse than none, because the user learns it is unreliable and stops reaching
+    /// for it.</para>
+    /// <para>Non-circular by construction: what makes a <c>TextBox</c> a filter box here is its
+    /// ACCESSIBLE NAME saying so, which is independent of the binding path being checked. Both directions
+    /// are asserted — an unrecognised path on a filter-named box, and a recognised path on a box whose
+    /// accessible name does not mention filtering, since that second case means either the name or the
+    /// recogniser is wrong.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryFilterBox_BindsANameCtrlFRecognises()
+    {
+        var app = FindAppProjectDir();
+        var presentation = XNamespace.Get("http://schemas.microsoft.com/winfx/2006/xaml/presentation");
+        var binding = new Regex(@"^\{Binding\s+(?<path>[\w.]+)", RegexOptions.CultureInvariant);
+        var filterish = new Regex("filter|search", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+        // The recogniser, read from the helper so the two cannot drift: a name added there without a view
+        // using it, or used by a view without being there, both show up below.
+        var recognised = FilterBoxNames(app);
+        Assert.True(recognised.Count >= 4,
+            $"only {recognised.Count} names were parsed out of FilterBoxes.BindingPaths, out of 4 measured — "
+            + "the parse is broken, so every check below compares against a short list");
+
+        var offenders = new List<string>();
+        var boxes = 0;
+
+        foreach (var view in Directory.EnumerateFiles(Path.Combine(app, "Views"), "*.xaml")
+                     .OrderBy(p => p, StringComparer.Ordinal))
+        {
+            foreach (var element in XDocument.Load(view).Descendants(presentation + "TextBox"))
+            {
+                var path = binding.Match((string?)element.Attribute("Text") ?? string.Empty);
+                if (!path.Success) continue;
+
+                var bound = path.Groups["path"].Value;
+                var accessible = (string?)element.Attribute(
+                    XName.Get("AutomationProperties.Name")) ?? string.Empty;
+                var named = filterish.IsMatch(accessible);
+                var known = recognised.Contains(bound);
+                if (!named && !known) continue;
+
+                boxes++;
+                var viewName = Path.GetFileNameWithoutExtension(view);
+
+                if (named && !known)
+                    offenders.Add($"{viewName} has a box announced as \"{accessible}\" bound to {bound}, "
+                                  + "which Ctrl+F does not recognise — so the shortcut silently does nothing "
+                                  + "on that tab. Add the name to FilterBoxes.BindingPaths.");
+
+                if (known && !named)
+                    offenders.Add($"{viewName} binds {bound}, which Ctrl+F treats as a filter box, but its "
+                                  + $"accessible name is \"{accessible}\" — either the name does not describe "
+                                  + "what the box is for, or the box is not a filter and Ctrl+F will land in "
+                                  + "the wrong place.");
+            }
+        }
+
+        // Vacuity floor: 13 filter boxes across 12 views today (Bulk Installer has two). A parse that
+        // stopped finding them would report success having checked nothing.
+        Assert.True(boxes >= 13,
+            $"only {boxes} filter boxes were found across Views/, out of 13 measured — the XAML parse is "
+            + "broken, not the views.");
+
+        Assert.True(offenders.Count == 0,
+            $"Ctrl+F must reach the filter box on every tab that has one:\n  {string.Join("\n  ", offenders)}"
+            + $"\n({boxes} boxes checked)");
+
+        // And the shell must actually do the lookup.
+        var shell = File.ReadAllText(Path.Combine(app, "MainWindow.xaml.cs"));
+        Assert.Contains("Key.F && Keyboard.Modifiers is ModifierKeys.Control", shell, StringComparison.Ordinal);
+        Assert.Contains("FilterBoxes.FindIn(ContentHost)", shell, StringComparison.Ordinal);
+    }
+
+    /// <summary>The names in <c>FilterBoxes.BindingPaths</c>, read from its source.</summary>
+    /// <remarks>
+    /// Read rather than referenced because the helper is <c>internal</c> to a WPF assembly and touching it
+    /// from a test would load presentation types for the sake of a string array.
+    /// </remarks>
+    private static HashSet<string> FilterBoxNames(string appDir)
+    {
+        var source = File.ReadAllText(Path.Combine(appDir, "Helpers", "FilterBoxes.cs"));
+        var at = source.IndexOf("BindingPaths = [", StringComparison.Ordinal);
+        Assert.True(at >= 0, "FilterBoxes.BindingPaths not found — this guard would compare against nothing");
+
+        var end = source.IndexOf(']', at);
+        Assert.True(end > at, "the BindingPaths initialiser is not closed");
+
+        return Regex.Matches(source[at..end], "\"(?<name>\\w+)\"")
+            .Select(m => m.Groups["name"].Value)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    /// <summary>
     /// Every issue template must apply at least one label, and every label it names must be one this
     /// repository actually defines.
     /// </summary>

--- a/SysManager/SysManager.Tests/FilterBoxTests.cs
+++ b/SysManager/SysManager.Tests/FilterBoxTests.cs
@@ -1,0 +1,69 @@
+// SysManager · FilterBoxTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Helpers;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="FilterBoxes.IsFilterBindingPath"/> — which <c>Text</c> bindings Ctrl+F treats as
+/// the tab's filter box.
+/// </summary>
+/// <remarks>
+/// The visual-tree walk around it needs real WPF elements on an STA thread, so what is pinned here is the
+/// decision: given a binding path, is this the box. Which views bind which name is held by
+/// <c>ArchitectureTests.EveryFilterBox_BindsANameCtrlFRecognises</c> against the XAML.
+/// </remarks>
+public class FilterBoxTests
+{
+    [Theory]
+    [InlineData("FilterText")]
+    [InlineData("SearchText")]
+    [InlineData("SearchQuery")]
+    [InlineData("Filter")]
+    public void TheFourNamesTheViewsActuallyBind_AreRecognised(string path)
+        => Assert.True(FilterBoxes.IsFilterBindingPath(path));
+
+    [Fact]
+    public void PlainFilter_IsRecognised_BecauseTaskSchedulerBindsIt()
+    {
+        // Kept as its own test rather than only a row above, because this is the one that was missing.
+        // Three names looked like the whole set; a scan of every TextBox announced as a filter or search
+        // box found Task Scheduler binding plain "Filter", where Ctrl+F would have done nothing at all.
+        Assert.True(FilterBoxes.IsFilterBindingPath("Filter"));
+        Assert.Contains("Filter", FilterBoxes.BindingPaths);
+    }
+
+    [Theory]
+    [InlineData("FilterTextLength")]
+    [InlineData("SearchTextPlaceholder")]
+    [InlineData("HasFilterText")]
+    [InlineData("filtertext")]
+    [InlineData("Filters")]
+    public void ANameThatMerelyLooksLikeAFilter_IsNotRecognised(string path)
+    {
+        // Exact, ordinal match on purpose. A prefix or contains rule would let the caret land in a
+        // different box on the same tab, and a shortcut that focuses the wrong control is worse than one
+        // that does nothing — the user types a search into whatever had focus.
+        Assert.False(FilterBoxes.IsFilterBindingPath(path));
+    }
+
+    [Fact]
+    public void AnUnboundTextBox_IsNotAFilter()
+    {
+        // FindIn passes null through for a TextBox whose Text is not bound at all, which is most of them:
+        // an editable cell, a hosts-file entry, a new-variable name.
+        Assert.False(FilterBoxes.IsFilterBindingPath(null));
+        Assert.False(FilterBoxes.IsFilterBindingPath(""));
+    }
+
+    [Fact]
+    public void TheRecogniserHasNoDuplicatesAndNoBlanks()
+    {
+        // A duplicate would be harmless and a blank would match every unbound box, which is the one entry
+        // that could make Ctrl+F land somewhere arbitrary.
+        Assert.Equal(FilterBoxes.BindingPaths.Length, FilterBoxes.BindingPaths.Distinct(StringComparer.Ordinal).Count());
+        Assert.DoesNotContain("", FilterBoxes.BindingPaths);
+    }
+}

--- a/SysManager/SysManager/Helpers/FilterBoxes.cs
+++ b/SysManager/SysManager/Helpers/FilterBoxes.cs
@@ -1,0 +1,75 @@
+// SysManager · FilterBoxes
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Finds the filter or search box on whichever tab is open, so Ctrl+F can put the caret in it.
+/// </summary>
+/// <remarks>
+/// A tab states which of its text boxes is the filter by what that box binds, and there was no need to
+/// invent a marker: 12 of the tabs already bind one of four property names. Keying on the existing
+/// binding means no view had to change and no view model gained a member — focusing a control is a View
+/// concern, and routing it through a view model would have put UI manipulation where the MVVM rules say
+/// it must not go.
+/// <para><b>The name list was measured, not assumed.</b> Three names looked like the whole set until a
+/// scan of every <c>TextBox</c> whose accessible name mentions filtering or search turned up a twelfth
+/// tab — Task Scheduler binds plain <c>Filter</c>. A shortcut that works on eleven tabs and silently not
+/// the twelfth is worse than none, because the user learns it is unreliable, so
+/// <c>ArchitectureTests.EveryFilterBox_BindsANameCtrlFRecognises</c> holds the list against the views.</para>
+/// </remarks>
+internal static class FilterBoxes
+{
+    /// <summary>
+    /// The property names a filter or search box binds its <c>Text</c> to, across all of <c>Views/</c>.
+    /// </summary>
+    internal static readonly string[] BindingPaths = ["FilterText", "SearchText", "SearchQuery", "Filter"];
+
+    /// <summary>True when a <c>Text</c> binding path belongs to a filter or search box.</summary>
+    /// <remarks>
+    /// Exact match, not a prefix or a contains: <c>FilterTextLength</c> or <c>SearchTextPlaceholder</c>
+    /// would be a different property, and a shortcut landing in the wrong box is worse than one that does
+    /// nothing. Pure and <c>internal</c> so the decision is testable without a WPF element — creating a
+    /// <c>TextBox</c> needs an STA thread, and the part worth pinning is which paths count.
+    /// </remarks>
+    internal static bool IsFilterBindingPath(string? path) =>
+        path is not null && Array.Exists(BindingPaths, p => string.Equals(p, path, StringComparison.Ordinal));
+
+    /// <summary>
+    /// The first filter or search box under <paramref name="root"/> in visual-tree order, or null when the
+    /// open tab has none.
+    /// </summary>
+    /// <remarks>
+    /// First in tree order rather than a specific one, because a tab with two search boxes — Bulk Installer
+    /// has a catalog filter and a winget search — reads top to bottom, and the first is the one a user
+    /// pressing Ctrl+F means. Returning null is the normal case on the many tabs that do not filter
+    /// anything; the caller then leaves the keypress alone.
+    /// <para>Visual tree, not logical: the box sits inside templated cards and panels, and the logical tree
+    /// does not cross a <c>ControlTemplate</c>. Collapsed subtrees are skipped, so a filter inside a section
+    /// the tab is currently hiding cannot take the caret somewhere invisible.</para>
+    /// </remarks>
+    internal static TextBox? FindIn(DependencyObject? root)
+    {
+        if (root is null) return null;
+
+        if (root is TextBox box && IsFilterBindingPath(BoundPath(box))) return box;
+        if (root is UIElement { Visibility: not Visibility.Visible }) return null;
+
+        for (var i = 0; i < VisualTreeHelper.GetChildrenCount(root); i++)
+        {
+            if (FindIn(VisualTreeHelper.GetChild(root, i)) is { } found) return found;
+        }
+
+        return null;
+    }
+
+    /// <summary>The property path a <c>TextBox.Text</c> is bound to, or null when it is not bound.</summary>
+    private static string? BoundPath(TextBox box) =>
+        BindingOperations.GetBinding(box, TextBox.TextProperty)?.Path?.Path;
+}

--- a/SysManager/SysManager/MainWindow.xaml.cs
+++ b/SysManager/SysManager/MainWindow.xaml.cs
@@ -329,6 +329,12 @@ public partial class MainWindow : Window
     /// </remarks>
     private void Window_KeyDown(object sender, KeyEventArgs e)
     {
+        if (e.Key is Key.F && Keyboard.Modifiers is ModifierKeys.Control)
+        {
+            FocusTheFilterBox(e);
+            return;
+        }
+
         if (e.Key is not (Key.Escape or Key.F5)) return;
         if (DataContext is not MainWindowViewModel vm) return;
         if (MainWindowViewModel.AcceleratorCommand(vm.SelectedNav, e.Key) is not { } command) return;
@@ -341,6 +347,27 @@ public partial class MainWindow : Window
         if (e.Key is Key.F5 && !command.CanExecute(null)) return;
 
         command.Execute(null);
+        e.Handled = true;
+    }
+
+    /// <summary>
+    /// Ctrl+F puts the caret in the open tab's filter box, and selects what is already there.
+    /// </summary>
+    /// <remarks>
+    /// <c>SelectAll</c> so a second Ctrl+F replaces the previous search rather than appending to it, which
+    /// is what the same key does in a browser and an editor.
+    /// <para>Only marked handled when a box was actually found. On the many tabs that filter nothing the
+    /// keypress is left alone, so a control that wants Ctrl+F for itself still gets it — and nothing has to
+    /// maintain a list of which tabs those are.</para>
+    /// <para><c>ContentHost</c> is the element the shell binds the live tab into, so the search starts at
+    /// the open tab and cannot reach a filter box on a tab that is not on screen.</para>
+    /// </remarks>
+    private void FocusTheFilterBox(KeyEventArgs e)
+    {
+        if (Helpers.FilterBoxes.FindIn(ContentHost) is not { } box) return;
+
+        box.Focus();
+        box.SelectAll();
         e.Handled = true;
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.86.0</Version>
-    <FileVersion>1.86.0.0</FileVersion>
-    <AssemblyVersion>1.86.0.0</AssemblyVersion>
+    <Version>1.87.0</Version>
+    <FileVersion>1.87.0.0</FileVersion>
+    <AssemblyVersion>1.87.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
The Ctrl+F half of #1549. F5 shipped in #2218; Escape turned out to be already implemented. Mnemonics are the last piece and are not here — see the end.

## No seam, and deliberately so

12 tabs already state which of their text boxes is the filter, by what its `Text` binds. So `Helpers/FilterBoxes` walks the visual tree under `ContentHost` — the element the shell binds the live tab into — for the first `TextBox` bound to one of those names, then focuses and selects it.

Nothing was added to any view model. **Focusing a control is a View concern**, and routing it through a VM would have put UI manipulation exactly where this repo's MVVM rules forbid it, in order to say something the views already say. No view changed either.

`SelectAll` so a second press replaces the search rather than appending — what the key does in a browser. The event is marked handled **only when a box was found**, so on the many tabs that filter nothing the keypress is left for anything else that wants it, and nothing has to maintain a list of which tabs those are. A box inside a collapsed section is skipped, so the caret cannot land off screen.

## My first name list was short, and the probe caught it

`FilterText`, `SearchText`, `SearchQuery` looked like the whole set — that is what a grep for the obvious names returns. Before writing the guard I scanned **every** `TextBox` whose accessible name mentions filtering or search, and found a twelfth tab:

```
TaskSchedulerView    binds 'Filter'    name 'Filter tasks by name or path'
```

Ctrl+F would have silently done nothing on Task Scheduler. That is the failure mode worth avoiding above all others here: **a shortcut that works on eleven tabs out of twelve is worse than none**, because the user learns it is unreliable and stops reaching for it. Mutation 1 of the proof is exactly this defect, so it cannot come back.

## The guard is non-circular by construction

`EveryFilterBox_BindsANameCtrlFRecognises` decides "is this a filter box" from the **accessible name**, which is independent of the binding path it then checks. Both directions fail:

- a filter-named box bound to an unrecognised path → Ctrl+F silently skips that tab
- a recognised path on a box whose accessible name does not describe filtering → either the name is wrong or Ctrl+F will land somewhere it should not

It reads the recogniser out of `FilterBoxes.cs` rather than hard-coding it, so a name added to the helper without a view using it, or used by a view without being in the helper, both surface. Vacuity floor at 13 boxes across 12 views (Bulk Installer has two: a catalog filter and a winget search).

## Exact matching, on purpose

Ordinal equality, not prefix and not case-insensitive. `FilterTextLength`, `SearchTextPlaceholder` and `HasFilterText` are different properties, and **a shortcut that focuses the wrong control is worse than one that does nothing** — the user types their search into whatever had focus. Mutations 2 and 3 cover both loosenings.

## Proof — 6 mutations, all RED in the named test, GREEN after

| Mutation | Caught by |
|---|---|
| the recogniser drops plain `Filter` | `EveryFilterBox_BindsANameCtrlFRecognises`, `PlainFilter_IsRecognised_BecauseTaskSchedulerBindsIt` |
| the match becomes a prefix | `ANameThatMerelyLooksLikeAFilter_IsNotRecognised` |
| the match becomes case-insensitive | same |
| the shell binds Alt+F instead of Ctrl+F | `EveryFilterBox_BindsANameCtrlFRecognises` |
| the lookup is rooted at the window, not the tab host | same |
| a filter box's accessible name stops describing what it is for | same |

Three files restored byte-for-byte with a SHA256 check after every run; tree re-verified green at the end.

## What is tested versus guarded, and why

The visual-tree walk needs real WPF elements on an STA thread, so what the unit tests pin is the **decision** — `IsFilterBindingPath`, including the near-miss names it must reject — and the walk's contract is held by source-text assertions plus the XAML guard. Stated rather than papered over: creating a `TextBox` in this suite would mean an STA helper, and three pumped-dispatcher variants have already broken in this repo in ways only CI caught.

## Verification

Four projects build Release at **0 errors / 0 warnings**; `dotnet format --verify-no-changes` clean on all four. Unit suite **5402 passing** (13 added). Protocol I with real greps: no debug code, no generic catch, author headers on every touched code file, leak scan over the diff plus both new files — 47 patterns, 0 hits.

Version 1.87.0; CHANGELOG, README, ARCHITECTURE, SECURITY updated here.

## Last piece of #1549

**Mnemonics** (`Content="_Scan"` so Alt+S works). WPF renders these natively with no layout change, but they put an underscore under a letter in every primary button caption — a visible change to text the user reads, on ~40 toolbars. That is a design decision rather than a mechanical one, so it wants a look before it ships rather than arriving in a batch.

## Deferred to the secondary workstation

Pressing Ctrl+F on a few real tabs and watching the caret land in the right box — particularly Bulk Installer, where two search boxes mean "the first in tree order" is a claim about reading order that only looks right on screen.
