### PR TITLE
feat: verify the publisher of a running process

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -314,7 +314,25 @@ Key services:
 - `DiskAnalyzerService` — folder-level space breakdown with progress
   reporting and system-path skipping.
 - `ProcessManagerService` — enumerate running processes, kill by PID,
-  open file location.
+  open file location. A `VerifySignatures` post-pass over the finished snapshot fills the
+  Signature column from the running image's certificate, through the shared
+  `Helpers/SignatureVerdict`. **A per-refresh cache is sufficient on a tab that polls**, and
+  the reason is the `knownPids` argument: `FilePath` is only read for a PID the caller has
+  not seen, and `ProcessManagerViewModel.ReconcileInto` keeps a surviving row's identity
+  fields — so the first refresh pays for every distinct image and each later one pays only
+  for processes that actually started. Keyed on the path, because one browser runs as a
+  dozen processes from one executable. The signature pair MUST stay in `ReconcileInto`'s
+  identity group: a fresh entry for a tracked PID carries no path, so its verdict is
+  `Unknown`, and copying it across would blank the column one tick after it appeared.
+- `Helpers/SignatureVerdict` — the file-path-to-three-state answer both the Startup Manager
+  and the Process Manager render, plus the sentence shown on hover. Separate from
+  `Helpers/Authenticode` on purpose: that type answers only the mechanical questions and
+  holds no policy, because the two fail-closed gates disagree with each other on what an
+  unsigned file means. This one carries exactly one policy — the informational one, for
+  columns that describe many files and admit no code: unsigned is ordinary, revocation is
+  offline, every answer comes with a readable sentence. A gate adopting those would stop
+  being a gate. Shared rather than copied so two tabs cannot describe one certificate in
+  two different sentences.
 - `WindowsFeaturesService` — list, enable, disable Windows optional features
   via `Get-WindowsOptionalFeature` / `Enable-WindowsOptionalFeature` PowerShell.
 - `UninstallerService` — winget-based uninstall + registry UninstallString

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.88.0] - 2026-09-10
+
+**The Process Manager now tells you whether Windows can confirm who made each running program.**
+The Safety column beside it recognises a process by its name, which is the thing anything can copy:
+a file called `svchost.exe` sitting in your downloads folder gets the same reassuring label as the
+real one. The new Signature column asks the file itself, reading the certificate inside it, and says
+"Verified", "Unsigned", or "Check failed" in as many words. It is the same question the Startup
+Manager already answers, now on the tab where you go looking when something is eating your CPU.
+
+### Added
+
+- **A Signature column in the Process Manager**, read from the running program's own certificate
+  rather than from anything it says about itself. Hovering explains the result in a sentence —
+  "Windows can confirm this really comes from Google LLC" — instead of leaving you to interpret a
+  colour.
+- **Unsigned is grey and says so kindly**, exactly as on the Startup Manager: most ordinary programs
+  are unsigned, and so is SysManager, so a warning colour on all of them would turn the column into
+  noise. Amber is kept for a file that *is* signed and whose signature does not hold up.
+- **A process whose file Windows will not let us read gets no badge at all** — that is most system
+  processes unless you run as administrator. Nothing was checked, so nothing is claimed.
+- The check costs the tab nothing on an ordinary refresh. Only processes that have just appeared are
+  looked at, and several processes from one program are answered once, so a browser running as a
+  dozen processes is one check rather than twelve.
+
+### Changed
+
+- The wording and the three states behind the Signature column now live in one place shared with the
+  Startup Manager, so the two tabs cannot end up describing the same certificate differently.
+
 ## [1.87.1] - 2026-09-10
 
 **Opening the Startup Manager no longer reaches out to the internet.** The Signature column checks

--- a/README.md
+++ b/README.md
@@ -573,6 +573,20 @@ a confirmation before it runs:
 - **Safety column** — every process is labelled **Windows**, **Known app** or
   **Not recognised**, with a hover explanation of what that means for ending it.
   Sortable, so everything unrecognised can be grouped together at a glance
+- **Signature column** — whether Windows can confirm who made the running program, read
+  from the file's own certificate. This is a different question from Safety, and the
+  difference is the point: Safety recognises a process by **name**, so a copy of
+  `svchost.exe` sitting in a downloads folder inherits the real one's label. The
+  certificate belongs to the file. Shows **Verified** ("Windows can confirm this really
+  comes from Google LLC" on hover), **Unsigned**, or **Check failed**
+  - **Unsigned is grey, not a warning** — most ordinary programs are unsigned, and so is
+    SysManager itself. Amber is kept for a file that *is* signed and whose signature does
+    not hold up, which is the one case worth a second look
+  - Processes whose file Windows will not let SysManager read — most system processes,
+    unless you run as administrator — get no badge at all rather than a guess
+  - Checked offline against certificates already on your PC, and only for processes that
+    have just appeared, so a tab that refreshes every second does not re-check the same
+    programs or reach for the network
 - Kill process with confirmation dialog, and the warning matches the real cost.
   Processes Windows genuinely cannot survive losing (`winlogon`, `csrss`, `lsass`, …)
   are refused outright. Security and servicing processes (Defender's engine, Windows

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.87.x   | :white_check_mark: |
-| < 1.87   | :x:                |
+| 1.88.x   | :white_check_mark: |
+| < 1.88   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a
@@ -111,13 +111,14 @@ What the app can and cannot do by design:
 - **External CLI downloads**: the Ookla speed-test CLI is downloaded from
   `install.speedtest.net` the first time it's used. If that URL changes,
   the feature fails safely rather than substituting an alternative.
-- **Signature checks on lists, and what they cost**: the Startup Manager's Signature column reads each
-  program's Authenticode certificate and builds its chain, which is a different job from the two gates
-  above. Those verify one file at a moment you asked for something, so they use the network: they look up
-  revocation and they will fetch a missing intermediate certificate, because that is what lets a genuine
-  signature verify. A column over every startup entry on the machine cannot do either — it would mean a
-  request per file, and on a disconnected PC a timeout per file — so it is restricted to what is already
-  on your machine, both for revocation and for certificate downloads. The two settings are decided
+- **Signature checks on lists, and what they cost**: the Signature columns in the Startup Manager and
+  the Process Manager read each program's Authenticode certificate and build its chain, which is a
+  different job from the two gates above. Those verify one file at a moment you asked for something, so
+  they use the network: they look up revocation and they will fetch a missing intermediate certificate,
+  because that is what lets a genuine signature verify. A column over every startup entry, or every
+  program running right now, cannot do either — it would mean a request per file, and on a disconnected
+  PC a timeout per file — so it is restricted to what is already on your machine, both for revocation
+  and for certificate downloads. The two settings are decided
   together in one place, because turning off only the first still leaves the second fetching. The
   trade-off is stated plainly: a certificate revoked since your PC last refreshed its lists still reads
   as verified, and a signed file whose issuer your PC has never seen reads as "Check failed" rather than

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -7126,6 +7126,56 @@ public partial class ArchitectureTests
         }
     }
 
+    /// <summary>
+    /// The Process Manager's signature pill is rendered, and the snapshot pipeline actually fills it in.
+    /// </summary>
+    /// <remarks>
+    /// The sibling of the Startup guard above, for the same column on the other tab, and it exists because
+    /// every weakness that one had to be mutated into existence applies here identically.
+    /// <list type="bullet">
+    /// <item><description><b>A name check would not work.</b> <c>Signature</c> is bound five times inside one
+    /// cell template — background, border brush, dot fill, label text, sort path — and
+    /// <c>SignatureDetail</c> twice, as tooltip and as the visibility source. So
+    /// <c>xaml.Contains("{Binding Signature")</c> stays green with any four of the five deleted. What the
+    /// pill cannot exist without is the label converter, which nothing else in this view uses, and the
+    /// detail serving as an actual tooltip.</description></item>
+    /// <item><description><b>Written-or-shown does not reach it.</b>
+    /// <see cref="EveryModelProperty_IsEitherWrittenOrShown"/> accepts a property that is merely assigned,
+    /// and <c>VerifySignatures</c> assigns this one — being assigned is what makes an unbound column a
+    /// defect rather than dead code.</description></item>
+    /// <item><description><b>Every unit test calls the post-pass directly.</b> Deleting
+    /// <c>VerifySignatures(results)</c> from <c>Snapshot</c> leaves all eight of them green while the column
+    /// renders nothing on a real machine, which is the unbound-surface defect one level up.</description></item>
+    /// </list>
+    /// </remarks>
+    [Fact]
+    public void TheProcessSignaturePill_IsRendered_AndTheSnapshotFillsItIn()
+    {
+        var appDir = FindAppProjectDir();
+        var view = XmlComment().Replace(
+            File.ReadAllText(Path.Combine(appDir, "Views", "ProcessManagerView.xaml")), string.Empty);
+        var service = File.ReadAllText(Path.Combine(appDir, "Services", "ProcessManagerService.cs"));
+
+        foreach (var (fragment, why) in new[]
+                 {
+                     ("Converter={StaticResource SigTrustText}",
+                      "the words the user reads — nothing else in this view uses that converter, so its "
+                      + "absence means the pill is gone"),
+                     ("ToolTip=\"{Binding SignatureDetail}\"",
+                      "the sentence explaining the pill; without it a coloured chip states a verdict and "
+                      + "never says what it means"),
+                 })
+        {
+            Assert.True(view.Contains(fragment, StringComparison.Ordinal),
+                $"ProcessManagerView.xaml no longer contains '{fragment}' — {why}. Every refresh still pays "
+                + "to verify each new process's certificate, so the work is being done and thrown away.");
+        }
+
+        var snapshot = SliceMethod(service,
+            "private IReadOnlyList<ProcessEntry> Snapshot(IReadOnlySet<int>? knownPids, CancellationToken ct)");
+        Assert.Contains("VerifySignatures(results)", snapshot, StringComparison.Ordinal);
+    }
+
     /// <summary>An <c>entry.Property =</c> assignment, capturing the property name.</summary>
     /// <remarks>
     /// Scoped to the <c>entry</c> local the post-passes all use, rather than any member assignment, so an

--- a/SysManager/SysManager.Tests/AuthenticodeTests.cs
+++ b/SysManager/SysManager.Tests/AuthenticodeTests.cs
@@ -191,6 +191,35 @@ public class AuthenticodeTests
         Assert.Contains("X509RevocationMode.Online", call, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// The informational path asks for OFFLINE revocation, and that is not a detail.
+    /// </summary>
+    /// <remarks>
+    /// The other half of <see cref="EveryFailClosedGate_AsksForOnlineRevocation"/>. Both the Startup Manager
+    /// and the Process Manager column run over every relevant file on the machine, so <c>Online</c> here
+    /// would mean a revocation fetch per file, and on a machine with no network a wait per file, in a tab
+    /// the user just opened. Changing it compiles, passes every other test, and is visible only as a tab
+    /// that takes seconds to populate on a train — so it is asserted.
+    /// <para>Lives here, next to the gate guard, rather than in one tab's test file: since the verdict was
+    /// shared this is one decision covering two tabs, and the copy that used to sit in
+    /// <c>StartupSignatureTests</c> failed with "move this guard with the code" the moment the chain build
+    /// moved. That is what it was for.</para>
+    /// </remarks>
+    [Fact]
+    public void TheInformationalPath_AsksForOfflineRevocation_SoItDoesNotFetchPerFile()
+    {
+        var source = File.ReadAllText(Path.Combine(AppProjectDir(), "Helpers", "SignatureVerdict.cs"));
+
+        var at = source.IndexOf("Authenticode.ValidateChain", StringComparison.Ordinal);
+        Assert.True(at >= 0,
+            "SignatureVerdict no longer validates a chain — move this guard with the code rather than "
+            + "deleting it");
+
+        var call = source[at..Math.Min(source.Length, at + 220)];
+        Assert.Contains("X509RevocationMode.Offline", call, StringComparison.Ordinal);
+        Assert.DoesNotContain("X509RevocationMode.Online", call, StringComparison.Ordinal);
+    }
+
     private static string HelperMethodSource(string signature)
     {
         var source = File.ReadAllText(Path.Combine(AppProjectDir(), "Helpers", "Authenticode.cs"));

--- a/SysManager/SysManager.Tests/ProcessSignatureTests.cs
+++ b/SysManager/SysManager.Tests/ProcessSignatureTests.cs
@@ -1,0 +1,221 @@
+// SysManager · ProcessSignatureTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for the Process Manager's signature column — who really made the running image.
+/// </summary>
+/// <remarks>
+/// The Safety chip beside it comes from the bundled process database, keyed on the process NAME, so a copy
+/// of <c>svchost.exe</c> in a user folder inherits the real one's chip. This column asks the file itself.
+/// <para>Shaped after <see cref="StartupSignatureTests"/> because the two tabs run the same post-pass over
+/// the same shared describer; the same gap is stated the same way, too. A genuinely signed file needs a
+/// test certificate and signtool, so <c>Verified</c> is covered at the palette level and in
+/// <see cref="AuthenticodeTests"/> rather than pretended at here.</para>
+/// </remarks>
+public class ProcessSignatureTests
+{
+    private static string WriteTempExe(byte[] bytes)
+    {
+        var path = Path.Combine(Path.GetTempPath(), "sysmgr_procsig_" + Guid.NewGuid().ToString("N") + ".exe");
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    private static ProcessEntry Entry(int pid, string path) =>
+        new() { Pid = pid, Name = "test", FilePath = path };
+
+    [Fact]
+    public void VerifySignatures_AnUnsignedImage_SaysSoWithoutAccusingIt()
+    {
+        var exe = WriteTempExe([0x4D, 0x5A, 0x90, 0x00]);
+        try
+        {
+            var entry = Entry(1000, exe);
+
+            ProcessManagerService.VerifySignatures([entry]);
+
+            Assert.Equal(SignatureTrust.Unsigned, entry.Signature);
+            // The wording matters as much as the state: most user programs are unsigned, and a sentence
+            // that read as a warning would make the whole column look like a list of problems.
+            Assert.Contains("does not mean it is unsafe", entry.SignatureDetail, StringComparison.Ordinal);
+        }
+        finally { File.Delete(exe); }
+    }
+
+    [Fact]
+    public void VerifySignatures_AnImageThatIsNotReadableAtAll_IsSuspectRatherThanUnsigned()
+    {
+        // An empty file is not "unsigned", it is unreadable — the distinction the three states exist for.
+        var exe = WriteTempExe([]);
+        try
+        {
+            var entry = Entry(1001, exe);
+
+            ProcessManagerService.VerifySignatures([entry]);
+
+            Assert.Equal(SignatureTrust.Invalid, entry.Signature);
+            Assert.Contains("could not read", entry.SignatureDetail, StringComparison.Ordinal);
+        }
+        finally { File.Delete(exe); }
+    }
+
+    [Fact]
+    public void VerifySignatures_AProcessWithNoReadablePath_IsLeftUnknownWithNoPill()
+    {
+        // The normal case for most system processes without elevation: Process.MainModule throws, FilePath
+        // stays empty, and nothing was checked. Unknown renders no chip, so the tab does not put a grey
+        // verdict on a program it never looked at.
+        var entry = Entry(4, "");
+
+        ProcessManagerService.VerifySignatures([entry]);
+
+        Assert.Equal(SignatureTrust.Unknown, entry.Signature);
+        Assert.Equal("", entry.SignatureDetail);
+    }
+
+    [Fact]
+    public void VerifySignatures_ManyProcessesFromOneExecutable_AllGetTheSameVerdict()
+    {
+        // The common case, not the exception: one browser runs as a dozen processes from one image. This is
+        // what the path-keyed cache is for, and a cache keyed on the wrong thing shows up here as later
+        // entries left blank.
+        var exe = WriteTempExe([0x4D, 0x5A, 0x90, 0x00]);
+        try
+        {
+            var tabs = Enumerable.Range(0, 12).Select(i => Entry(2000 + i, exe)).ToList();
+
+            ProcessManagerService.VerifySignatures(tabs);
+
+            Assert.All(tabs, e => Assert.Equal(SignatureTrust.Unsigned, e.Signature));
+            Assert.All(tabs, e => Assert.Equal(tabs[0].SignatureDetail, e.SignatureDetail));
+        }
+        finally { File.Delete(exe); }
+    }
+
+    [Fact]
+    public void VerifySignatures_TwoDifferentImages_AreNotConflatedByTheCache()
+    {
+        // The negative side of the test above. A cache keyed on something shared between the two — the
+        // process name, say, which is "test" for both here — would hand the second entry the first one's
+        // answer, and the column would be confidently wrong rather than blank.
+        var unsigned = WriteTempExe([0x4D, 0x5A, 0x90, 0x00]);
+        var unreadable = WriteTempExe([]);
+        try
+        {
+            var a = Entry(3000, unsigned);
+            var b = Entry(3001, unreadable);
+
+            ProcessManagerService.VerifySignatures([a, b]);
+
+            Assert.Equal(SignatureTrust.Unsigned, a.Signature);
+            Assert.Equal(SignatureTrust.Invalid, b.Signature);
+            Assert.NotEqual(a.SignatureDetail, b.SignatureDetail);
+        }
+        finally
+        {
+            File.Delete(unsigned);
+            File.Delete(unreadable);
+        }
+    }
+
+    [Fact]
+    public void VerifySignatures_LeavesTheDatabaseSafetyChipAlone()
+    {
+        // Two columns answering two questions. The interesting row is exactly the one where they disagree —
+        // a program the database recognises by name, running from an image nobody signed — so one must not
+        // overwrite the other.
+        var exe = WriteTempExe([0x4D, 0x5A]);
+        try
+        {
+            var entry = Entry(3100, exe);
+            entry.SafetyLevel = "System";
+            entry.Category = "System";
+
+            ProcessManagerService.VerifySignatures([entry]);
+
+            Assert.Equal("System", entry.SafetyLevel);
+            Assert.Equal("System", entry.Category);
+            Assert.Equal(SignatureTrust.Unsigned, entry.Signature);
+        }
+        finally { File.Delete(exe); }
+    }
+
+    /// <summary>
+    /// A refresh must not blank the column on a row it is only updating.
+    /// </summary>
+    /// <remarks>
+    /// This is the regression the design is most exposed to. A snapshot carries no image path for a PID the
+    /// caller already tracks — that is what makes the per-refresh cache cheap — so the fresh entry's verdict
+    /// is <see cref="SignatureTrust.Unknown"/> by construction. If <c>ReconcileInto</c> ever copied the
+    /// signature pair across with the volatile metrics, the chip would appear on first load and vanish one
+    /// tick later, which is the kind of flicker that reads as a rendering bug rather than a lost value.
+    /// </remarks>
+    [Fact]
+    public void ReconcileInto_ASurvivingProcess_KeepsTheSignatureItWasVerifiedWith()
+    {
+        var target = new BulkObservableCollection<ProcessEntry>();
+        var started = new DateTime(2026, 9, 10, 8, 0, 0, DateTimeKind.Utc);
+
+        var tracked = new ProcessEntry
+        {
+            Pid = 4242,
+            Name = "chrome",
+            FilePath = @"C:\Program Files\Contoso\app.exe",
+            StartTime = started,
+            Signature = SignatureTrust.Verified,
+            SignatureDetail = "Windows can confirm this really comes from Contoso Ltd.",
+            MemoryBytes = 100,
+        };
+        target.Add(tracked);
+
+        // What a refresh actually hands over for a PID it already tracks: metrics, no path, no verdict.
+        var fresh = new ProcessEntry { Pid = 4242, Name = "chrome", StartTime = started, MemoryBytes = 250 };
+
+        ViewModels.ProcessManagerViewModel.ReconcileInto(target, [fresh]);
+
+        var row = Assert.Single(target);
+        Assert.Same(tracked, row);
+        Assert.Equal(250, row.MemoryBytes);                                     // the metric did update
+        Assert.Equal(SignatureTrust.Verified, row.Signature);                   // the verdict did not
+        Assert.Equal("Windows can confirm this really comes from Contoso Ltd.", row.SignatureDetail);
+    }
+
+    [Fact]
+    public void ReconcileInto_APidWindowsReused_DoesNotInheritTheOldProcessSignature()
+    {
+        // The other half: a reused PID is a DIFFERENT program, so keeping the row would show the previous
+        // one's verified publisher against something entirely unrelated. Start time is what tells them
+        // apart, and the row is replaced rather than updated.
+        var target = new BulkObservableCollection<ProcessEntry>();
+        target.Add(new ProcessEntry
+        {
+            Pid = 4242,
+            Name = "chrome",
+            StartTime = new DateTime(2026, 9, 10, 8, 0, 0, DateTimeKind.Utc),
+            Signature = SignatureTrust.Verified,
+            SignatureDetail = "Windows can confirm this really comes from Contoso Ltd.",
+        });
+
+        var reused = new ProcessEntry
+        {
+            Pid = 4242,
+            Name = "something-else",
+            StartTime = new DateTime(2026, 9, 10, 9, 30, 0, DateTimeKind.Utc),
+        };
+
+        ViewModels.ProcessManagerViewModel.ReconcileInto(target, [reused]);
+
+        var row = Assert.Single(target);
+        Assert.Same(reused, row);
+        Assert.Equal(SignatureTrust.Unknown, row.Signature);
+        Assert.Equal("", row.SignatureDetail);
+    }
+}

--- a/SysManager/SysManager.Tests/StartupSignatureTests.cs
+++ b/SysManager/SysManager.Tests/StartupSignatureTests.cs
@@ -168,28 +168,22 @@ public class StartupSignatureTests
     }
 
     /// <summary>
-    /// The scan asks for OFFLINE revocation, and that is not a detail.
+    /// The scan still routes its verdict through the shared describer rather than growing its own copy.
     /// </summary>
     /// <remarks>
-    /// The two fail-closed gates pass <c>Online</c> because each verifies one file at a moment when a
-    /// network request is acceptable — pinned by
-    /// <see cref="AuthenticodeTests.EveryFailClosedGate_AsksForOnlineRevocation"/>. This runs over every
-    /// startup entry on the machine, so <c>Online</c> here would mean a revocation fetch per file, and on a
-    /// machine with no network a wait per file, in a tab the user just opened. A local-first app does not do
-    /// that. Changing this compiles, passes every other test, and is only visible as a tab that takes
-    /// seconds to populate on a train — so it is asserted.
+    /// The revocation mode itself moved with the chain build and is pinned by
+    /// <see cref="AuthenticodeTests.TheInformationalPath_AsksForOfflineRevocation_SoItDoesNotFetchPerFile"/>.
+    /// What is this tab's business is that it keeps ASKING the shared describer: the wording of a verdict is
+    /// user-facing copy, and a local reimplementation here would compile, pass, and leave two tabs
+    /// describing one certificate in two different sentences.
     /// </remarks>
     [Fact]
-    public void TheScan_AsksForOfflineRevocation_SoItDoesNotFetchPerFile()
+    public void TheScan_GetsItsVerdictFromTheSharedDescriber()
     {
         var source = File.ReadAllText(ServiceSourcePath("StartupService.cs"));
 
-        var at = source.IndexOf("Authenticode.ValidateChain", StringComparison.Ordinal);
-        Assert.True(at >= 0, "StartupService no longer validates a chain — move this guard with the code");
-
-        var call = source[at..Math.Min(source.Length, at + 200)];
-        Assert.Contains("X509RevocationMode.Offline", call, StringComparison.Ordinal);
-        Assert.DoesNotContain("X509RevocationMode.Online", call, StringComparison.Ordinal);
+        Assert.Contains("SignatureVerdict.Describe(path)", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Authenticode.ReadSigner", source, StringComparison.Ordinal);
     }
 
     // Walks up to the app project — source is not copied to the test output.
@@ -214,7 +208,7 @@ public class StartupSignatureTests
     [InlineData("CN=Only Name", "Only Name")]
     [InlineData("cn=Lowercase Marker, C=US", "Lowercase Marker")]
     public void CommonName_TakesJustTheCommonName(string subject, string expected)
-        => Assert.Equal(expected, StartupService.CommonName(subject));
+        => Assert.Equal(expected, Helpers.SignatureVerdict.CommonName(subject));
 
     [Fact]
     public void CommonName_QuotedNameContainingAComma_IsKeptWhole()
@@ -222,7 +216,7 @@ public class StartupSignatureTests
         // "Acme, Inc." is a real shape for a company name, and splitting on the comma would render
         // "comes from Acme" — a different company.
         Assert.Equal("Acme, Inc.",
-            StartupService.CommonName("CN=\"Acme, Inc.\", O=Acme, C=US"));
+            Helpers.SignatureVerdict.CommonName("CN=\"Acme, Inc.\", O=Acme, C=US"));
     }
 
     [Theory]
@@ -230,7 +224,7 @@ public class StartupSignatureTests
     [InlineData("   ", "")]
     [InlineData("O=No Common Name Here", "O=No Common Name Here")]
     public void CommonName_WithoutAUsableCn_FallsBackWithoutInventing(string subject, string expected)
-        => Assert.Equal(expected, StartupService.CommonName(subject));
+        => Assert.Equal(expected, Helpers.SignatureVerdict.CommonName(subject));
 
     // ── The palette: what the user reads, and how loudly ──
 

--- a/SysManager/SysManager/Helpers/SignatureVerdict.cs
+++ b/SysManager/SysManager/Helpers/SignatureVerdict.cs
@@ -1,0 +1,100 @@
+// SysManager · SignatureVerdict
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Security.Cryptography.X509Certificates;
+using Serilog;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Turns a file path into the three-state answer an informational column shows: who signed it, or why
+/// nobody can say.
+/// </summary>
+/// <remarks>
+/// This is deliberately NOT part of <see cref="Authenticode"/>. That type's contract is that it answers
+/// only the mechanical questions — read the signer, build the chain — and holds no policy about what an
+/// answer MEANS, because the two fail-closed gates disagree with each other on the most important case:
+/// an unsigned file is fatal for the third-party Ookla binary and expected for our own build. Folding a
+/// meaning into <c>Authenticode</c> is how one of those gates would quietly become permissive.
+/// <para>So this type carries one specific policy: <b>the informational one</b>, used by columns that
+/// describe many files and admit no code. Its three rules are the ones a list needs and a gate must not
+/// have — unsigned is ordinary rather than fatal, revocation is checked offline against what is already on
+/// the machine, and every answer comes with a sentence a non-technical reader can act on. A gate that
+/// adopted these would stop being a gate.</para>
+/// <para>Shared between the Startup Manager and the Process Manager because both ask the identical
+/// question of an executable on disk, and because the alternative — the same paragraph of copy written
+/// twice — is the kind of duplication that drifts into two tabs describing the same verdict differently.
+/// </para>
+/// </remarks>
+internal static class SignatureVerdict
+{
+    /// <summary>
+    /// The trust state of the file at <paramref name="path"/>, and a sentence explaining it.
+    /// </summary>
+    /// <remarks>
+    /// Never throws and never returns <see cref="SignatureTrust.Unknown"/>: a caller that could not resolve
+    /// a path does not call this at all, which is what keeps "we did not look" distinguishable from "we
+    /// looked and this is what we found".
+    /// </remarks>
+    internal static (SignatureTrust Trust, string Detail) Describe(string path)
+    {
+        var (state, cert, hresult) = Authenticode.ReadSigner(path);
+
+        if (state is SignerState.Unsigned)
+            return (SignatureTrust.Unsigned,
+                "Nobody signed this file, so Windows cannot confirm who made it. That is normal for many "
+                + "small programs and does not mean it is unsafe — it just means there is nothing to check.");
+
+        if (state is SignerState.Unreadable || cert is null)
+            return (SignatureTrust.Invalid,
+                $"This file carries signature data that Windows could not read (0x{hresult:X8}). A signed "
+                + "file whose signature will not open is worth a closer look.");
+
+        using (cert)
+        {
+            var signer = CommonName(cert.Subject);
+
+            if (!Authenticode.ValidateChain(cert, X509RevocationMode.Offline, out var statuses))
+            {
+                Log.Debug("Signature chain did not validate for {Path}: {Status}",
+                    LogService.SanitizePath(path), statuses);
+                return (SignatureTrust.Invalid,
+                    $"This file says it comes from {signer}, but Windows could not confirm that "
+                    + $"({statuses}). Worth a closer look before you trust it.");
+            }
+
+            return (SignatureTrust.Verified,
+                $"Windows can confirm this really comes from {signer}.");
+        }
+    }
+
+    /// <summary>
+    /// The common name out of a certificate subject, or the whole subject when it carries no CN.
+    /// </summary>
+    /// <remarks>
+    /// A subject reads <c>CN=Google LLC, O=Google LLC, L=Mountain View, S=California, C=US</c>. The tooltip
+    /// says "comes from Google LLC", so only the CN belongs in it — the rest is correct and unreadable.
+    /// A quoted CN containing a comma keeps everything up to the closing quote.
+    /// </remarks>
+    internal static string CommonName(string subject)
+    {
+        if (string.IsNullOrWhiteSpace(subject)) return "";
+
+        const string marker = "CN=";
+        var at = subject.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (at < 0) return subject.Trim();
+
+        var rest = subject[(at + marker.Length)..].TrimStart();
+        if (rest.StartsWith('"'))
+        {
+            var close = rest.IndexOf('"', 1);
+            return close > 1 ? rest[1..close] : rest[1..].Trim();
+        }
+
+        var comma = rest.IndexOf(',');
+        return (comma >= 0 ? rest[..comma] : rest).Trim();
+    }
+}

--- a/SysManager/SysManager/Models/ProcessEntry.cs
+++ b/SysManager/SysManager/Models/ProcessEntry.cs
@@ -35,6 +35,23 @@ public sealed partial class ProcessEntry : ObservableObject
     [ObservableProperty] private string _category = "Unknown";
     [ObservableProperty] private string _safetyLevel = "Unknown";
 
+    /// <summary>
+    /// Whether Windows can confirm who made the running image, from its certificate.
+    /// </summary>
+    /// <remarks>
+    /// A different question from <see cref="SafetyLevel"/>, which comes from the bundled process database
+    /// and answers "is this Windows, or something I installed?" by name. This one answers "is this really
+    /// from who it says?" from the file itself, so a copy of <c>svchost.exe</c> sitting in a user folder
+    /// cannot inherit the real one's reputation.
+    /// <para>Defaults to <see cref="SignatureTrust.Unknown"/>, which renders no pill: a process whose image
+    /// path could not be read — most system processes, without elevation — has not been checked, and a grey
+    /// chip there would be a verdict it has not earned.</para>
+    /// </remarks>
+    [ObservableProperty] private SignatureTrust _signature = SignatureTrust.Unknown;
+
+    /// <summary>The sentence behind <see cref="Signature"/>, shown on hover. Empty when nothing was checked.</summary>
+    [ObservableProperty] private string _signatureDetail = "";
+
     /// <summary>True when the process has a valid, accessible file path (cached on creation).</summary>
     [ObservableProperty] private bool _canOpenFileLocation;
 

--- a/SysManager/SysManager/Models/SignatureTrust.cs
+++ b/SysManager/SysManager/Models/SignatureTrust.cs
@@ -1,0 +1,38 @@
+// SysManager · SignatureTrust
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+namespace SysManager.Models;
+
+/// <summary>
+/// What a certificate check could establish about an executable on disk.
+/// </summary>
+/// <remarks>
+/// Its own file rather than a companion inside <c>StartupEntry.cs</c>, where it started: the Startup
+/// Manager asked the question first, but a running process and a startup entry ask the identical one, and
+/// a type shared by two models does not belong inside one of them.
+/// </remarks>
+public enum SignatureTrust
+{
+    /// <summary>
+    /// Nothing was checked — no readable file was resolved for the entry. Renders no pill at all: this
+    /// says something about the scan, not about the program, and a grey "unknown" chip would read as a
+    /// verdict.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// No embedded signature. Ordinary, not suspicious — most small utilities are unsigned, and so are
+    /// SysManager's own builds.
+    /// </summary>
+    Unsigned,
+
+    /// <summary>Signed, and the certificate's chain validated to a trusted root.</summary>
+    Verified,
+
+    /// <summary>
+    /// Signed, but the signature could not be confirmed — the chain failed to validate, or the signature
+    /// data itself could not be read. The one state here that deserves attention.
+    /// </summary>
+    Invalid,
+}

--- a/SysManager/SysManager/Models/StartupEntry.cs
+++ b/SysManager/SysManager/Models/StartupEntry.cs
@@ -102,32 +102,6 @@ public sealed partial class StartupEntry : ObservableObject
     public string TaskPath { get; init; } = "";
 }
 
-/// <summary>What a certificate check could establish about a startup entry's executable.</summary>
-public enum SignatureTrust
-{
-    /// <summary>
-    /// Nothing was checked — the command did not resolve to a readable file. Renders no pill at all: this
-    /// says something about the scan, not about the program, and a grey "unknown" chip would read as a
-    /// verdict.
-    /// </summary>
-    Unknown,
-
-    /// <summary>
-    /// No embedded signature. Ordinary, not suspicious — most small utilities are unsigned, and so are
-    /// SysManager's own builds.
-    /// </summary>
-    Unsigned,
-
-    /// <summary>Signed, and the certificate's chain validated to a trusted root.</summary>
-    Verified,
-
-    /// <summary>
-    /// Signed, but the signature could not be confirmed — the chain failed to validate, or the signature
-    /// data itself could not be read. The one state here that deserves attention.
-    /// </summary>
-    Invalid,
-}
-
 public enum StartupSource
 {
     RegistryCurrentUser,

--- a/SysManager/SysManager/Services/ProcessManagerService.cs
+++ b/SysManager/SysManager/Services/ProcessManagerService.cs
@@ -139,7 +139,50 @@ public sealed partial class ProcessManagerService
             foreach (var p in procs) p.Dispose();
         }
 
+        VerifySignatures(results);
+
         return results;
+    }
+
+    /// <summary>
+    /// Fills <see cref="ProcessEntry.Signature"/> and <see cref="ProcessEntry.SignatureDetail"/> for every
+    /// entry whose image path was read.
+    /// </summary>
+    /// <remarks>
+    /// A post-pass over the finished list, matching <c>StartupService.VerifySignatures</c>, and using the
+    /// same <see cref="Helpers.SignatureVerdict"/> so the two tabs cannot describe one certificate in two
+    /// ways.
+    /// <para><b>Why a per-refresh cache is enough on a tab that polls.</b> Reading a certificate and
+    /// building its chain is the expensive part here, and this list refreshes on a timer, so the obvious
+    /// worry is paying that cost every tick. It does not: <see cref="ProcessEntry.FilePath"/> is only
+    /// populated for a PID the caller has not seen before — that is the whole point of the
+    /// <c>knownPids</c> argument — and a surviving row keeps its own identity fields through
+    /// <c>ProcessManagerViewModel.ReconcileInto</c>. So the first refresh pays for every distinct image on
+    /// the machine, and each one after it pays only for processes that actually started. A cache that
+    /// outlived the call would buy nothing and would have to answer for a file replaced on disk.</para>
+    /// <para>Keyed on the path rather than the PID because a machine runs one browser as a dozen processes
+    /// from one executable, and that is the common case rather than the exception.</para>
+    /// </remarks>
+    internal static void VerifySignatures(IReadOnlyList<ProcessEntry> entries)
+    {
+        Dictionary<string, (SignatureTrust Trust, string Detail)> cache =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in entries)
+        {
+            // No path: a system process whose module list Windows refused, which is most of them without
+            // elevation. Nothing was checked, so the pill does not render — see ProcessEntry.Signature.
+            if (entry.FilePath.Length == 0) continue;
+
+            if (!cache.TryGetValue(entry.FilePath, out var verdict))
+            {
+                verdict = Helpers.SignatureVerdict.Describe(entry.FilePath);
+                cache[entry.FilePath] = verdict;
+            }
+
+            entry.Signature = verdict.Trust;
+            entry.SignatureDetail = verdict.Detail;
+        }
     }
 
     /// <summary>

--- a/SysManager/SysManager/Services/StartupService.cs
+++ b/SysManager/SysManager/Services/StartupService.cs
@@ -750,12 +750,10 @@ public sealed class StartupService
     /// A post-pass over the finished list, like <see cref="EnrichWithDescriptions"/> and for the same
     /// reason: every source (registry, startup folder, scheduled task) is enriched identically and there is
     /// one place to test.
-    /// <para><b>Offline revocation, not online.</b> The two fail-closed gates verify one file at a moment
-    /// when a network request is acceptable. This runs over every startup entry on the machine, so an
-    /// online chain build would mean a revocation fetch per file — and on a machine with no network, a wait
-    /// per file. A local-first app does not do that to a tab the user just opened. The cost is that a
-    /// certificate revoked since the last CRL refresh still reads as verified, which is the right trade for
-    /// an informational column and the wrong one for an installer gate.</para>
+    /// <para>The verdict and its wording come from <see cref="Helpers.SignatureVerdict"/>, shared with the
+    /// Process Manager's column, which is also where the reasoning for offline-only checking lives. Kept
+    /// there rather than restated here so the two tabs cannot end up describing the same certificate
+    /// differently.</para>
     /// <para>Results are cached per resolved path: several entries pointing at one executable is normal
     /// (an updater and its tray helper), and chain building is the expensive part.</para>
     /// </remarks>
@@ -771,72 +769,12 @@ public sealed class StartupService
 
             if (!cache.TryGetValue(path, out var verdict))
             {
-                verdict = Inspect(path);
+                verdict = Helpers.SignatureVerdict.Describe(path);
                 cache[path] = verdict;
             }
 
             entry.Signature = verdict.Trust;
             entry.SignatureDetail = verdict.Detail;
         }
-    }
-
-    private static (SignatureTrust Trust, string Detail) Inspect(string path)
-    {
-        var (state, cert, hresult) = Helpers.Authenticode.ReadSigner(path);
-
-        if (state is Helpers.SignerState.Unsigned)
-            return (SignatureTrust.Unsigned,
-                "Nobody signed this file, so Windows cannot confirm who made it. That is normal for many "
-                + "small programs and does not mean it is unsafe — it just means there is nothing to check.");
-
-        if (state is Helpers.SignerState.Unreadable || cert is null)
-            return (SignatureTrust.Invalid,
-                $"This file carries signature data that Windows could not read (0x{hresult:X8}). A signed "
-                + "file whose signature will not open is worth a closer look.");
-
-        using (cert)
-        {
-            var signer = CommonName(cert.Subject);
-
-            if (!Helpers.Authenticode.ValidateChain(
-                    cert, System.Security.Cryptography.X509Certificates.X509RevocationMode.Offline, out var statuses))
-            {
-                Log.Debug("Startup entry signature chain did not validate for {Path}: {Status}",
-                    LogService.SanitizePath(path), statuses);
-                return (SignatureTrust.Invalid,
-                    $"This file says it comes from {signer}, but Windows could not confirm that "
-                    + $"({statuses}). Worth a closer look before you trust it.");
-            }
-
-            return (SignatureTrust.Verified,
-                $"Windows can confirm this really comes from {signer}.");
-        }
-    }
-
-    /// <summary>
-    /// The common name out of a certificate subject, or the whole subject when it carries no CN.
-    /// </summary>
-    /// <remarks>
-    /// A subject reads <c>CN=Google LLC, O=Google LLC, L=Mountain View, S=California, C=US</c>. The tooltip
-    /// says "comes from Google LLC", so only the CN belongs in it — the rest is correct and unreadable.
-    /// A quoted CN containing a comma keeps everything up to the closing quote.
-    /// </remarks>
-    internal static string CommonName(string subject)
-    {
-        if (string.IsNullOrWhiteSpace(subject)) return "";
-
-        const string marker = "CN=";
-        var at = subject.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
-        if (at < 0) return subject.Trim();
-
-        var rest = subject[(at + marker.Length)..].TrimStart();
-        if (rest.StartsWith('"'))
-        {
-            var close = rest.IndexOf('"', 1);
-            return close > 1 ? rest[1..close] : rest[1..].Trim();
-        }
-
-        var comma = rest.IndexOf(',');
-        return (comma >= 0 ? rest[..comma] : rest).Trim();
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.87.1</Version>
-    <FileVersion>1.87.1.0</FileVersion>
-    <AssemblyVersion>1.87.1.0</AssemblyVersion>
+    <Version>1.88.0</Version>
+    <FileVersion>1.88.0.0</FileVersion>
+    <AssemblyVersion>1.88.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -168,8 +168,11 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
             if (existing.TryGetValue(fresh.Pid, out var current) && current.StartTime == fresh.StartTime)
             {
                 // Same process instance — update only the volatile metrics; identity fields
-                // (Name, FilePath, Icon, PlainDescription, Category, SafetyLevel, StartTime)
-                // are stable for a given process and stay as they were.
+                // (Name, FilePath, Icon, PlainDescription, Category, SafetyLevel, Signature,
+                // SignatureDetail, StartTime) are stable for a given process and stay as they were.
+                // The signature pair MUST stay in that group: the fresh entry carries no path for a PID
+                // already tracked, so its verdict is Unknown, and copying it over would blank the column
+                // one tick after it appeared.
                 current.CpuPercent = fresh.CpuPercent;
                 current.MemoryBytes = fresh.MemoryBytes;
                 current.ThreadCount = fresh.ThreadCount;

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -234,6 +234,38 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
+                    <!-- Safety above answers "is this Windows, or something I installed?" from the bundled
+                         database, keyed on the process NAME — so a copy of svchost.exe in a user folder
+                         inherits the real one's chip. This asks the file itself who signed it, which is the
+                         question a name cannot be trusted to answer.
+                         Chip structure and converters are the Startup Manager's Signature column verbatim
+                         (StartupView.xaml): same RadiusMd/6,3 border, 6px dot, FontSize 11 SemiBold, and
+                         Visibility driven by SignatureDetail rather than the enum, because that string is
+                         non-empty in exactly the three states worth showing.
+                         Placed after Category rather than beside Safety, for the reason Category itself
+                         states above: two judgement chips side by side compete for the same attention. The
+                         Startup Manager separates its two the same way, with a text column between them. -->
+                    <DataGridTemplateColumn Header="Signature" Width="110" MinWidth="100" SortMemberPath="Signature">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Border CornerRadius="{StaticResource RadiusMd}" Padding="6,3"
+                                        Background="{Binding Signature, Converter={StaticResource SigTrustBg}}"
+                                        BorderBrush="{Binding Signature, Converter={StaticResource SigTrustBg}}"
+                                        BorderThickness="1" HorizontalAlignment="Left"
+                                        ToolTip="{Binding SignatureDetail}"
+                                        Visibility="{Binding SignatureDetail, Converter={StaticResource FlexVis}}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <Ellipse Width="6" Height="6" VerticalAlignment="Center" Margin="0,0,4,0"
+                                                 Fill="{Binding Signature, Converter={StaticResource SigTrustBrush}}"/>
+                                        <TextBlock Text="{Binding Signature, Converter={StaticResource SigTrustText}}"
+                                                   FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center"
+                                                   Foreground="{Binding Signature, Converter={StaticResource SigTrustBrush}}"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+
                     <DataGridTemplateColumn Header="Actions" Width="120" MinWidth="120" CanUserSort="False" CanUserResize="False">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>


### PR DESCRIPTION
Closes #1581.

## Problem

The Process Manager's Safety chip is keyed on the process **name**, looked up in the bundled 108-entry database. That is the one attribute anything can copy: a file called `svchost.exe` sitting in a downloads folder gets the same reassuring **Windows** label as the real one in `System32`. The tab that people open when something is eating their CPU had no way to answer "is this actually the program it says it is?"

#1581 named three surfaces. Two were already done, and re-deriving that is what scoped this PR:

| Surface | Status | How |
|---|---|---|
| Drivers | shipped **v1.79.0** | `IsSigned` added to the `Win32_PnPSignedDriver` query — Windows answers it directly |
| Startup Manager | shipped **v1.85.0** | real verification: `CreateFromSignedFile` + chain build |
| Process Manager | **this PR** | same as Startup, which is why it waited for the machinery |

One claim in the issue does not survive checking, and it is worth recording rather than quietly dropping. It says `ContextMenuService` "does the same" with `CompanyName`. It does not: that call is a **display-name** fallback, `ProductName` first and the bare filename last, used to label a context-menu entry. It is not headed "Publisher" and nothing reads it as provenance. Not a fourth surface.

## What the user sees

A **Signature** column showing **Verified** / **Unsigned** / **Check failed**, with the reason on hover ("Windows can confirm this really comes from Google LLC").

- **Unsigned is grey, not amber.** Most ordinary programs are unsigned and so is SysManager, so colouring all of them as warnings would turn the column into noise the user learns to skip. Amber is kept for a file that *is* signed and whose signature does not hold up.
- **No badge at all** for a process whose image Windows will not let us read, which is most system processes without elevation. Nothing was checked, so nothing is claimed — `SignatureTrust.Unknown` renders nothing.
- **Placed after Category, not beside Safety.** `ProcessManagerView.xaml` already states the reason on the Category column: "two chips side by side would compete for the same attention." The Startup Manager separates its two the same way, with a text column between them.

## Design

**Shared, not copied.** The verdict and its wording moved out of `StartupService` into `Helpers/SignatureVerdict`, used by both tabs. Deliberately **not** folded into `Helpers/Authenticode`, whose own class doc forbids it:

> What is deliberately NOT shared: the policy that decides what the answer MEANS. The two existing callers disagree on the most important case … Folding those together is how a fail-closed gate quietly becomes permissive.

That reasoning is right, so `SignatureVerdict` sits above `Authenticode` and carries exactly one policy — the *informational* one, for columns that describe many files and admit no code: unsigned is ordinary, revocation is offline, every answer comes with a readable sentence. A gate adopting those three would stop being a gate.

`SignatureTrust` also moved to its own file. It started inside `Models/StartupEntry.cs`; a type shared by two models does not belong inside one of them.

**A per-refresh cache is sufficient on a tab that polls**, which is the non-obvious part. The worry is paying for a chain build every tick. It does not happen, because of the `knownPids` argument that already exists: `FilePath` is only populated for a PID the caller has not seen, and `ReconcileInto` keeps a surviving row's identity fields. So the first refresh pays for every distinct image on the machine, and each one after it pays only for processes that actually started. A cache that outlived the call would buy nothing and would owe an answer for a file replaced on disk. Keyed on the path, because one browser running as a dozen processes from one executable is the common case, not the exception.

## Guards

`TheProcessSignaturePill_IsRendered_AndTheSnapshotFillsItIn` — the sibling of the Startup guard, added because every weakness that one had to be mutated into existence applies here identically:

- **A name check would not work.** `Signature` is bound five times in one cell template (background, border, dot, label, sort path) and `SignatureDetail` twice (tooltip, visibility), so `Contains("{Binding Signature")` stays green with any four of five deleted. The guard requires the label converter — nothing else in this view uses it — and the detail serving as an actual tooltip.
- **Written-or-shown does not reach it.** `EveryModelProperty_IsEitherWrittenOrShown` accepts a merely-assigned property, and `VerifySignatures` assigns this one. Being assigned is what makes an unbound column a defect rather than dead code.
- **Every unit test calls the post-pass directly**, so deleting `VerifySignatures(results)` from `Snapshot` would leave all eight green while the column rendered nothing.

One pre-existing guard fired during this work and named its own fix: `TheScan_AsksForOfflineRevocation_SoItDoesNotFetchPerFile` failed with *"StartupService no longer validates a chain — move this guard with the code"* the moment the chain build moved. It is now `AuthenticodeTests.TheInformationalPath_AsksForOfflineRevocation_SoItDoesNotFetchPerFile`, next to the fail-closed-gate guard it is the other half of, because it is now one decision covering two tabs. What stayed on the Startup tests is what is that tab's own business: that it keeps *asking* the shared describer rather than growing a local copy.

## Red before, green after

`D:\rel-tmp\procsig-proof.py` — six mutations, rebuild and re-run per mutation, every file restored hash-verified. Each one is caught by a **different** test, which is the signal worth having; one catch-all failing six times would prove much less.

| Mutation | Result | Caught by |
|---|---|---|
| baseline | GREEN (137) | — |
| 1. drop `VerifySignatures(results)` from `Snapshot` | **RED** | `TheProcessSignaturePill_IsRendered_AndTheSnapshotFillsItIn` |
| 2. key the cache on process name instead of path | **RED** | `VerifySignatures_TwoDifferentImages_AreNotConflatedByTheCache` |
| 3. verify entries with no path too | **RED** | `VerifySignatures_AProcessWithNoReadablePath_IsLeftUnknownWithNoPill` |
| 4. delete the pill's label binding | **RED** | `TheProcessSignaturePill_IsRendered_AndTheSnapshotFillsItIn` |
| 5. delete the pill's tooltip | **RED** | `TheProcessSignaturePill_IsRendered_AndTheSnapshotFillsItIn` |
| 6. copy the fresh (Unknown) verdict onto a surviving row | **RED** | `ReconcileInto_ASurvivingProcess_KeepsTheSignatureItWasVerifiedWith` |
| restored | GREEN (137) | — |

Mutation 6 is the regression this design is most exposed to, and it is why the signature pair has to stay in `ReconcileInto`'s identity group: a fresh entry for a tracked PID carries no path, so its verdict is `Unknown` by construction, and copying it across would make the chip appear on first load and vanish one tick later — flicker that reads as a rendering bug rather than a lost value.

## Verification

- `dotnet build` — all four projects, **0 warnings, 0 errors**
- Unit suite: **5415 passed, 0 failed** (5405 → 5415: 8 new behaviour tests, 1 new guard, 1 relocated)
- `dotnet format --verify-no-changes` — all four projects, exit 0
- Leak scan — all 43 current terms against the 52601-byte staged diff, 0 hits, floor asserted
- Docs in this PR: `CHANGELOG.md`, `README.md` (Process Manager section), `ARCHITECTURE.md` (`ProcessManagerService` post-pass + `SignatureVerdict`), `SECURITY.md` (supported version → 1.88.x, and the signature-cost bullet now covers both tabs)

Version bumped to 1.88.0.

**Deferred to the secondary workstation:** the visual check on the three pill states in the live tab, and how the column reads against Safety on a real process list. Same deferral as v1.85.0's — the main workstation never launches the app.
