### PR TITLE
fix: stop collecting an event account SID that nothing reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.88.1] - 2026-09-10
+
+**The Event Log tab no longer collects an account identifier it never showed you.** For every event it
+read — up to five thousand at a time — it also picked up the Windows security identifier of the account
+behind that event, and then did nothing with it: no column displayed it, no export included it, nothing
+read it at all. Since the app is not going to show it, it should not be picking it up. Removed, along
+with the tests that were quietly keeping it alive.
+
+### Fixed
+
+- **A per-event account SID is no longer read or held in memory.** It was never displayed and never
+  written to any file — the Event Log's CSV export lists its columns explicitly and this was not among
+  them — so nothing left your PC before or after this change. It is simply data the app had no reason
+  to be holding.
+- The field also did not contain what its name said. It was labelled as a user name while holding a raw
+  identifier like `S-1-5-21-…`, which would have needed translating before it meant anything to anyone
+  reading it.
+
+### Changed
+
+- A new build check fails if any model value is filled in and then displayed nowhere and read by
+  nothing. That is this project's most persistent class of mistake — work done on every refresh and
+  thrown away — and it had been caught by review rather than by the build. All 193 such values are now
+  checked on every pull request.
+
 ## [1.88.0] - 2026-09-10
 
 **The Process Manager now tells you whether Windows can confirm who made each running program.**

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -3455,6 +3455,103 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Every model property is shown by a view or genuinely READ by code — being assigned is not enough.
+    /// </summary>
+    /// <remarks>
+    /// The strictly stronger sibling of <see cref="EveryModelProperty_IsEitherWrittenOrShown"/>, and the
+    /// gap between them is not academic: that guard's criterion is "written OR shown", and it therefore
+    /// accepts a property that is diligently filled in and consumed by nobody. Being filled in is what
+    /// makes that a defect rather than dead code — the app pays for the value on every refresh and throws
+    /// it away.
+    /// <para><c>FriendlyEventEntry.UserName</c> (#2225) was the live instance: assigned from
+    /// <c>rec.UserId?.Value</c> for every event record, bound by no view, read by no service. Three unit
+    /// tests named it — asserting that it raised <c>PropertyChanged</c> and defaulted to null — which
+    /// exercised the toolkit rather than a feature and is what let it look alive.</para>
+    /// <para><b>What actually does the work here, measured rather than assumed.</b> The criterion that
+    /// catches the defect is the plain one: no XAML binding, and no dotted reference from any C# file. Two
+    /// refinements sit alongside it, and both were predicted to be load-bearing and are not — so they are
+    /// documented as what they are, because a guard whose comment claims more than its code delivers is how
+    /// a weak check survives review.</para>
+    /// <list type="number">
+    /// <item><description><b>Dotted binding paths count</b> (<c>{Binding SelectedEntry.MachineName}</c> is
+    /// a real binding, and <c>MachineName</c> was a false positive of the first sweep until this was
+    /// added). But <b>0 of the 193 properties are reachable ONLY that way</b> — every dotted-bound one also
+    /// has a bare binding or a C# read. Correct, not currently load-bearing. A negative control asserting
+    /// it would be an assertion that cannot fail, so there is not one.</description></item>
+    /// <item><description><b>An assignment is not a read</b> — the match rejects a following <c>=</c>
+    /// while still accepting <c>==</c>, <c>=&gt;</c> and <c>!=</c>. Also <b>0 live instances</b>: no
+    /// property is assigned as <c>x.Prop =</c> without a dotted read somewhere. It notably does NOT catch
+    /// this defect either, and a mutation proved it: relaxing the exclusion while restoring the field left
+    /// the guard RED, because <c>UserName = rec.UserId?.Value</c> is an object-initializer member with no
+    /// leading dot, which the read check never matched in either form. Kept because the distinction is
+    /// right for a post-pass-assigned property (<c>entry.Signature = …</c>), which is the shape the next
+    /// instance is likely to take.</description></item>
+    /// </list>
+    /// <para>C# comments are stripped first, for the reason the guard above gives: this codebase comments
+    /// heavily enough that a comment merely naming a property would credit it as read — including the
+    /// comment left in place of the deleted field.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryModelProperty_IsBoundOrRead()
+    {
+        var appDir = FindAppProjectDir();
+        var modelsDir = Path.Combine(appDir, "Models") + Path.DirectorySeparatorChar;
+
+        var xaml = XmlComment().Replace(string.Join('\n', Directory
+            .EnumerateFiles(appDir, "*.xaml", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Select(File.ReadAllText)), string.Empty);
+
+        var sources = Directory
+            .EnumerateFiles(appDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .ToDictionary(f => f, f => CSharpComment().Replace(File.ReadAllText(f), string.Empty));
+
+        var dead = new List<string>();
+        var inspected = 0;
+
+        foreach (var (path, source) in sources.Where(kv => kv.Key.StartsWith(modelsDir, StringComparison.Ordinal)))
+        {
+            var typeName = TypeDeclaration().Match(source).Groups[1].Value;
+            if (typeName.Length == 0) continue;
+
+            foreach (var m in ObservablePropertyField().Matches(source).Cast<Match>())
+            {
+                var field = m.Groups[1].Value;
+                var property = char.ToUpperInvariant(field[0]) + field[1..];
+                inspected++;
+
+                var name = Regex.Escape(property);
+                if (Regex.IsMatch(xaml, $@"\{{Binding\s+(?:[A-Za-z_]\w*\.)*{name}\b")) continue;
+                if (Regex.IsMatch(xaml, $@"Path=(?:[A-Za-z_]\w*\.)*{name}\b")) continue;
+                if (Regex.IsMatch(xaml, $@"SortMemberPath=""(?:[A-Za-z_]\w*\.)*{name}""")) continue;
+
+                // A read anywhere but its own declaring file. Its own file counts too, for a computed
+                // property built from it (MemoryDisplay from MemoryBytes).
+                if (sources.Any(kv => Regex.IsMatch(kv.Value, $@"\.{name}\b\s*(?!=[^=])"))) continue;
+                if (Regex.IsMatch(source, $@"=>[^;]*\b{name}\b")) continue;
+
+                dead.Add($"{typeName}.{property} ({Path.GetFileName(path)})");
+            }
+        }
+
+        // Measured floor, not a token one: every check above is a "no match" assertion, and a no-match
+        // assertion is what silently passes when its pattern rots. 193 inspected today.
+        Assert.True(inspected >= 185,
+            $"only {inspected} model properties were inspected, out of 193 measured — the extraction has "
+            + "stopped matching every [ObservableProperty] declaration, so a pass here means nothing.");
+
+        Assert.True(dead.Count == 0,
+            "these model properties are filled in and then read by nothing and shown nowhere, so the app "
+            + "pays for the value on every refresh and throws it away. Bind them, consume them, or remove "
+            + $"them:\n  {string.Join("\n  ", dead)}");
+    }
+
+    /// <summary>A C# line, doc or block comment — stripped before a property is credited as read.</summary>
+    [GeneratedRegex(@"//.*?$|/\*.*?\*/", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline)]
+    private static partial Regex CSharpComment();
+
+    /// <summary>
     /// Every view-model property is shown by a view or read by code — not merely maintained.
     /// </summary>
     /// <remarks>

--- a/SysManager/SysManager.Tests/FriendlyEventEntryExtendedTests.cs
+++ b/SysManager/SysManager.Tests/FriendlyEventEntryExtendedTests.cs
@@ -27,7 +27,6 @@ public class FriendlyEventEntryExtendedTests
         e.FullMessage = "full";
         e.Xml = "<x/>";
         e.MachineName = "pc";
-        e.UserName = "u";
         e.RecordId = 99;
         e.Explanation = "exp";
         e.Recommendation = "rec";
@@ -42,7 +41,6 @@ public class FriendlyEventEntryExtendedTests
         Assert.Contains(nameof(e.FullMessage), raised);
         Assert.Contains(nameof(e.Xml), raised);
         Assert.Contains(nameof(e.MachineName), raised);
-        Assert.Contains(nameof(e.UserName), raised);
         Assert.Contains(nameof(e.RecordId), raised);
         Assert.Contains(nameof(e.Explanation), raised);
         Assert.Contains(nameof(e.Recommendation), raised);
@@ -98,10 +96,12 @@ public class FriendlyEventEntryExtendedTests
     }
 
     [Fact]
-    public void MachineAndUser_AreOptional()
+    public void MachineName_IsOptional()
     {
+        // Optional because a record from a forwarded or exported log may carry no machine at all. The
+        // companion UserName assertion went with the field in #2225: it held a SID that nothing read, and
+        // asserting its default was the only thing keeping the property looking alive.
         var e = new FriendlyEventEntry();
         Assert.Null(e.MachineName);
-        Assert.Null(e.UserName);
     }
 }

--- a/SysManager/SysManager/Models/FriendlyEventEntry.cs
+++ b/SysManager/SysManager/Models/FriendlyEventEntry.cs
@@ -31,7 +31,13 @@ public sealed partial class FriendlyEventEntry : ObservableObject
     [ObservableProperty] private string _fullMessage = "";       // full rendered text
     [ObservableProperty] private string _xml = "";               // raw xml for power users
     [ObservableProperty] private string? _machineName;
-    [ObservableProperty] private string? _userName;
+    // No UserName: one was declared here and assigned from rec.UserId?.Value for every record, and
+    // nothing ever read it — no view bound it, no service consumed it. It also did not hold what its name
+    // promised: UserId is a SecurityIdentifier, so the value was a SID (S-1-5-21-…), which means anything
+    // to a reader only after SecurityIdentifier.Translate, a call that fails for an account the machine
+    // cannot resolve. Same decision as ProcessEntry.UserName: implement it properly or do not imply it
+    // exists. If the Event Log tab wants it, #2225 records where the SID comes from and what showing it
+    // would take — it belongs beside MachineName in the detail pane, translated and cached per SID.
     [ObservableProperty] private long _recordId;
     [ObservableProperty] private string _explanation = "";       // friendly explanation
     [ObservableProperty] private string _recommendation = "";    // what to try

--- a/SysManager/SysManager/Services/EventLogService.cs
+++ b/SysManager/SysManager/Services/EventLogService.cs
@@ -196,7 +196,6 @@ public sealed partial class EventLogService
             // 5000 strings for the lifetime of the tab. LogsViewModel fills it on selection via
             // GetXmlAsync. Unlike FullMessage, nothing filters on it.
             MachineName = rec.MachineName,
-            UserName = rec.UserId?.Value,
             RecordId = rec.RecordId ?? 0
         };
     }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.88.0</Version>
-    <FileVersion>1.88.0.0</FileVersion>
-    <AssemblyVersion>1.88.0.0</AssemblyVersion>
+    <Version>1.88.1</Version>
+    <FileVersion>1.88.1.0</FileVersion>
+    <AssemblyVersion>1.88.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #2225.

## Problem

`EventLogService` filled in `FriendlyEventEntry.UserName` from `rec.UserId?.Value` for every record it read — up to 5000 per refresh — and nothing consumed it.

```
Services/EventLogService.cs:199:   UserName = rec.UserId?.Value,      <- the only writer
$ grep -rn "UserName" SysManager/SysManager/Views/                    <- no match, any form
```

The sibling field from the same construction site *is* shown, which is what makes the omission visible rather than a design choice:

```
Views/LogsView.xaml:423:  <TextBlock ... Text="{Binding SelectedEntry.MachineName}"/>
```

Three unit tests named the property — asserting it raised `PropertyChanged` and defaulted to null. They exercised the toolkit, not a feature, so they stayed green whatever the tab did. That is what let it look alive.

**The value was also not what the name promised.** `UserId` is a `SecurityIdentifier`, so this held a SID (`S-1-5-21-…`), meaningful to a reader only after `SecurityIdentifier.Translate` — a call that fails for an account the machine cannot resolve.

## Fix: option A from the issue

Delete it. The precedent is written into `ProcessEntry`, where the same field was removed rather than implemented:

> the choices were to implement it properly or not to imply it exists. Dropped.

Here it was worse off than there: it *was* assigned, so the work happened on every refresh and was thrown away. #2225 records where the SID comes from and what showing it would take, if the Event Log tab ever wants it — that is option B, and it stays available at the cost of one line.

Option A rather than B because a new column is a visible feature nobody asked for, while removing an invisible dead field is cleanup. The comment left in the model says which is which, so the next reader does not rediscover the question.

**Not a privacy leak before this change, and worth saying explicitly rather than implying it:** the Logs CSV export writes an explicit column list and no reflection exists anywhere in the app, so the SID never reached a file.

```
ViewModels/LogsViewModel.cs:348:
sw.WriteLine("Timestamp,Severity,Log,Provider,EventId,Message,Explanation,Recommendation");
$ grep -rn "GetProperties()" --include=*.cs SysManager/SysManager/     <- no match
```

## The guard, and an honest account of what it does

`EveryModelProperty_IsBoundOrRead` — the stronger sibling of `EveryModelProperty_IsEitherWrittenOrShown`. The gap between them is the whole point: that guard's criterion is "written **OR** shown", so it accepts a property that is diligently filled in and consumed by nobody. Being filled in is precisely what makes this a defect rather than dead code.

193 properties inspected, floor asserted at 185 — every check in it is a "no match" assertion, and a no-match assertion is what silently passes when its pattern rots.

**Two refinements I expected to be load-bearing are not, and the guard's own documentation now says so.** A comment claiming more than its code delivers is how a weak check survives review, so both were measured instead of assumed:

| Refinement | Live instances | Kept because |
|---|---|---|
| Dotted binding paths count (`{Binding SelectedEntry.X}`) | **0 of 193** | It is correct, and `MachineName` was a false positive of the first sweep until it was added |
| An assignment is not a read (`.Prop` rejects a following `=`) | **0 of 193** | Right for a post-pass-assigned property (`entry.Signature = …`), the shape the next instance likely takes |

So the criterion that actually catches this is the plain one: no XAML binding, no dotted reference from any C# file. There is deliberately **no negative control** asserting the dotted-path arm, because with 0 live instances it would be an assertion that cannot fail.

The second row corrected a claim of mine that a mutation refuted — see case C below.

## Red before, green after

Two proof runs. `D:\rel-tmp\username-proof.py` established the guard catches the defect; `username-proof2.py` tested the refinements from both sides. Every file restored hash-verified in both.

| Case | Result | Reason reported |
|---|---|---|
| A. current state (field deleted, strict check) | GREEN | — |
| B. **field and assignment restored — the shipped pre-fix state** | **RED** | "filled in and then read by nothing" |
| C. field restored **and** the read exclusion relaxed | **RED** | still caught |
| D. field deleted, read exclusion relaxed | GREEN | nothing else depends on it |
| E. dotted-path allowance removed | GREEN | 0 properties are dotted-only |

**Case C is the interesting one, because I predicted GREEN.** I had claimed the assignment-vs-read exclusion was "the blind spot that hid the defect". It is not: `UserName = rec.UserId?.Value` is an object-initializer member with no leading dot, so `\.UserName\b` never matched it in either form. The guard is more robust than I claimed and for a different reason than I gave. The doc comment now states the measured version.

Case E prompted the follow-up measurement that found 0 dotted-only properties, which is why the negative control was removed rather than left in place asserting nothing.

## Verification

- `dotnet build` — app and all three test projects, **0 warnings, 0 errors**
- Unit suite: **5416 passed, 0 failed** (5415 → 5416: the new guard; the three removed assertions lived inside existing tests)
- `dotnet format --verify-no-changes` — all four projects, exit 0
- Leak scan — all 43 current terms against the 13775-byte staged diff, 0 hits, floor asserted
- `CHANGELOG.md` updated; no README or ARCHITECTURE change, since nothing user-visible changed

Version bumped to 1.88.1.
