### PR TITLE
fix: keep the informational signature check off the network

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -296,6 +296,14 @@ Key services:
 - `Helpers/Authenticode` — the two Authenticode operations, defined once: `ReadSigner`
   (three-way `Signed`/`Unsigned`/`Unreadable`, never throws) and `ValidateChain` (one strict
   policy — `ExcludeRoot`, `NoFlag`, fail-closed — with the revocation mode as a parameter).
+  `PolicyFor` builds that policy, and it exists because **`Offline` revocation alone does not
+  make a chain build local**: a missing intermediate is still fetched over AIA under a separate
+  switch that defaults to on, so a caller that chose `Offline` to avoid a request per file made
+  one anyway and, with no network, waited out `UrlRetrievalTimeout` for each. The two settings
+  are therefore derived from the one argument rather than offered separately —
+  `DisableCertificateDownloads` is on exactly when revocation is `Offline` — so the scanning
+  callers stay local and the two fail-closed gates keep the fetch that lets a genuine signature
+  validate.
   Deliberately holds no policy about what an answer MEANS: an unsigned file is fatal for the
   Ookla download and expected for our own build, so each caller keeps that decision. Two
   calls rather than one because both fail-closed callers compare the subject BEFORE building

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.87.1] - 2026-09-10
+
+**Opening the Startup Manager no longer reaches out to the internet.** The Signature column checks
+each program's certificate against your own machine, and it was written to do that without asking any
+server anything — but Windows has a second, separate switch for that, and it was left at its default.
+So on a PC that had not seen a particular publisher's certificate before, checking the column could
+quietly fetch part of it, and on a PC with no connection at all it could sit and wait for that fetch to
+time out. It now asks nothing and answers immediately.
+
+### Fixed
+
+- **The signature check on the Startup Manager makes no network request.** Turning off the revocation
+  lookup, which the tab already did, does not turn off certificate downloads — that is a separate
+  setting, and it defaults to on. Both are now decided together, so a check that was chosen to stay
+  local actually stays local.
+- On a machine with no network, that column no longer waits out a download timeout per unfamiliar
+  publisher before it can draw.
+- The two places that verify a single file and *should* use the network — the in-app updater checking
+  a downloaded build, and the check on the third-party speed-test tool before it runs — keep it. There,
+  fetching a missing intermediate certificate is what lets a genuine signature verify, and the wait is
+  part of an action you asked for.
+
 ## [1.87.0] - 2026-09-10
 
 **Ctrl+F now jumps to the search box.** On the twelve tabs that have one — processes, services,

--- a/README.md
+++ b/README.md
@@ -493,7 +493,10 @@ a confirmation before it runs:
     itself; the tooltip says so in as many words. Amber is reserved for a file that *is* signed and
     whose signature does not hold up — the one case here worth a second look.
   - The check runs offline, against certificates already on your PC, so opening the tab never waits
-    on the network.
+    on the network — it downloads nothing, not even a missing piece of a certificate. The cost of
+    that is honest rather than hidden: if your PC has never seen a particular publisher's
+    certificate, the column says **Check failed** instead of fetching the rest and confirming it.
+    The tooltip says Windows could not confirm the publisher, which is exactly what happened.
 - Sort by name, publisher, location, safety, status, signature, or startup impact via clickable column
   headers
 - Plain-language description for recognised programs (from the built-in database) instead

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -111,6 +111,18 @@ What the app can and cannot do by design:
 - **External CLI downloads**: the Ookla speed-test CLI is downloaded from
   `install.speedtest.net` the first time it's used. If that URL changes,
   the feature fails safely rather than substituting an alternative.
+- **Signature checks on lists, and what they cost**: the Startup Manager's Signature column reads each
+  program's Authenticode certificate and builds its chain, which is a different job from the two gates
+  above. Those verify one file at a moment you asked for something, so they use the network: they look up
+  revocation and they will fetch a missing intermediate certificate, because that is what lets a genuine
+  signature verify. A column over every startup entry on the machine cannot do either — it would mean a
+  request per file, and on a disconnected PC a timeout per file — so it is restricted to what is already
+  on your machine, both for revocation and for certificate downloads. The two settings are decided
+  together in one place, because turning off only the first still leaves the second fetching. The
+  trade-off is stated plainly: a certificate revoked since your PC last refreshed its lists still reads
+  as verified, and a signed file whose issuer your PC has never seen reads as "Check failed" rather than
+  being confirmed by a download. That is the right bias for a column that informs, and the wrong one for
+  a gate that admits code, which is why they differ.
 - **Local diagnostic log**: SysManager keeps 14 days of rolling log files in
   `%LocalAppData%\SysManager\logs`. They never leave the machine on their own —
   there is no upload path. Your Windows user name is replaced with `[user]` on

--- a/SysManager/SysManager.Tests/AuthenticodeTests.cs
+++ b/SysManager/SysManager.Tests/AuthenticodeTests.cs
@@ -100,27 +100,66 @@ public class AuthenticodeTests
     // ── ValidateChain: the policy, pinned against the source ──
 
     /// <summary>
-    /// The one chain policy this app uses is the strict one, and it fails closed.
+    /// The one chain policy this app uses is the strict one: revocation honoured, root excluded from it,
+    /// no verification flag relaxed.
     /// </summary>
     /// <remarks>
-    /// Asserted against the source rather than by execution, deliberately and with the reason stated:
-    /// producing a signed binary whose chain can be made to fail on demand needs a test certificate and
-    /// signtool. What CAN be checked mechanically is that the policy is the strict one — revocation
-    /// honoured, root excluded from it, no verification flags relaxed — and that a failed build returns
-    /// false rather than falling through.
+    /// Asserted on the policy object itself rather than on the text of the method that used to build it.
+    /// The previous version of this guard matched source lines, and it would have passed unchanged through
+    /// the defect it now covers: a setting that is simply absent leaves no line to fail on.
+    /// </remarks>
+    [Theory]
+    [InlineData(X509RevocationMode.Online)]
+    [InlineData(X509RevocationMode.Offline)]
+    public void EveryPolicy_IsTheStrictOne(X509RevocationMode revocation)
+    {
+        var policy = Authenticode.PolicyFor(revocation);
+
+        Assert.Equal(revocation, policy.RevocationMode);
+        Assert.Equal(X509RevocationFlag.ExcludeRoot, policy.RevocationFlag);
+        Assert.Equal(X509VerificationFlags.NoFlag, policy.VerificationFlags);
+    }
+
+    /// <summary>
+    /// The offline policy really is offline: it does not download a missing intermediate certificate
+    /// either.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="X509RevocationMode.Offline"/> suppresses the CRL and OCSP fetch and nothing else, so a
+    /// chain build under it still followed the Authority Information Access extension and downloaded any
+    /// intermediate the local store did not have. That is a network request from a tab the user merely
+    /// opened, and on a machine with no network it is a wait per unrecognised issuer — the exact stall the
+    /// offline mode was chosen to avoid. The pairing is the whole point of
+    /// <see cref="Authenticode.PolicyFor"/>, so it is pinned in both directions: the fail-closed gates
+    /// must keep the download, because there a missing intermediate is what a legitimate signature needs
+    /// fetched before it can validate.
+    /// </remarks>
+    [Fact]
+    public void OnlyTheOnlinePolicy_MayDownloadACertificate()
+    {
+        Assert.True(Authenticode.PolicyFor(X509RevocationMode.Offline).DisableCertificateDownloads);
+        Assert.False(Authenticode.PolicyFor(X509RevocationMode.Online).DisableCertificateDownloads);
+    }
+
+    /// <summary>
+    /// The chain build uses that policy, and a build that fails returns false rather than falling through.
+    /// </summary>
+    /// <remarks>
+    /// Still asserted against the source, deliberately and with the reason stated: producing a signed
+    /// binary whose chain can be made to fail on demand needs a test certificate and signtool. What CAN be
+    /// checked mechanically is that the policy above is the one handed to the chain, and that the failure
+    /// path returns.
     /// <para>This guard replaces the equivalent assertions that used to live inside
     /// <c>UpdateServiceAuthenticodeTests.VerifyAuthenticode_PinsThePublisherAndBuildsAChain</c>, which went
     /// RED the moment the chain build moved out of that method — correctly, and it is the reason this one
     /// exists rather than the assertions simply being dropped.</para>
     /// </remarks>
     [Fact]
-    public void ValidateChain_UsesTheStrictPolicy_AndFailsClosed()
+    public void ValidateChain_BuildsWithThatPolicy_AndFailsClosed()
     {
         var method = HelperMethodSource("internal static bool ValidateChain");
 
-        Assert.Contains("chain.ChainPolicy.RevocationMode = revocation", method, StringComparison.Ordinal);
-        Assert.Contains("X509RevocationFlag.ExcludeRoot", method, StringComparison.Ordinal);
-        Assert.Contains("X509VerificationFlags.NoFlag", method, StringComparison.Ordinal);
+        Assert.Contains("ChainPolicy = PolicyFor(revocation)", method, StringComparison.Ordinal);
         Assert.Contains("chain.Build(certificate)", method, StringComparison.Ordinal);
         Assert.Contains("return false", method, StringComparison.Ordinal);
     }
@@ -159,10 +198,20 @@ public class AuthenticodeTests
         Assert.True(start >= 0, $"'{signature}' not found in Helpers/Authenticode.cs — this test would "
             + "otherwise assert nothing at all");
 
-        // To the end of the file: ValidateChain is the last member, and a slice that ran to a marker the
-        // file no longer contains would silently be empty.
-        var method = source[start..];
-        Assert.True(method.Length > 200, $"the slice from '{signature}' is {method.Length} chars — not a method body");
+        // To the next member declared at the same indentation, or the end of the file when the requested
+        // one is last. Slicing to the end unconditionally was fine while ValidateChain WAS last, and
+        // stopped being fine the moment a member was added after it: the slice then also covered that
+        // member's body, and an assertion could pass on text belonging to a method it was not about.
+        var body = source[start..];
+        var next = body.IndexOf("\n    internal static ", 1, StringComparison.Ordinal);
+        var method = next > 0 ? body[..next] : body;
+
+        // Doc comments out, for the same reason: every assertion below names a construct, and this file's
+        // prose explains those constructs at length. A guard that can be satisfied by the sentence
+        // describing the code instead of the code is not a guard.
+        method = string.Join('\n', method.Split('\n').Where(l => !l.TrimStart().StartsWith("///", StringComparison.Ordinal)));
+
+        Assert.True(method.Length > 200, $"the slice from '{signature}' is {method.Length} chars of code — not a method body");
         return method;
     }
 

--- a/SysManager/SysManager/Helpers/Authenticode.cs
+++ b/SysManager/SysManager/Helpers/Authenticode.cs
@@ -91,7 +91,8 @@ internal static class Authenticode
     /// <c>Online</c> for the two fail-closed gates, which verify one file at a moment when a network
     /// request is acceptable. Anything scanning many files, or running on the assumption that the machine
     /// may be offline, passes <c>Offline</c> — a local-first app must not make a revocation request per
-    /// file and must not hang when there is no network.
+    /// file and must not hang when there is no network. This one argument settles certificate downloads
+    /// too; see <see cref="PolicyFor"/> for why the two cannot be chosen separately.
     /// </param>
     /// <param name="statuses">
     /// The comma-separated chain statuses when validation fails, for the caller's log. Empty on success.
@@ -103,10 +104,7 @@ internal static class Authenticode
     /// </remarks>
     internal static bool ValidateChain(X509Certificate2 certificate, X509RevocationMode revocation, out string statuses)
     {
-        using var chain = new X509Chain();
-        chain.ChainPolicy.RevocationMode = revocation;
-        chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
-        chain.ChainPolicy.VerificationFlags = X509VerificationFlags.NoFlag;
+        using var chain = new X509Chain { ChainPolicy = PolicyFor(revocation) };
 
         if (chain.Build(certificate))
         {
@@ -117,4 +115,36 @@ internal static class Authenticode
         statuses = string.Join(", ", chain.ChainStatus.Select(s => s.Status.ToString()));
         return false;
     }
+
+    /// <summary>
+    /// The chain policy for a given revocation mode: strict verification, and network access allowed only
+    /// where the caller has already accepted it.
+    /// </summary>
+    /// <remarks>
+    /// <b>Certificate downloads travel with the revocation mode, and this is the reason the method
+    /// exists.</b> <see cref="X509RevocationMode.Offline"/> suppresses the CRL and OCSP fetch, and it is
+    /// easy to read that as "this chain build does not touch the network". It is not: when an intermediate
+    /// certificate is missing from the local store, the chain engine follows the Authority Information
+    /// Access extension and downloads it, under a separate switch that defaults to allowing it. So a caller
+    /// that chose <c>Offline</c> because it is scanning a whole tab's worth of files still made a request
+    /// per unrecognised issuer — and on a machine with no network, waited out
+    /// <see cref="X509ChainPolicy.UrlRetrievalTimeout"/> for each one, which is the stall <c>Offline</c>
+    /// was picked to avoid.
+    /// <para>The two settings are therefore derived from one another rather than exposed as a second
+    /// parameter: a caller passing <c>Offline</c> has already said it cannot afford a network request, and
+    /// a caller passing <c>Online</c> is one of the two fail-closed gates verifying a single file at a
+    /// moment when a request is expected — there, downloading a missing intermediate is what lets a
+    /// legitimate signature validate.</para>
+    /// <para>The cost on the offline path is that a signed file whose issuer is not cached locally now
+    /// fails to validate where it previously might have succeeded after a download. That is the honest
+    /// answer for an informational column: the tooltip says Windows could not confirm the publisher, which
+    /// is exactly what happened, and it says it immediately instead of after a timeout.</para>
+    /// </remarks>
+    internal static X509ChainPolicy PolicyFor(X509RevocationMode revocation) => new()
+    {
+        RevocationMode = revocation,
+        RevocationFlag = X509RevocationFlag.ExcludeRoot,
+        VerificationFlags = X509VerificationFlags.NoFlag,
+        DisableCertificateDownloads = revocation is X509RevocationMode.Offline,
+    };
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.87.0</Version>
-    <FileVersion>1.87.0.0</FileVersion>
-    <AssemblyVersion>1.87.0.0</AssemblyVersion>
+    <Version>1.87.1</Version>
+    <FileVersion>1.87.1.0</FileVersion>
+    <AssemblyVersion>1.87.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
## Problem

`X509RevocationMode.Offline` suppresses the CRL and OCSP fetch, and it is easy to read that as "this chain build does not touch the network". It is not. When an intermediate certificate is missing from the local store, the chain engine follows the Authority Information Access extension and downloads it, governed by `X509ChainPolicy.DisableCertificateDownloads` — a separate switch that defaults to allowing the download. Nothing in this repo set it:

```
$ grep -rn "DisableCertificateDownloads|UrlRetrievalTimeout" --include=*.cs SysManager/
(no matches)
```

So the Startup Manager's Signature column, which passes `Offline` precisely *because* it runs over every startup entry on the machine, still made a network request per unfamiliar issuer — and on a PC with no connection, waited out `UrlRetrievalTimeout` (15s by default) for each one before the column could draw.

The docs already claimed the opposite. `README.md`:

> The check runs offline, against certificates already on your PC, so opening the tab never waits on the network.

`ARCHITECTURE.md` made the same claim, reasoning that `Online` "would mean a revocation request per file and, with no network, a wait per file" — true of revocation, and only half the story. This change makes both statements true instead of aspirational.

## Fix

`Authenticode.PolicyFor(revocation)` now builds the one chain policy, and derives the download setting from the revocation mode rather than exposing it as a second parameter:

```csharp
internal static X509ChainPolicy PolicyFor(X509RevocationMode revocation) => new()
{
    RevocationMode = revocation,
    RevocationFlag = X509RevocationFlag.ExcludeRoot,
    VerificationFlags = X509VerificationFlags.NoFlag,
    DisableCertificateDownloads = revocation is X509RevocationMode.Offline,
};
```

Derived, not separate, because the two are the same decision: a caller that chose `Offline` has already said it cannot afford a network request per file. The two fail-closed gates — the in-app updater checking a downloaded build, and the check on the Ookla CLI before it runs — pass `Online` and keep the download, because there a missing intermediate is exactly what a genuine signature needs fetched before it can validate, and the wait belongs to an action the user asked for.

There is one implementation, verified rather than assumed:

```
$ grep -rn "new X509Chain|CreateFromSignedFile" --include=*.cs SysManager/SysManager/
Helpers/Authenticode.cs:73:  var signer = X509Certificate.CreateFromSignedFile(filePath);
Helpers/Authenticode.cs:107: using var chain = new X509Chain { ChainPolicy = PolicyFor(revocation) };
```
(plus doc-comment references)

## Trade-off, stated rather than buried

A signed file whose issuer is not cached locally now fails to validate where it previously might have succeeded after a download, so the column reads **Check failed** rather than confirming it. That is the honest answer for an informational column: the tooltip already says Windows could not confirm the publisher, which is precisely what happened — and it says it immediately instead of after a timeout. It is the wrong bias for a gate that admits code, which is why the gates differ. Documented in `SECURITY.md` and in the README bullet.

## The guard was weaker than it looked

`ValidateChain_UsesTheStrictPolicy_AndFailsClosed` asserted source lines:

```csharp
Assert.Contains("chain.ChainPolicy.RevocationMode = revocation", method, StringComparison.Ordinal);
Assert.Contains("X509RevocationFlag.ExcludeRoot", method, StringComparison.Ordinal);
```

It would have passed unchanged through this defect, because a setting that is simply **absent** leaves no line to fail on. Tightened in place rather than duplicated: the policy assertions now run against the real `X509ChainPolicy` object, in both directions, and only the wiring and the fail-closed return are still checked against source (producing a signed binary whose chain fails on demand needs a test certificate and signtool — stated in the test's own remarks).

Two further hazards in that test's helper, fixed while there:

- `HelperMethodSource` sliced **to the end of the file** with the comment "ValidateChain is the last member". Adding `PolicyFor` after it made that false, and the slice would have covered a method the assertions were not about.
- The slice included the next member's doc comment, which is prose describing the very constructs being asserted. Doc comments are now stripped, so no assertion can be satisfied by the sentence explaining the code.

## Red before, green after

`D:\rel-tmp\aia-proof.py` — three mutations, rebuild and re-run per mutation, restore hash-verified:

| Mutation | Result |
|---|---|
| baseline | GREEN (10 / 10) |
| 1. drop `DisableCertificateDownloads` (the shipped pre-fix state) | **RED** (1 failed) |
| 2. invert it to `Online` (proves the direction is asserted, not just non-default) | **RED** (1 failed) |
| 3. build the policy inline again (proves the wiring guard is not vacuous) | **RED** (1 failed) |
| restored | GREEN (10 / 10) |

`RESTORE VERIFIED`.

## Verification

- `dotnet build` — app and unit projects, **0 warnings, 0 errors**
- Unit suite, run twice (once after the doc edits): **5405 passed, 0 failed**
- `dotnet format --verify-no-changes` — all four projects, exit 0
- Leak scan — all 43 current terms against the 15398-byte diff, 0 hits, floor asserted so the scan cannot pass on an empty diff
- Docs updated in this PR: `CHANGELOG.md`, `README.md`, `SECURITY.md` (new "Signature checks on lists, and what they cost" bullet — the column had no `SECURITY.md` coverage at all), `ARCHITECTURE.md`

Version bumped to 1.87.1.
