### PR TITLE
fix: ask Windows whether a signature holds, instead of deciding ourselves

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -286,13 +286,11 @@ Key services:
   post-pass, `VerifySignatures`, answers "who really made this" with a certificate rather
   than `FileVersionInfo.CompanyName`, which is the string the `Publisher` column shows and
   which any program can set to "Microsoft Corporation". It uses the shared
-  `Helpers/Authenticode` reader and chain validator with **`X509RevocationMode.Offline`** —
-  unlike the update and Ookla gates, which pass `Online`: this runs over every entry on the
-  machine, so an online build would mean a revocation request per file and, with no network,
-  a wait per file, in a tab the user just opened. Results are cached per resolved
-  executable path, since several entries pointing at one exe is normal. `ResolveExecutablePath`
-  is the single answer to "which file is this entry", shared with `ExtractPublisher`, so the
-  Publisher and the certificate can never describe different files.
+  `Helpers/SignatureVerdict`, which asks Windows via `WinVerifyTrust` — **not** the managed
+  chain the two fail-closed gates build. Results are cached per resolved executable path,
+  since several entries pointing at one exe is normal. `ResolveExecutablePath` is the single
+  answer to "which file is this entry", shared with `ExtractPublisher`, so the Publisher and
+  the certificate can never describe different files.
 - `Helpers/Authenticode` — the two Authenticode operations, defined once: `ReadSigner`
   (three-way `Signed`/`Unsigned`/`Unreadable`, never throws) and `ValidateChain` (one strict
   policy — `ExcludeRoot`, `NoFlag`, fail-closed — with the revocation mode as a parameter).
@@ -301,14 +299,29 @@ Key services:
   switch that defaults to on, so a caller that chose `Offline` to avoid a request per file made
   one anyway and, with no network, waited out `UrlRetrievalTimeout` for each. The two settings
   are therefore derived from the one argument rather than offered separately —
-  `DisableCertificateDownloads` is on exactly when revocation is `Offline` — so the scanning
-  callers stay local and the two fail-closed gates keep the fetch that lets a genuine signature
-  validate.
+  `DisableCertificateDownloads` is on exactly when revocation is `Offline`.
   Deliberately holds no policy about what an answer MEANS: an unsigned file is fatal for the
   Ookla download and expected for our own build, so each caller keeps that decision. Two
   calls rather than one because both fail-closed callers compare the subject BEFORE building
   a chain, and a single "inspect" would add a revocation fetch on the path where the subject
   already failed.
+  **Its only remaining callers are those two gates.** The informational columns used it and
+  moved off it, because an offline managed chain cannot answer for an arbitrary file: measured
+  over 82 running process images it verified 1 and reported failure for 47, on
+  `RevocationStatusUnknown` (46 of 48, no cached CRL) and `PartialChain` (29, intermediate not
+  local). Loosening the flags enough to pass means `AllowUnknownCertificateAuthority`, which
+  accepts any certificate authority and verifies nothing.
+- `Helpers/WindowsTrust` — `WinVerifyTrust` behind a four-state answer
+  (`Trusted`/`NoSignature`/`Expired`/`NotTrusted`), the mechanism Explorer's Digital Signatures
+  tab and Process Explorer use. Over the same 82 images: 46 trusted, 1 genuine failure. Called
+  with `WTD_REVOKE_NONE` plus `WTD_CACHE_ONLY_URL_RETRIEVAL`, which is a supported way to say
+  "answer from this machine only" — the guarantee `Offline` was reached for and does not give.
+  `Classify` is a pure HRESULT map, kept `internal` and tested directly, because it is what
+  decides the colour a user sees and the previous mechanism's wrong verdicts came from
+  classification rather than from reading. Costs ~25 ms per file and does not get cheaper warm,
+  so callers cache and stay off the UI thread. Does not see catalog signatures
+  (`WTD_CHOICE_FILE` reads the embedded one), which is why Windows components still read as
+  unsigned.
 - `DuplicateFileService` — three-pass duplicate finder (size grouping →
   partial hash pre-filter → full SHA-256). Read-only, never deletes.
 - `DiskAnalyzerService` — folder-level space breakdown with progress
@@ -329,10 +342,14 @@ Key services:
   `Helpers/Authenticode` on purpose: that type answers only the mechanical questions and
   holds no policy, because the two fail-closed gates disagree with each other on what an
   unsigned file means. This one carries exactly one policy — the informational one, for
-  columns that describe many files and admit no code: unsigned is ordinary, revocation is
-  offline, every answer comes with a readable sentence. A gate adopting those would stop
+  columns that describe many files and admit no code: unsigned is ordinary, nothing reaches
+  the network, every answer comes with a readable sentence. A gate adopting those would stop
   being a gate. Shared rather than copied so two tabs cannot describe one certificate in
   two different sentences.
+  The verdict comes from `Helpers/WindowsTrust`; the certificate is still read, but **only for
+  the publisher's name**, never for the verdict. That ordering is the fix: a name is cosmetic,
+  so failing to read one costs a phrase in a tooltip, while the verdict decides a colour. Every
+  phrasing here has a form that works with no name, which is what lets the name be optional.
 - `WindowsFeaturesService` — list, enable, disable Windows optional features
   via `Get-WindowsOptionalFeature` / `Enable-WindowsOptionalFeature` PowerShell.
 - `UninstallerService` — winget-based uninstall + registry UninstallString

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.88.2] - 2026-09-10
+
+**The Signature column was telling you almost every program on your PC had failed its check.** It was
+supposed to be the rare warning; instead it was the normal answer. On this machine it confirmed one
+signed program out of forty-eight and put an amber "Check failed" on the other forty-seven — File
+Explorer, Outlook, Windows Terminal, Windows Settings among them. All of those are properly signed by
+Microsoft. The column now asks Windows for its verdict instead of working it out itself, and gets the
+same answer you would see in a file's own Properties window: forty-six confirmed, and the one remaining
+warning is a genuine expired certificate.
+
+### Fixed
+
+- **The Signature column now agrees with Windows.** It uses the same check that sits behind the
+  **Digital Signatures** tab in a file's Properties, so the two can no longer disagree — and if you
+  want to double-check anything the column says, that dialog is the second opinion.
+- **Nothing is accused for being unreadable.** A file the app cannot make sense of now reads as
+  unsigned, because that is what Windows says about it. Previously our own reader failing to parse a
+  file produced a warning about the file, which was blaming the wrong party.
+- The warning colour is back to meaning what it says. On a normal PC it should now appear rarely, and
+  when it does it is worth the look.
+- No network request is made, on either tab. That was already the intent and the previous approach
+  could not actually deliver it — a certificate check that cannot reach the internet also cannot
+  finish, which is a large part of why every answer came back as a failure.
+
+### Known limitation, stated rather than left to be discovered
+
+- Windows signs many of its own components through a separate catalogue file rather than inside the
+  program, and that kind of signature is not read yet. Those show as **Unsigned**. It understates them
+  instead of accusing them, and it is the next thing to fix on this column.
+
 ## [1.88.1] - 2026-09-10
 
 **The Event Log tab no longer collects an account identifier it never showed you.** For every event it

--- a/README.md
+++ b/README.md
@@ -492,11 +492,12 @@ a confirmation before it runs:
   - **Unsigned is grey, not a warning.** Most small utilities are unsigned and so is SysManager
     itself; the tooltip says so in as many words. Amber is reserved for a file that *is* signed and
     whose signature does not hold up — the one case here worth a second look.
-  - The check runs offline, against certificates already on your PC, so opening the tab never waits
-    on the network — it downloads nothing, not even a missing piece of a certificate. The cost of
-    that is honest rather than hidden: if your PC has never seen a particular publisher's
-    certificate, the column says **Check failed** instead of fetching the rest and confirming it.
-    The tooltip says Windows could not confirm the publisher, which is exactly what happened.
+  - The verdict is Windows' own, from the same check behind Explorer's **Digital Signatures** tab, so
+    it agrees with what Windows tells you elsewhere. It asks for no revocation lookup and answers from
+    your PC only, so opening the tab never waits on the network and downloads nothing.
+  - What it does not yet see: a signature kept in a Windows catalogue instead of inside the file. A
+    number of Windows components are signed that way and currently show as **Unsigned** — the column
+    understates them rather than accusing them.
 - Sort by name, publisher, location, safety, status, signature, or startup impact via clickable column
   headers
 - Plain-language description for recognised programs (from the built-in database) instead
@@ -584,9 +585,12 @@ a confirmation before it runs:
     not hold up, which is the one case worth a second look
   - Processes whose file Windows will not let SysManager read — most system processes,
     unless you run as administrator — get no badge at all rather than a guess
-  - Checked offline against certificates already on your PC, and only for processes that
-    have just appeared, so a tab that refreshes every second does not re-check the same
-    programs or reach for the network
+  - The verdict is Windows' own — the same check behind Explorer's **Digital Signatures** tab. It asks
+    for no revocation lookup and answers from your PC only, and it runs just for processes that have
+    just appeared, so a tab refreshing every second neither re-checks the same programs nor reaches
+    for the network
+  - Windows components signed through a Windows catalogue rather than inside the file show as
+    **Unsigned** for now — understated rather than accused
 - Kill process with confirmation dialog, and the warning matches the real cost.
   Processes Windows genuinely cannot survive losing (`winlogon`, `csrss`, `lsass`, …)
   are refused outright. Security and servicing processes (Defender's engine, Windows

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -111,19 +111,22 @@ What the app can and cannot do by design:
 - **External CLI downloads**: the Ookla speed-test CLI is downloaded from
   `install.speedtest.net` the first time it's used. If that URL changes,
   the feature fails safely rather than substituting an alternative.
-- **Signature checks on lists, and what they cost**: the Signature columns in the Startup Manager and
-  the Process Manager read each program's Authenticode certificate and build its chain, which is a
-  different job from the two gates above. Those verify one file at a moment you asked for something, so
-  they use the network: they look up revocation and they will fetch a missing intermediate certificate,
-  because that is what lets a genuine signature verify. A column over every startup entry, or every
-  program running right now, cannot do either — it would mean a request per file, and on a disconnected
-  PC a timeout per file — so it is restricted to what is already on your machine, both for revocation
-  and for certificate downloads. The two settings are decided
-  together in one place, because turning off only the first still leaves the second fetching. The
-  trade-off is stated plainly: a certificate revoked since your PC last refreshed its lists still reads
-  as verified, and a signed file whose issuer your PC has never seen reads as "Check failed" rather than
-  being confirmed by a download. That is the right bias for a column that informs, and the wrong one for
-  a gate that admits code, which is why they differ.
+- **Signature checks on lists, and what they cost**: the Signature columns in the Startup Manager and the
+  Process Manager ask Windows for its verdict, through the same `WinVerifyTrust` API that Explorer's
+  *Digital Signatures* tab uses. That is a different job from the two gates above, which compare a specific
+  publisher and therefore build a certificate chain themselves, using the network to look up revocation and
+  to fetch a missing intermediate certificate. A column covering every startup entry, or every program
+  running right now, cannot do that — it would mean a request per file, and on a disconnected PC a wait per
+  file — so it asks for **no revocation check** and tells Windows to answer from this machine's caches
+  only. No network request is made for a column.
+  - The trade-off, stated plainly: a certificate revoked since your PC last refreshed its lists still reads
+    as verified. That is the right bias for a column that informs you and the wrong one for a gate that
+    admits code, which is why the two differ.
+  - What the columns do **not** see: a signature stored in a Windows catalogue rather than inside the file.
+    Many Windows components are signed that way and currently read as "Unsigned" — the column understates
+    them rather than accusing them.
+  - Reading the publisher's *name* is a separate step from deciding whether the signature holds, and it
+    only ever affects the wording of a tooltip. A verdict is never derived from it.
 - **Local diagnostic log**: SysManager keeps 14 days of rolling log files in
   `%LocalAppData%\SysManager\logs`. They never leave the machine on their own —
   there is no upload path. Your Windows user name is replaced with `[user]` on

--- a/SysManager/SysManager.Tests/AuthenticodeTests.cs
+++ b/SysManager/SysManager.Tests/AuthenticodeTests.cs
@@ -192,32 +192,36 @@ public class AuthenticodeTests
     }
 
     /// <summary>
-    /// The informational path asks for OFFLINE revocation, and that is not a detail.
+    /// The informational path does not build a managed chain at all, and must not go back to one.
     /// </summary>
     /// <remarks>
-    /// The other half of <see cref="EveryFailClosedGate_AsksForOnlineRevocation"/>. Both the Startup Manager
-    /// and the Process Manager column run over every relevant file on the machine, so <c>Online</c> here
-    /// would mean a revocation fetch per file, and on a machine with no network a wait per file, in a tab
-    /// the user just opened. Changing it compiles, passes every other test, and is visible only as a tab
-    /// that takes seconds to populate on a train — so it is asserted.
-    /// <para>Lives here, next to the gate guard, rather than in one tab's test file: since the verdict was
-    /// shared this is one decision covering two tabs, and the copy that used to sit in
-    /// <c>StartupSignatureTests</c> failed with "move this guard with the code" the moment the chain build
-    /// moved. That is what it was for.</para>
+    /// This replaces a guard that pinned <c>X509RevocationMode.Offline</c> on <c>SignatureVerdict</c>. That
+    /// guard was correct about the intent and the intent turned out to be unreachable: an offline chain
+    /// build verified 1 of 48 signed process images and reported "Check failed" for 47, because it still
+    /// demands a revocation answer with no cached CRL and an intermediate it may not fetch. The
+    /// informational columns now ask Windows through <c>WinVerifyTrust</c>.
+    /// <para>So what is worth asserting has inverted: not "which revocation mode", but that the verdict is
+    /// no longer derived from a chain we build. The two fail-closed gates still do, which is what
+    /// <see cref="EveryFailClosedGate_AsksForOnlineRevocation"/> covers — this is the other half, and
+    /// keeping both here is what stops a future change from quietly giving the columns the gates' mechanism
+    /// back.</para>
     /// </remarks>
     [Fact]
-    public void TheInformationalPath_AsksForOfflineRevocation_SoItDoesNotFetchPerFile()
+    public void TheInformationalPath_DoesNotBuildAManagedChain()
     {
         var source = File.ReadAllText(Path.Combine(AppProjectDir(), "Helpers", "SignatureVerdict.cs"));
+        Assert.True(source.Length > 1000, "SignatureVerdict.cs is too small to be the real file");
 
-        var at = source.IndexOf("Authenticode.ValidateChain", StringComparison.Ordinal);
-        Assert.True(at >= 0,
-            "SignatureVerdict no longer validates a chain — move this guard with the code rather than "
-            + "deleting it");
+        Assert.Contains("WindowsTrust.Verify(path)", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("ValidateChain", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("X509RevocationMode", source, StringComparison.Ordinal);
 
-        var call = source[at..Math.Min(source.Length, at + 220)];
-        Assert.Contains("X509RevocationMode.Offline", call, StringComparison.Ordinal);
-        Assert.DoesNotContain("X509RevocationMode.Online", call, StringComparison.Ordinal);
+        // The certificate is still read, for the publisher's NAME only. That distinction is the reason the
+        // column stopped accusing everything, so it is stated in the assertion rather than left to a
+        // comment: a verdict derived from ReadSigner is the defect coming back.
+        Assert.Contains("Authenticode.ReadSigner(path)", source, StringComparison.Ordinal);
+        var signer = source[source.IndexOf("private static string Signer", StringComparison.Ordinal)..];
+        Assert.Contains("Authenticode.ReadSigner(path)", signer, StringComparison.Ordinal);
     }
 
     private static string HelperMethodSource(string signature)

--- a/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupViewModelTests.cs
@@ -395,10 +395,57 @@ public class DeepCleanupViewModelTests
         Assert.Equal("marker", vm.LargeScanStatus);
     }
 
+    /// <summary>
+    /// The constructor's background load picks a default location — which is why the test below awaits it.
+    /// </summary>
+    /// <remarks>
+    /// This is the mechanism behind the CI failure, observed directly rather than inferred from a timing
+    /// race. Clearing <c>SelectedLocation</c> and then letting the load finish shows the value coming back:
+    /// the load ends with <c>SelectedLocation = ScanLocations.FirstOrDefault()</c> and does not check
+    /// whether anything set it in the meantime. Any test that clears the property without first awaiting
+    /// initialization is racing that assignment, and on a slower machine it loses.
+    /// <para>Picking a default is deliberate product behaviour — the tab opens ready to scan rather than
+    /// demanding a choice first — so this pins it rather than treating it as the bug. The bug is only ever
+    /// a test that does not account for it.</para>
+    /// </remarks>
+    [Fact]
+    public async Task TheConstructorLoad_PicksADefaultLocation_EvenAfterOneWasCleared()
+    {
+        var vm = NewVm();
+        vm.SelectedLocation = null;
+
+        await vm.InitializationComplete;
+
+        // Conditional on the machine having any scannable folder at all, so this cannot fail on an
+        // environment with no Downloads, Documents or fixed drive rather than on the behaviour.
+        if (vm.ScanLocations.Count == 0) return;
+
+        Assert.NotNull(vm.SelectedLocation);
+        Assert.Same(vm.ScanLocations[0], vm.SelectedLocation);
+    }
+
+    /// <summary>
+    /// With no location picked, the scan says so instead of scanning something the user did not choose.
+    /// </summary>
+    /// <remarks>
+    /// <b>Awaiting <c>InitializationComplete</c> is what makes this deterministic, and it is not
+    /// decoration.</b> The constructor launches its location enumeration fire-and-forget, and that load
+    /// ends by assigning <c>SelectedLocation = ScanLocations.FirstOrDefault()</c>. Setting the property to
+    /// null before the load finishes therefore gets overwritten mid-test, and the scan runs against
+    /// Downloads — the assertion then fails with "Found 0 files ≥ 500 MB in Downloads", which reads like a
+    /// broken feature rather than a race.
+    /// <para>It went red in CI on the pull request that added an unrelated test class, because that shifted
+    /// the timing enough to lose a race this machine happened to win. <c>ViewModelBase</c> exposes
+    /// <c>InitializationComplete</c> for exactly this ("tests can await it to observe the loaded state
+    /// deterministically instead of racing the fire-and-forget load"), so the seam existed and this test
+    /// simply was not using it. The wider sweep of tests with the same exposure is #2201.</para>
+    /// </remarks>
     [Fact]
     public async Task ScanLargeFiles_NoLocation_SetsErrorStatus()
     {
         var vm = NewVm();
+        await vm.InitializationComplete;
+
         vm.SelectedLocation = null;
 
         await vm.ScanLargeFilesCommand.ExecuteAsync(null);

--- a/SysManager/SysManager.Tests/ProcessSignatureTests.cs
+++ b/SysManager/SysManager.Tests/ProcessSignatureTests.cs
@@ -50,10 +50,19 @@ public class ProcessSignatureTests
         finally { File.Delete(exe); }
     }
 
+    /// <summary>
+    /// A file Windows cannot parse reads as unsigned, and specifically not as a problem.
+    /// </summary>
+    /// <remarks>
+    /// The inverse of what this asserted before the mechanism changed, deliberately. Reading the
+    /// certificate ourselves turned an unparseable file into an amber chip, which was the reader failing
+    /// rather than anything about the file. <c>WinVerifyTrust</c> returns <c>TRUST_E_NOSIGNATURE</c> for
+    /// every such case — measured on an empty file, a two-byte stub, a text file named <c>.exe</c>, a
+    /// missing path and a directory — so an image the app cannot make sense of is never accused.
+    /// </remarks>
     [Fact]
-    public void VerifySignatures_AnImageThatIsNotReadableAtAll_IsSuspectRatherThanUnsigned()
+    public void VerifySignatures_AnImageWindowsCannotParse_ReadsAsUnsignedRatherThanAccused()
     {
-        // An empty file is not "unsigned", it is unreadable — the distinction the three states exist for.
         var exe = WriteTempExe([]);
         try
         {
@@ -61,8 +70,8 @@ public class ProcessSignatureTests
 
             ProcessManagerService.VerifySignatures([entry]);
 
-            Assert.Equal(SignatureTrust.Invalid, entry.Signature);
-            Assert.Contains("could not read", entry.SignatureDetail, StringComparison.Ordinal);
+            Assert.Equal(SignatureTrust.Unsigned, entry.Signature);
+            Assert.Contains("nothing to check", entry.SignatureDetail, StringComparison.Ordinal);
         }
         finally { File.Delete(exe); }
     }
@@ -100,30 +109,40 @@ public class ProcessSignatureTests
         finally { File.Delete(exe); }
     }
 
+    /// <summary>
+    /// A verdict reached for one entry does not leak onto an entry that was never checked.
+    /// </summary>
+    /// <remarks>
+    /// The negative side of the caching test above, and it had to be rebuilt when the mechanism changed.
+    /// It used to pit two synthetic files against each other expecting two different verdicts; under
+    /// <c>WinVerifyTrust</c> every synthetic file is <c>TRUST_E_NOSIGNATURE</c>, so no pair of files a test
+    /// can create will disagree — which is a better outcome for users and a worse one for that assertion.
+    /// <para>What is still fully deterministic, and is the failure that would actually matter: an entry with
+    /// no image path must come out of the loop untouched even when an earlier entry in the same call got a
+    /// verdict. A cache keyed on nothing, or a verdict variable hoisted out of the loop, shows up here as a
+    /// system process wearing another program's signature.</para>
+    /// </remarks>
     [Fact]
-    public void VerifySignatures_TwoDifferentImages_AreNotConflatedByTheCache()
+    public void VerifySignatures_AnEntryWithNoPath_DoesNotInheritTheVerdictBeforeIt()
     {
-        // The negative side of the test above. A cache keyed on something shared between the two — the
-        // process name, say, which is "test" for both here — would hand the second entry the first one's
-        // answer, and the column would be confidently wrong rather than blank.
-        var unsigned = WriteTempExe([0x4D, 0x5A, 0x90, 0x00]);
-        var unreadable = WriteTempExe([]);
+        var exe = WriteTempExe([0x4D, 0x5A, 0x90, 0x00]);
         try
         {
-            var a = Entry(3000, unsigned);
-            var b = Entry(3001, unreadable);
+            var checkedFirst = Entry(3000, exe);
+            var noPath = Entry(3001, "");
+            var checkedLast = Entry(3002, exe);
 
-            ProcessManagerService.VerifySignatures([a, b]);
+            ProcessManagerService.VerifySignatures([checkedFirst, noPath, checkedLast]);
 
-            Assert.Equal(SignatureTrust.Unsigned, a.Signature);
-            Assert.Equal(SignatureTrust.Invalid, b.Signature);
-            Assert.NotEqual(a.SignatureDetail, b.SignatureDetail);
+            Assert.Equal(SignatureTrust.Unsigned, checkedFirst.Signature);
+            Assert.Equal(SignatureTrust.Unknown, noPath.Signature);
+            Assert.Equal("", noPath.SignatureDetail);
+
+            // And the entry after the gap still gets its own answer, from the cache rather than a re-read.
+            Assert.Equal(SignatureTrust.Unsigned, checkedLast.Signature);
+            Assert.Equal(checkedFirst.SignatureDetail, checkedLast.SignatureDetail);
         }
-        finally
-        {
-            File.Delete(unsigned);
-            File.Delete(unreadable);
-        }
+        finally { File.Delete(exe); }
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/StartupSignatureTests.cs
+++ b/SysManager/SysManager.Tests/StartupSignatureTests.cs
@@ -106,12 +106,22 @@ public class StartupSignatureTests
         finally { File.Delete(exe); }
     }
 
+    /// <summary>
+    /// A file Windows cannot parse at all reads as unsigned, not as a problem.
+    /// </summary>
+    /// <remarks>
+    /// This asserts the opposite of what it used to, and the change is the point. The old mechanism read
+    /// the certificate itself, so an empty file surfaced as "signature data present but unreadable" and got
+    /// an amber chip — an accusation produced by the reader failing, not by anything about the file.
+    /// <para>Measured against <c>WinVerifyTrust</c> instead: an empty file, a two-byte stub, a text file
+    /// named <c>.exe</c>, a path that does not exist and even a directory all return
+    /// <c>TRUST_E_NOSIGNATURE</c>. Windows declines to accuse anything it cannot parse, and the column now
+    /// says the same. That is why nothing synthetic can produce the amber state — see
+    /// <see cref="WindowsTrustTests"/> for the mapping, which is where the amber arm is actually pinned.</para>
+    /// </remarks>
     [Fact]
-    public void VerifySignatures_FileWhoseSignatureCannotBeRead_IsFlagged()
+    public void VerifySignatures_FileWindowsCannotParse_ReadsAsUnsignedRatherThanAccused()
     {
-        // An empty file cannot be read as an image at all, which Authenticode.ReadSigner reports as
-        // Unreadable rather than Unsigned. The two must not collapse: one is the common case and the other
-        // is the only state in this column worth a second look.
         var exe = WriteTempExe([]);
         try
         {
@@ -119,8 +129,8 @@ public class StartupSignatureTests
 
             StartupService.VerifySignatures([entry]);
 
-            Assert.Equal(SignatureTrust.Invalid, entry.Signature);
-            Assert.Contains("could not read", entry.SignatureDetail, StringComparison.Ordinal);
+            Assert.Equal(SignatureTrust.Unsigned, entry.Signature);
+            Assert.Contains("nothing to check", entry.SignatureDetail, StringComparison.Ordinal);
         }
         finally { File.Delete(exe); }
     }

--- a/SysManager/SysManager.Tests/WindowsTrustTests.cs
+++ b/SysManager/SysManager.Tests/WindowsTrustTests.cs
@@ -1,0 +1,174 @@
+// SysManager · WindowsTrustTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Helpers;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="WindowsTrust"/> — what Windows concludes about a file's signature, and how that
+/// HRESULT becomes the thing a user reads.
+/// </summary>
+/// <remarks>
+/// <see cref="WindowsTrust.Classify"/> is where the amber chip is decided, so it is tested directly rather
+/// than through a file. Producing a file that is signed-but-untrusted on demand needs a certificate and
+/// signtool; the HRESULT that such a file returns does not, and it is the HRESULT that drives the colour.
+/// <para>That split is exactly what the previous mechanism got wrong. Its wrong verdicts came from the
+/// classification, not from the reading, and no test looked at classification in isolation — so 47 of 48
+/// signed programs were labelled "Check failed" through two releases with a green suite.</para>
+/// </remarks>
+public class WindowsTrustTests
+{
+    // The HRESULTs, named. Written as literals here on purpose: the production constants are private, and a
+    // test that imported them would agree with a typo instead of catching one.
+    private const int SOk = 0;
+    private const int TrustENoSignature = unchecked((int)0x800B0100);
+    private const int TrustESubjectFormUnknown = unchecked((int)0x800B0003);
+    private const int TrustEProviderUnknown = unchecked((int)0x800B0001);
+    private const int CertEExpired = unchecked((int)0x800B0101);
+    private const int CertEUntrustedRoot = unchecked((int)0x800B0109);
+    private const int TrustEExplicitDistrust = unchecked((int)0x800B0111);
+    private const int TrustEBadDigest = unchecked((int)0x80096010);
+    private const int CertERevoked = unchecked((int)0x800B010C);
+
+    [Fact]
+    public void SOk_IsTheOnlyTrustedAnswer()
+        => Assert.Equal(TrustResult.Trusted, WindowsTrust.Classify(SOk));
+
+    /// <summary>
+    /// The three "there is nothing here to check" results are grouped, and that grouping is the fix.
+    /// </summary>
+    /// <remarks>
+    /// <c>TRUST_E_NOSIGNATURE</c> is the ordinary one. The other two come back for a file the Authenticode
+    /// provider does not handle, which is also "nothing to check" rather than "suspect". Classifying those
+    /// as a failure would put an amber chip on ordinary files and teach the user to ignore the column — the
+    /// failure mode this whole mechanism change exists to undo.
+    /// </remarks>
+    [Theory]
+    [InlineData(TrustENoSignature)]
+    [InlineData(TrustESubjectFormUnknown)]
+    [InlineData(TrustEProviderUnknown)]
+    public void NothingToCheck_IsUnsignedRatherThanAFailure(int hresult)
+        => Assert.Equal(TrustResult.NoSignature, WindowsTrust.Classify(hresult));
+
+    [Fact]
+    public void AnExpiredCertificate_GetsItsOwnState_NotTheGenericFailure()
+    {
+        // Separate because the sentence a user reads differs: an expired signing certificate on an older
+        // program is common and says nothing about the file, while an untrusted root or a modified file
+        // does. Collapsing them would make the tooltip lie about one of the two.
+        Assert.Equal(TrustResult.Expired, WindowsTrust.Classify(CertEExpired));
+        Assert.NotEqual(WindowsTrust.Classify(CertEExpired), WindowsTrust.Classify(CertEUntrustedRoot));
+    }
+
+    [Theory]
+    [InlineData(CertEUntrustedRoot)]
+    [InlineData(TrustEExplicitDistrust)]
+    [InlineData(TrustEBadDigest)]
+    [InlineData(CertERevoked)]
+    public void AGenuineSignatureProblem_IsNotTrusted(int hresult)
+        => Assert.Equal(TrustResult.NotTrusted, WindowsTrust.Classify(hresult));
+
+    [Fact]
+    public void AnUnrecognisedFailure_IsNotTrusted_RatherThanQuietlyTrusted()
+    {
+        // The default arm must fail closed. An HRESULT nobody enumerated is a signature Windows would not
+        // accept, and mapping the unknown to Trusted is how a check becomes decorative.
+        Assert.Equal(TrustResult.NotTrusted, WindowsTrust.Classify(unchecked((int)0x8007000E)));
+        Assert.Equal(TrustResult.NotTrusted, WindowsTrust.Classify(unchecked((int)0x80004005)));
+    }
+
+    /// <summary>
+    /// Every file a test can create comes back unsigned, and that is measured rather than assumed.
+    /// </summary>
+    /// <remarks>
+    /// Windows declines to accuse anything it cannot parse: an empty file, a two-byte stub, a text file
+    /// named <c>.exe</c>, a path that does not exist and a directory all return <c>TRUST_E_NOSIGNATURE</c>.
+    /// That is worth pinning, because it is the property that makes the amber state unreachable by accident
+    /// — the previous mechanism produced it from an unparseable file, which is how the column filled with
+    /// warnings about ordinary things.
+    /// </remarks>
+    [Fact]
+    public void NothingUnparseable_IsEverAccused()
+    {
+        var empty = WriteTemp([]);
+        var stub = WriteTemp([0x4D, 0x5A]);
+        var text = WriteTemp(System.Text.Encoding.ASCII.GetBytes("not a program at all"));
+        var missing = Path.Combine(Path.GetTempPath(), "sysmgr_absent_" + Guid.NewGuid().ToString("N") + ".exe");
+
+        try
+        {
+            foreach (var path in new[] { empty, stub, text, missing, Path.GetTempPath() })
+                Assert.Equal(TrustResult.NoSignature, WindowsTrust.Verify(path));
+        }
+        finally
+        {
+            File.Delete(empty);
+            File.Delete(stub);
+            File.Delete(text);
+        }
+    }
+
+    [Fact]
+    public void ABlankPath_IsAnsweredWithoutCallingWindows()
+    {
+        // Not a real question, and the native call would have to marshal a null string to ask it.
+        Assert.Equal(TrustResult.NoSignature, WindowsTrust.Verify(""));
+        Assert.Equal(TrustResult.NoSignature, WindowsTrust.Verify("   "));
+    }
+
+    /// <summary>
+    /// The call asks for no revocation lookup and answers from this machine only.
+    /// </summary>
+    /// <remarks>
+    /// This is the whole "a column makes no network request" guarantee, and it is a property of three
+    /// flags rather than of anything observable from a passing test: dropping
+    /// <c>WTD_CACHE_ONLY_URL_RETRIEVAL</c> compiles, returns the same verdicts on a connected machine, and
+    /// is visible only as a tab that stalls on a train. The previous mechanism's equivalent guarantee was
+    /// asserted the same way and is the reason that regression was caught at all.
+    /// <para>Asserted against the source because the flags go into a native struct the managed side cannot
+    /// read back. The population floor keeps it from passing on a file that no longer contains the call.</para>
+    /// </remarks>
+    [Fact]
+    public void TheTrustCall_AsksForNoNetwork()
+    {
+        var source = File.ReadAllText(Path.Combine(AppProjectDir(), "Helpers", "WindowsTrust.cs"));
+        Assert.True(source.Length > 2000, "WindowsTrust.cs is too small to be the real file");
+
+        // Revocation off: a lookup per file is what a list cannot afford.
+        Assert.Contains("fdwRevocationChecks = WtdRevokeNone", source, StringComparison.Ordinal);
+        Assert.Contains("WtdRevocationCheckNone", source, StringComparison.Ordinal);
+
+        // And the one that actually stops the trust provider fetching: answer from local caches only.
+        Assert.Contains("WtdCacheOnlyUrlRetrieval", source, StringComparison.Ordinal);
+        Assert.Contains("dwProvFlags = WtdSaferFlag | WtdCacheOnlyUrlRetrieval | WtdRevocationCheckNone",
+            source, StringComparison.Ordinal);
+
+        // No UI, ever: WinVerifyTrust will otherwise put a modal dialog on screen from a background scan.
+        Assert.Contains("dwUIChoice = WtdUiNone", source, StringComparison.Ordinal);
+
+        // The state the verify call allocates has to be released, once per file.
+        Assert.Contains("Close(data)", source, StringComparison.Ordinal);
+        Assert.Contains("WtdStateActionClose", source, StringComparison.Ordinal);
+    }
+
+    // Walks up to the app project — source is not copied to the test output.
+    private static string AppProjectDir()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "Helpers")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);   // else the assertions above would silently test nothing
+        return Path.Combine(dir!.FullName, "SysManager");
+    }
+
+    private static string WriteTemp(byte[] bytes)
+    {
+        var path = Path.Combine(Path.GetTempPath(), "sysmgr_trust_" + Guid.NewGuid().ToString("N") + ".exe");
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+}

--- a/SysManager/SysManager/Helpers/SignatureVerdict.cs
+++ b/SysManager/SysManager/Helpers/SignatureVerdict.cs
@@ -2,10 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Security.Cryptography.X509Certificates;
-using Serilog;
 using SysManager.Models;
-using SysManager.Services;
 
 namespace SysManager.Helpers;
 
@@ -14,20 +11,28 @@ namespace SysManager.Helpers;
 /// nobody can say.
 /// </summary>
 /// <remarks>
-/// This is deliberately NOT part of <see cref="Authenticode"/>. That type's contract is that it answers
-/// only the mechanical questions — read the signer, build the chain — and holds no policy about what an
-/// answer MEANS, because the two fail-closed gates disagree with each other on the most important case:
-/// an unsigned file is fatal for the third-party Ookla binary and expected for our own build. Folding a
-/// meaning into <c>Authenticode</c> is how one of those gates would quietly become permissive.
+/// <b>The verdict comes from Windows, not from a chain we build ourselves.</b> This used to read the
+/// signer certificate and build an <c>X509Chain</c> offline, and that does not work: measured over the 82
+/// distinct process images on a stock Windows 11 machine it verified <b>1</b> and reported "Check failed"
+/// for <b>47</b>, including Explorer, svchost and Outlook. An offline chain build still demands a
+/// revocation answer it has no cached CRL for, and an intermediate certificate it cannot fetch. See
+/// <see cref="WindowsTrust"/> for the measurement and the flags. <c>WinVerifyTrust</c> over the same files
+/// returns 46 trusted and 1 genuine failure.
+/// <para>The certificate is still read, but only for the publisher's <em>name</em> — never for the
+/// verdict. That ordering matters: a name is cosmetic, so failing to read one costs a phrase in a tooltip,
+/// whereas the verdict decides what colour the user sees.</para>
+/// <para>This is deliberately NOT part of <see cref="Authenticode"/>. That type answers only the
+/// mechanical managed questions and holds no policy, because the two fail-closed gates disagree with each
+/// other on the most important case: an unsigned file is fatal for the third-party Ookla binary and
+/// expected for our own build. Folding a meaning into it is how one of those gates would quietly become
+/// permissive.</para>
 /// <para>So this type carries one specific policy: <b>the informational one</b>, used by columns that
-/// describe many files and admit no code. Its three rules are the ones a list needs and a gate must not
-/// have — unsigned is ordinary rather than fatal, revocation is checked offline against what is already on
-/// the machine, and every answer comes with a sentence a non-technical reader can act on. A gate that
-/// adopted these would stop being a gate.</para>
+/// describe many files and admit no code. Its rules are the ones a list needs and a gate must not have —
+/// unsigned is ordinary rather than fatal, nothing reaches the network, and every answer comes with a
+/// sentence a non-technical reader can act on. A gate that adopted these would stop being a gate.</para>
 /// <para>Shared between the Startup Manager and the Process Manager because both ask the identical
 /// question of an executable on disk, and because the alternative — the same paragraph of copy written
-/// twice — is the kind of duplication that drifts into two tabs describing the same verdict differently.
-/// </para>
+/// twice — is the kind of duplication that drifts into two tabs describing one verdict differently.</para>
 /// </remarks>
 internal static class SignatureVerdict
 {
@@ -41,33 +46,54 @@ internal static class SignatureVerdict
     /// </remarks>
     internal static (SignatureTrust Trust, string Detail) Describe(string path)
     {
-        var (state, cert, hresult) = Authenticode.ReadSigner(path);
+        var verdict = WindowsTrust.Verify(path);
 
-        if (state is SignerState.Unsigned)
-            return (SignatureTrust.Unsigned,
+        return verdict switch
+        {
+            TrustResult.NoSignature => (SignatureTrust.Unsigned,
                 "Nobody signed this file, so Windows cannot confirm who made it. That is normal for many "
-                + "small programs and does not mean it is unsafe — it just means there is nothing to check.");
+                + "small programs and does not mean it is unsafe — it just means there is nothing to check."),
 
-        if (state is SignerState.Unreadable || cert is null)
-            return (SignatureTrust.Invalid,
-                $"This file carries signature data that Windows could not read (0x{hresult:X8}). A signed "
-                + "file whose signature will not open is worth a closer look.");
+            TrustResult.Expired => (SignatureTrust.Invalid,
+                Signer(path) is { Length: > 0 } expired
+                    ? $"This file says it comes from {expired}, and the certificate used to sign it has "
+                      + "expired without a timestamp Windows can fall back on. Common in older programs, "
+                      + "and not proof of anything wrong — but it means the signature can no longer be "
+                      + "confirmed."
+                    : "The certificate used to sign this file has expired without a timestamp Windows can "
+                      + "fall back on, so the signature can no longer be confirmed."),
+
+            TrustResult.NotTrusted => (SignatureTrust.Invalid,
+                Signer(path) is { Length: > 0 } claimed
+                    ? $"This file says it comes from {claimed}, but Windows does not trust that signature. "
+                      + "Worth a closer look before you trust it."
+                    : "This file carries a signature Windows does not trust. Worth a closer look before "
+                      + "you trust it."),
+
+            _ => (SignatureTrust.Verified,
+                Signer(path) is { Length: > 0 } signer
+                    ? $"Windows can confirm this really comes from {signer}."
+                    : "Windows can confirm this file is signed and has not been modified since."),
+        };
+    }
+
+    /// <summary>
+    /// The publisher name from the file's embedded certificate, or an empty string when there is none to
+    /// read.
+    /// </summary>
+    /// <remarks>
+    /// Cosmetic by design. An empty result costs the tooltip a name and changes no verdict, which is why
+    /// this is a separate step rather than folded into the trust check — every phrasing in
+    /// <see cref="Describe"/> has a form that works without it.
+    /// </remarks>
+    private static string Signer(string path)
+    {
+        var (state, cert, _) = Authenticode.ReadSigner(path);
+        if (state is not SignerState.Signed || cert is null) return "";
 
         using (cert)
         {
-            var signer = CommonName(cert.Subject);
-
-            if (!Authenticode.ValidateChain(cert, X509RevocationMode.Offline, out var statuses))
-            {
-                Log.Debug("Signature chain did not validate for {Path}: {Status}",
-                    LogService.SanitizePath(path), statuses);
-                return (SignatureTrust.Invalid,
-                    $"This file says it comes from {signer}, but Windows could not confirm that "
-                    + $"({statuses}). Worth a closer look before you trust it.");
-            }
-
-            return (SignatureTrust.Verified,
-                $"Windows can confirm this really comes from {signer}.");
+            return CommonName(cert.Subject);
         }
     }
 

--- a/SysManager/SysManager/Helpers/WindowsTrust.cs
+++ b/SysManager/SysManager/Helpers/WindowsTrust.cs
@@ -1,0 +1,196 @@
+// SysManager · WindowsTrust
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Runtime.InteropServices;
+
+namespace SysManager.Helpers;
+
+/// <summary>What Windows itself concludes about a file's signature.</summary>
+internal enum TrustResult
+{
+    /// <summary>Signed, and Windows trusts the signature: the chain resolves and the file is unmodified.</summary>
+    Trusted,
+
+    /// <summary>No signature Windows can see. Ordinary — most small programs are unsigned, and so are ours.</summary>
+    NoSignature,
+
+    /// <summary>The signing certificate has expired and no countersignature timestamp rescues it.</summary>
+    Expired,
+
+    /// <summary>
+    /// Signed, and the signature does not hold up: an untrusted or unreachable root, a revoked or
+    /// explicitly distrusted certificate, or a file altered after it was signed. The one state worth a
+    /// second look.
+    /// </summary>
+    NotTrusted,
+}
+
+/// <summary>
+/// Asks Windows whether it trusts a file's signature, through <c>WinVerifyTrust</c>.
+/// </summary>
+/// <remarks>
+/// <b>Why this exists alongside <see cref="Authenticode"/> rather than inside it.</b> Those are two
+/// different mechanisms answering two different questions, and conflating them is what produced the defect
+/// this type fixes. <see cref="Authenticode"/> reads a certificate and builds a chain with the managed
+/// <c>X509Chain</c>, which the two fail-closed gates need because they compare a specific publisher's
+/// subject before deciding. This asks the operating system for a verdict, which is what an informational
+/// column needs.
+/// <para><b>The measurement that made the case.</b> Over the 82 distinct process images running on a stock
+/// Windows 11 machine, the managed approach verified <b>1</b> and reported "Check failed" for <b>47</b> —
+/// including Explorer, svchost and Outlook. <c>WinVerifyTrust</c> over the same files: <b>46 trusted, 1
+/// genuine failure</b> (an expired certificate). The managed path cannot do better without the network,
+/// because <c>RevocationMode.Offline</c> still demands a revocation answer it has no cached CRL for
+/// (<c>RevocationStatusUnknown</c> on 46 of 48) and a chain it cannot complete locally
+/// (<c>PartialChain</c> on 29). Loosening the flags far enough to pass would mean accepting any
+/// certificate authority, which is not verification.</para>
+/// <para><b>No network request.</b> <c>WTD_REVOKE_NONE</c> asks for no revocation check, and
+/// <c>WTD_CACHE_ONLY_URL_RETRIEVAL</c> tells the trust provider to answer from this machine's caches
+/// rather than fetching anything. That is the "local only" guarantee the offline chain policy was reached
+/// for and does not actually deliver — here it is a documented, supported mode rather than a side effect
+/// of a revocation setting.</para>
+/// <para><b>What this does NOT see: catalog signatures.</b> <c>WTD_CHOICE_FILE</c> verifies the signature
+/// embedded in the file, and Windows components are largely signed through a <c>.cat</c> catalog instead.
+/// 35 of the 82 images above fall in that group and still report <see cref="TrustResult.NoSignature"/>.
+/// Tracked separately; adding it means a catalog lookup before this call, not a change to it.</para>
+/// </remarks>
+internal static partial class WindowsTrust
+{
+    /// <summary><c>WINTRUST_ACTION_GENERIC_VERIFY_V2</c> — the standard Authenticode policy provider.</summary>
+    private static Guid _genericVerifyV2 = new("00AAC56B-CD44-11d0-8CC2-00C04FC295EE");
+
+    private const uint WtdUiNone = 2;
+    private const uint WtdRevokeNone = 0;
+    private const uint WtdChoiceFile = 1;
+    private const uint WtdStateActionVerify = 1;
+    private const uint WtdStateActionClose = 2;
+    private const uint WtdSaferFlag = 0x100;
+    private const uint WtdCacheOnlyUrlRetrieval = 0x1000;
+    private const uint WtdRevocationCheckNone = 0x10;
+
+    // The HRESULTs worth telling apart. Everything else is folded into NotTrusted rather than guessed at.
+    private const uint TrustENoSignature = 0x800B0100;
+    private const uint TrustESubjectFormUnknown = 0x800B0003;
+    private const uint TrustEProviderUnknown = 0x800B0001;
+    private const uint CertEExpired = 0x800B0101;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WINTRUST_FILE_INFO
+    {
+        public uint cbStruct;
+        public IntPtr pcwszFilePath;
+        public IntPtr hFile;
+        public IntPtr pgKnownSubject;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WINTRUST_DATA
+    {
+        public uint cbStruct;
+        public IntPtr pPolicyCallbackData;
+        public IntPtr pSIPClientData;
+        public uint dwUIChoice;
+        public uint fdwRevocationChecks;
+        public uint dwUnionChoice;
+        public IntPtr pFile;
+        public uint dwStateAction;
+        public IntPtr hWVTStateData;
+        public IntPtr pwszURLReference;
+        public uint dwProvFlags;
+        public uint dwUIContext;
+        public IntPtr pSignatureSettings;
+    }
+
+    /// <summary>
+    /// <c>WinVerifyTrust</c> has no A/W variants, so no <c>EntryPoint</c> suffix applies. It reports
+    /// failure as a non-zero HRESULT return rather than by setting the last error, so there is no
+    /// <c>SetLastError</c> either.
+    /// </summary>
+    [LibraryImport("wintrust.dll")]
+    private static partial int WinVerifyTrust(IntPtr window, ref Guid action, IntPtr data);
+
+    /// <summary>
+    /// Windows' verdict on the signature of the file at <paramref name="filePath"/>. Never throws.
+    /// </summary>
+    /// <remarks>
+    /// Costs roughly 25 ms per file and does not get cheaper on a second pass, so a caller covering a
+    /// whole list needs a cache and must keep this off the UI thread.
+    /// </remarks>
+    internal static TrustResult Verify(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath)) return TrustResult.NoSignature;
+
+        var path = Marshal.StringToHGlobalUni(filePath);
+        var file = Marshal.AllocHGlobal(Marshal.SizeOf<WINTRUST_FILE_INFO>());
+        var data = Marshal.AllocHGlobal(Marshal.SizeOf<WINTRUST_DATA>());
+
+        try
+        {
+            Marshal.StructureToPtr(
+                new WINTRUST_FILE_INFO
+                {
+                    cbStruct = (uint)Marshal.SizeOf<WINTRUST_FILE_INFO>(),
+                    pcwszFilePath = path,
+                },
+                file, fDeleteOld: false);
+
+            Marshal.StructureToPtr(
+                new WINTRUST_DATA
+                {
+                    cbStruct = (uint)Marshal.SizeOf<WINTRUST_DATA>(),
+                    dwUIChoice = WtdUiNone,
+                    fdwRevocationChecks = WtdRevokeNone,
+                    dwUnionChoice = WtdChoiceFile,
+                    pFile = file,
+                    dwStateAction = WtdStateActionVerify,
+                    dwProvFlags = WtdSaferFlag | WtdCacheOnlyUrlRetrieval | WtdRevocationCheckNone,
+                },
+                data, fDeleteOld: false);
+
+            var hr = WinVerifyTrust(IntPtr.Zero, ref _genericVerifyV2, data);
+
+            // WTD_STATEACTION_VERIFY allocates state inside the trust provider; the CLOSE call is what
+            // releases it. Skipping it leaks native memory once per file, which on a list this size is the
+            // difference between a tab that costs nothing and one that grows all session.
+            Close(data);
+
+            return Classify(hr);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(data);
+            Marshal.FreeHGlobal(file);
+            Marshal.FreeHGlobal(path);
+        }
+    }
+
+    /// <summary>Releases the provider state the verify call allocated.</summary>
+    private static void Close(IntPtr data)
+    {
+        var closing = Marshal.PtrToStructure<WINTRUST_DATA>(data);
+        closing.dwStateAction = WtdStateActionClose;
+        Marshal.StructureToPtr(closing, data, fDeleteOld: false);
+        WinVerifyTrust(IntPtr.Zero, ref _genericVerifyV2, data);
+    }
+
+    /// <summary>
+    /// Maps an HRESULT to the four states. Pure and internal so the mapping is testable without a signed
+    /// file — producing one on demand needs a certificate and signtool, and the mapping is the part that
+    /// decides what the user is told.
+    /// </summary>
+    /// <remarks>
+    /// The three "no signature" HRESULTs are grouped deliberately. <c>TRUST_E_NOSIGNATURE</c> is the
+    /// ordinary one; <c>TRUST_E_SUBJECT_FORM_UNKNOWN</c> and <c>TRUST_E_PROVIDER_UNKNOWN</c> come back for
+    /// a file the Authenticode provider does not handle at all, which is also "there is nothing here to
+    /// check" rather than "this is suspect". Calling those NotTrusted would put an amber chip on ordinary
+    /// files and teach the user to ignore the column, which is the failure mode this whole change exists
+    /// to undo.
+    /// </remarks>
+    internal static TrustResult Classify(int hresult) => (uint)hresult switch
+    {
+        0 => TrustResult.Trusted,
+        TrustENoSignature or TrustESubjectFormUnknown or TrustEProviderUnknown => TrustResult.NoSignature,
+        CertEExpired => TrustResult.Expired,
+        _ => TrustResult.NotTrusted,
+    };
+}

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.88.1</Version>
-    <FileVersion>1.88.1.0</FileVersion>
-    <AssemblyVersion>1.88.1.0</AssemblyVersion>
+    <Version>1.88.2</Version>
+    <FileVersion>1.88.2.0</FileVersion>
+    <AssemblyVersion>1.88.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #2229.

## Problem

The Signature column reported **"Check failed"** for almost every signed program on a healthy Windows 11 machine. Measured over the 82 distinct images of the running process list:

| | Verified | Unsigned | "Check failed" |
|---|---|---|---|
| **Shipped (v1.85.0 – v1.88.1)** | **1** | 34 | **47** |
| **This change** | **46** | 33 | **1** |

Amber was meant to be the rare case. It was the default, on File Explorer, `svchost`, Outlook, Windows Terminal, Windows Settings and the rest — all properly Microsoft-signed. The one remaining warning is a genuine expired certificate with no timestamp to fall back on.

It was invisible to the suite for two releases because every test supplies its own file, and the `Verified` arm was explicitly documented as untestable without a test certificate. That gap is now closed from the other end: the HRESULT-to-state mapping is tested directly, since that is what decides the colour.

## Root cause

`RevocationMode.Offline` does not mean *skip revocation*. The chain engine still wants a revocation answer for every non-root certificate and, with no cached CRL, reports `OfflineRevocation` + `RevocationStatusUnknown` and `Build()` returns false — **46 of 48**. `PartialChain` accounted for 29 more: the intermediate is not in the local store, and #2222 correctly stopped fetching it.

Four policies measured over the same certificates, all keeping `Offline` and no downloads:

| Candidate | Verified | Blocked by |
|---|---|---|
| `NoFlag` (shipped) | 1 / 48 | RevocationStatusUnknown 46, PartialChain 29, NotTimeValid 12 |
| ignore revocation-unknown | 15 / 48 | RevocationStatusUnknown 32, PartialChain 29 |
| + ignore `NotTimeValid` | 18 / 48 | **PartialChain 29** |
| + `AllowUnknownCertificateAuthority` | 48 / 48 | nothing — and nothing is verified either |

So the two requirements conflict **in the approach, not in a flag**: a chain that validates needs the network, and a column covering every entry on the machine must not use it. The last row reaches 48/48 only by accepting any certificate authority, which a self-signed certificate would also pass.

Three changes had already been made to this one mechanism — introduced in v1.85.0, downloads disabled in v1.87.1, extended to a second tab in v1.88.0 — so per the 3-Strike rule this was the root assumption being wrong rather than a case for a fourth attempt. Stopped, measured, wrote it up in #2229, and the mechanism was chosen rather than assumed.

## Fix

`Helpers/WindowsTrust` — `WinVerifyTrust` with `WINTRUST_ACTION_GENERIC_VERIFY_V2`, the API behind Explorer's *Digital Signatures* tab, Autoruns and Process Explorer. A user who doubts the column can now check it against a file's own Properties dialog and get the same answer.

**No network request.** `WTD_REVOKE_NONE` asks for no revocation lookup and `WTD_CACHE_ONLY_URL_RETRIEVAL` tells the trust provider to answer from this machine's caches. That is a documented, supported "local only" mode — the guarantee `Offline` was reached for and does not deliver.

**The certificate is still read, but only for the publisher's name — never for the verdict.** That ordering is the fix in miniature: a name is cosmetic, so failing to read one costs a phrase in a tooltip, while a verdict decides a colour. Every phrasing has a form that works without a name.

Kept in its own type rather than folded into `Helpers/Authenticode`, whose class doc forbids it holding meaning-policy — the two fail-closed gates (the updater and the Ookla binary) still build managed chains and still disagree with each other on what an unsigned file means. That reasoning was right and is respected.

## Two behaviours inverted on purpose

**A file Windows cannot parse now reads as unsigned, not accused.** Measured: an empty file, a two-byte stub, a text file named `.exe`, a path that does not exist and even a directory all return `TRUST_E_NOSIGNATURE`. Windows declines to accuse what it cannot parse. Previously *our reader* failing to parse a file produced a warning about the file, which blamed the wrong party — and it means the amber state is now unreachable from any synthetic input, which is the property worth having.

**The cache non-conflation test had to be rebuilt.** It pitted two synthetic files against each other expecting different verdicts; under `WinVerifyTrust` no pair of files a test can create will disagree. Replaced with the failure that is still deterministic and is the one that would actually matter: an entry with no image path must come out of the loop untouched even when an earlier entry got a verdict — a cache keyed on nothing, or a verdict hoisted out of the loop, shows up as a system process wearing another program's signature.

## Red before, green after

`D:\rel-tmp\wvt-proof.py` — seven mutations, rebuild and re-run per mutation, both files restored hash-verified.

| Mutation | Result | Caught by |
|---|---|---|
| baseline | GREEN | — |
| 1. classify "no signature" as a failure — **the shipped defect's shape** | **RED** | 11 tests, across all four classes |
| 2. fail **open**: map an unknown HRESULT to Trusted | **RED** | `AnUnrecognisedFailure_IsNotTrusted_RatherThanQuietlyTrusted` |
| 3. collapse an expired certificate into the generic failure | **RED** | `AnExpiredCertificate_GetsItsOwnState_NotTheGenericFailure` |
| 4. drop `WTD_CACHE_ONLY_URL_RETRIEVAL` — the no-network guarantee | **RED** | `TheTrustCall_AsksForNoNetwork` |
| 5. never release the provider state (a native leak per file) | **RED** | `TheTrustCall_AsksForNoNetwork` |
| 6. stop reading the certificate for the publisher name | **RED** | `TheInformationalPath_DoesNotBuildAManagedChain` |
| 7. take the verdict from the certificate read instead of Windows | **RED** | `TheInformationalPath_DoesNotBuildAManagedChain` |
| restored | GREEN | — |

Mutation 1 tripping 11 tests is the useful signal: the defect's shape is now visible from four independent directions rather than one.

One honest limit: the `DoesNotContain("ValidateChain")` and `DoesNotContain("X509RevocationMode")` arms of guard 6/7 cannot be driven red without writing the bad code back in, so they are documented intent rather than proven arms. The positive arms of the same guard are proven, above.

## Known limitations, documented rather than left to be found

- **Catalog signatures are not read** (#2230). `WTD_CHOICE_FILE` verifies the embedded signature, and Windows signs many of its own components through a `.cat` file — 35 of the 82 images. They read **Unsigned**, which understates them rather than accusing them. README, `SECURITY.md` and the changelog all say so.
- **First load costs ~2 s** (#2231). `WinVerifyTrust` is ~25 ms per file and does not get cheaper warm — 2163 ms cold, 2188 ms on an immediately repeated pass. That is Windows' price, not ours, so the fix is to take verification off the critical path rather than to optimise it. The steady-state refresh is unaffected (0 verifications, since only new PIDs carry a path).

## Verification

- `dotnet build` — all four projects, **0 warnings, 0 errors**
- Unit suite: **5428 passed, 0 failed**, run twice (once after the doc edits)
- End-to-end against the real process list through the app's own code: Verified 46, Unsigned 33, Invalid 1 per distinct image; 140 / 93 / 2 per row; steady-state refresh verifies nothing
- `dotnet format --verify-no-changes` — all four projects, exit 0
- Leak scan — all 43 current terms against the 53798-byte staged diff, 0 hits, floor asserted
- Docs corrected in this PR, all of which described the old mechanism: `README.md` (both tab sections), `SECURITY.md`, `ARCHITECTURE.md`, `CHANGELOG.md`

Version bumped to 1.88.2.

**Deferred to the secondary workstation:** the three pill states rendered in the live tabs. The verdict distribution is verified here through the service; what is not verified on this machine is how the column looks now that amber is rare.
