### PR TITLE
fix: read a signature stored in a Windows catalogue too

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -319,9 +319,21 @@ Key services:
   `Classify` is a pure HRESULT map, kept `internal` and tested directly, because it is what
   decides the colour a user sees and the previous mechanism's wrong verdicts came from
   classification rather than from reading. Costs ~25 ms per file and does not get cheaper warm,
-  so callers cache and stay off the UI thread. Does not see catalog signatures
-  (`WTD_CHOICE_FILE` reads the embedded one), which is why Windows components still read as
-  unsigned.
+  so callers cache and stay off the UI thread.
+  **Two questions, in order.** `WTD_CHOICE_FILE` sees only the signature embedded in a file, and
+  Windows signs most of its own components through a `.cat` catalogue — 35 of those 82 images carry
+  no embedded signature and 12 of the 35 verify through a catalogue (`powershell.exe`, `cmd.exe`,
+  `conhost.exe`, the search host). So a `NoSignature` answer gets a second question:
+  `CryptCATAdminAcquireContext2` with **SHA-256 by name** (the older `CryptCATAdminAcquireContext`
+  implies SHA-1), hash the file, `CryptCATAdminEnumCatalogFromHash`, then `WinVerifyTrust` again with
+  `WTD_CHOICE_CATALOG`. The hash is both the lookup key and the member tag; the tag is upper-case hex
+  because that is the documented shape, and measurement showed it is **not** load-bearing (forcing lower
+  case left every real verification passing). Only `NoSignature` falls through — an expired
+  or untrusted embedded signature is an answer, and looking for a catalogue that might disagree would
+  be picking the more flattering verdict. Two native handles and an allocation are released on every
+  path including the failures, because a leak here is once per unsigned file per refresh on a tab
+  that polls. `CatalogSignatureTests` (integration) is the only place this can be verified for real:
+  no file a unit test can create is catalog-signed.
 - `DuplicateFileService` — three-pass duplicate finder (size grouping →
   partial hash pre-filter → full SHA-256). Read-only, never deletes.
 - `DiskAnalyzerService` — folder-level space breakdown with progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.88.3] - 2026-09-10
+
+**Windows' own programs no longer show as "Unsigned".** Windows signs most of its own components in a
+separate catalogue file rather than inside the program itself, and the Signature column was only looking
+inside the program — so PowerShell, Command Prompt, the console host and the search box all appeared to
+have no signature at all. They are signed, and Windows says so; we just were not asking the right
+question. On this machine that moves twelve more programs into **Verified**, and what is left marked
+unsigned is genuinely unsigned.
+
+### Fixed
+
+- **A signature stored in a Windows catalogue is now read too.** The column asks about the signature
+  inside the file first and, only when there is none, looks the file up in your PC's catalogues — so a
+  program carrying its own signature costs nothing extra.
+- Together with the previous fix, the column now confirms 59 of the 82 programs running on a test
+  machine, against 1 before either change. The 22 still marked unsigned are ordinary third-party
+  programs that really are unsigned, and the single warning left is a genuinely expired certificate.
+- Still no network request, for either kind of signature.
+- A file the app cannot open — locked, or permission denied — reads as unsigned rather than as a
+  problem, the same way anything unparseable already did. "We could not look" must not read as "we
+  looked and it failed".
+
+### Known limitation
+
+- Opening the Process Manager now takes around three and a half seconds the first time while it checks
+  each program, though later refreshes are unaffected because only newly started programs are checked.
+  Making the list appear immediately and fill the column in behind it is the next change on this tab.
+
 ## [1.88.2] - 2026-09-10
 
 **The Signature column was telling you almost every program on your PC had failed its check.** It was

--- a/README.md
+++ b/README.md
@@ -495,9 +495,10 @@ a confirmation before it runs:
   - The verdict is Windows' own, from the same check behind Explorer's **Digital Signatures** tab, so
     it agrees with what Windows tells you elsewhere. It asks for no revocation lookup and answers from
     your PC only, so opening the tab never waits on the network and downloads nothing.
-  - What it does not yet see: a signature kept in a Windows catalogue instead of inside the file. A
-    number of Windows components are signed that way and currently show as **Unsigned** — the column
-    understates them rather than accusing them.
+  - **Windows components count as signed too.** Windows signs most of its own programs through a separate
+    catalogue file rather than inside the program, and both are read — so `powershell.exe`, `cmd.exe` and
+    the rest are confirmed rather than listed as unsigned. Anything still marked **Unsigned** after that is
+    genuinely unsigned.
 - Sort by name, publisher, location, safety, status, signature, or startup impact via clickable column
   headers
 - Plain-language description for recognised programs (from the built-in database) instead
@@ -589,8 +590,10 @@ a confirmation before it runs:
     for no revocation lookup and answers from your PC only, and it runs just for processes that have
     just appeared, so a tab refreshing every second neither re-checks the same programs nor reaches
     for the network
-  - Windows components signed through a Windows catalogue rather than inside the file show as
-    **Unsigned** for now — understated rather than accused
+  - **Windows components count as signed too** — Windows signs most of its own programs through a
+    separate catalogue file rather than inside the program, and both are read, so `svchost.exe`,
+    `conhost.exe` and the rest are confirmed rather than listed as unsigned. What is still marked
+    **Unsigned** is genuinely unsigned
 - Kill process with confirmation dialog, and the warning matches the real cost.
   Processes Windows genuinely cannot survive losing (`winlogon`, `csrss`, `lsass`, …)
   are refused outright. Security and servicing processes (Defender's engine, Windows

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -122,9 +122,10 @@ What the app can and cannot do by design:
   - The trade-off, stated plainly: a certificate revoked since your PC last refreshed its lists still reads
     as verified. That is the right bias for a column that informs you and the wrong one for a gate that
     admits code, which is why the two differ.
-  - What the columns do **not** see: a signature stored in a Windows catalogue rather than inside the file.
-    Many Windows components are signed that way and currently read as "Unsigned" — the column understates
-    them rather than accusing them.
+  - **Both kinds of signature are read.** Windows signs most of its own components through a catalogue file
+    (`.cat`) rather than inside the program, so the check asks about the embedded signature first and, when
+    there is none, looks the file up in the machine's catalogues. Neither step contacts anything. A file
+    reported as unsigned after both is genuinely unsigned.
   - Reading the publisher's *name* is a separate step from deciding whether the signature holds, and it
     only ever affects the wording of a tooltip. A verdict is never derived from it.
 - **Local diagnostic log**: SysManager keeps 14 days of rolling log files in

--- a/SysManager/SysManager.IntegrationTests/CatalogSignatureTests.cs
+++ b/SysManager/SysManager.IntegrationTests/CatalogSignatureTests.cs
@@ -1,0 +1,135 @@
+// SysManager · CatalogSignatureTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Helpers;
+
+namespace SysManager.IntegrationTests;
+
+/// <summary>
+/// The catalog half of <see cref="WindowsTrust"/>, against real Windows binaries.
+/// </summary>
+/// <remarks>
+/// This lives in the integration suite rather than the unit one because it is a genuine system dependency:
+/// it needs the machine's catalog store, and there is no way to fake one. The unit suite covers the HRESULT
+/// mapping and the member-tag formatting, which is where the decisions are.
+/// <para><b>It exists because the unit suite structurally could not catch the defect it guards.</b> Every
+/// unit test writes its own temp file, and no file a test can create is catalog-signed — so a catalog
+/// lookup that silently returned "no signature" for everything would pass the entire unit suite. Reporting
+/// <c>powershell.exe</c> as unsigned is exactly what shipped for three releases.</para>
+/// </remarks>
+[Collection("Sequential")]
+public class CatalogSignatureTests
+{
+    /// <summary>
+    /// Windows binaries signed through a catalog rather than in the file are recognised as trusted.
+    /// </summary>
+    /// <remarks>
+    /// These carry no embedded Authenticode signature — Explorer's Digital Signatures tab shows nothing for
+    /// them — yet `Get-AuthenticodeSignature` calls them Valid, and so do Autoruns and Process Explorer,
+    /// because their signature lives in a <c>.cat</c> under <c>CatRoot</c>. Measured on a stock Windows 11
+    /// machine: 12 of the 35 running images with no embedded signature verify this way.
+    /// <para>Asserted per file with the name in the message, so a failure says WHICH binary stopped
+    /// verifying rather than only that the count changed.</para>
+    /// </remarks>
+    [Theory]
+    [InlineData(@"System32\cmd.exe")]
+    [InlineData(@"System32\conhost.exe")]
+    [InlineData(@"System32\WindowsPowerShell\v1.0\powershell.exe")]
+    public void ACatalogSignedWindowsBinary_IsTrusted(string relative)
+    {
+        var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), relative);
+
+        // Skip rather than fail if a future Windows drops one of these: the claim is about catalog
+        // verification, not about which binaries ship.
+        if (!File.Exists(path)) return;
+
+        Assert.Equal(TrustResult.Trusted, WindowsTrust.Verify(path));
+    }
+
+    /// <summary>
+    /// At least one of them really is catalog-signed rather than all of them having gained an embedded one.
+    /// </summary>
+    /// <remarks>
+    /// The vacuity guard for the test above. If Microsoft ever embedded signatures in these files, that test
+    /// would keep passing while exercising nothing of the catalog path — the very failure mode this whole
+    /// area has already produced once. There is no public way to ask "was that answered by a catalog", so
+    /// this asserts the observable proxy: the file has no embedded signature of its own, which is what makes
+    /// the trusted verdict above necessarily a catalog result.
+    /// </remarks>
+    [Fact]
+    public void AtLeastOneOfThem_HasNoEmbeddedSignature_SoTheCatalogPathIsWhatAnswered()
+    {
+        var windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        string[] candidates =
+        [
+            Path.Combine(windows, @"System32\cmd.exe"),
+            Path.Combine(windows, @"System32\conhost.exe"),
+            Path.Combine(windows, @"System32\WindowsPowerShell\v1.0\powershell.exe"),
+        ];
+
+        var present = candidates.Where(File.Exists).ToList();
+        Assert.NotEmpty(present);
+
+        // No embedded certificate to read: Authenticode.ReadSigner reports Unsigned for a catalog-signed
+        // file, because the certificate is not in the file at all.
+        var withoutEmbedded = present
+            .Where(p => Authenticode.ReadSigner(p).State is SignerState.Unsigned)
+            .ToList();
+
+        Assert.True(withoutEmbedded.Count > 0,
+            "every candidate now carries its own embedded signature, so the theory above no longer "
+            + "exercises the catalog path at all. Pick binaries that are still catalog-signed, or the "
+            + "catalog lookup is unguarded: "
+            + string.Join(", ", present.Select(Path.GetFileName)));
+
+        // And those same files verify — which they can only do through a catalog.
+        foreach (var p in withoutEmbedded)
+            Assert.Equal(TrustResult.Trusted, WindowsTrust.Verify(p));
+    }
+
+    [Fact]
+    public void AFileInNoCatalogAndWithNoSignature_IsUnsignedRatherThanAccused()
+    {
+        // The other side: the catalog lookup must not turn "not in any catalog" into a problem. This is the
+        // normal state of most third-party programs — 22 of 82 images on the measured machine.
+        var path = Path.Combine(Path.GetTempPath(), "sysmgr_nocat_" + Guid.NewGuid().ToString("N") + ".exe");
+        File.WriteAllBytes(path, [0x4D, 0x5A, 0x90, 0x00]);
+
+        try
+        {
+            Assert.Equal(TrustResult.NoSignature, WindowsTrust.Verify(path));
+        }
+        finally { File.Delete(path); }
+    }
+
+    /// <summary>
+    /// Repeated verification of a catalog-signed file keeps working and keeps giving the same answer.
+    /// </summary>
+    /// <remarks>
+    /// <b>Deliberately NOT a leak test, and the reason is worth recording.</b> The first version of this
+    /// counted process handles across 200 verifications. A mutation removing
+    /// <c>CryptCATAdminReleaseCatalogContext</c> — and a second removing
+    /// <c>CryptCATAdminReleaseContext</c> — left it passing: those release a catalogue *context*, which is a
+    /// heap structure rather than a kernel handle, so <c>Process.HandleCount</c> never moves. It measured the
+    /// wrong instrument, and a leak test that cannot see the leak is worse than none because it is cited as
+    /// coverage.
+    /// <para>The release calls are pinned by source assertion in
+    /// <c>WindowsTrustTests.AFileWithNoEmbeddedSignature_IsAlsoCheckedAgainstTheCatalogs</c>, which both
+    /// mutations do fail. What is left worth asserting here is the property a repeated call actually has:
+    /// the second and two-hundredth answer match the first, which is what a context reused or released out
+    /// from under the next call would break.</para>
+    /// </remarks>
+    [Fact]
+    public void RepeatedVerification_KeepsGivingTheSameAnswer()
+    {
+        var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), @"System32\cmd.exe");
+        if (!File.Exists(path)) return;
+
+        var first = WindowsTrust.Verify(path);
+        Assert.Equal(TrustResult.Trusted, first);
+
+        for (var i = 0; i < 50; i++) Assert.Equal(first, WindowsTrust.Verify(path));
+    }
+}

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -9336,6 +9336,11 @@ public partial class ArchitectureTests
             "RmGetList",
             "RmEndSession",
             "SHGetKnownFolderPath",   // shell32: returns a PWSTR, no A/W pair
+            // wintrust: the "2" suffix IS the wide-only revision. It takes the hash algorithm as a PCWSTR
+            // and ships no A/W pair, so appending W binds nothing. Confirmed by running it rather than by
+            // reading a header: the catalog lookup it opens verifies 12 real Windows binaries, which a
+            // failed bind could not do (LibraryImport throws EntryPointNotFoundException at first use).
+            "CryptCATAdminAcquireContext2",
         ];
 
         var root = Path.Combine(FindRepoRoot(), "SysManager", "SysManager");

--- a/SysManager/SysManager.Tests/WindowsTrustTests.cs
+++ b/SysManager/SysManager.Tests/WindowsTrustTests.cs
@@ -120,6 +120,72 @@ public class WindowsTrustTests
     }
 
     /// <summary>
+    /// A file with no signature of its own gets a second question: the Windows catalogs.
+    /// </summary>
+    /// <remarks>
+    /// Windows signs most of its own components through a <c>.cat</c> file rather than inside the binary, so
+    /// <c>WTD_CHOICE_FILE</c> alone reports <c>powershell.exe</c>, <c>cmd.exe</c> and <c>conhost.exe</c> as
+    /// unsigned — 12 of the 35 running images with no embedded signature verify through a catalog.
+    /// <para>Asserted against the source because no file a unit test can create is catalog-signed: a catalog
+    /// lookup that silently answered "no signature" for everything would pass this entire suite. The real
+    /// verification is <c>CatalogSignatureTests</c> in the integration project, against actual Windows
+    /// binaries; what belongs here is that the second question is asked at all, and asked ONLY for
+    /// <see cref="TrustResult.NoSignature"/>.</para>
+    /// <para>That last part is a decision, not a detail: falling back for an expired or untrusted embedded
+    /// signature would be choosing the more flattering of two verdicts.</para>
+    /// </remarks>
+    [Fact]
+    public void AFileWithNoEmbeddedSignature_IsAlsoCheckedAgainstTheCatalogs()
+    {
+        var source = File.ReadAllText(Path.Combine(AppProjectDir(), "Helpers", "WindowsTrust.cs"));
+        Assert.True(source.Length > 3000, "WindowsTrust.cs is too small to be the real file");
+
+        // The fallback happens, and only on the no-signature answer.
+        Assert.Contains("embedded is TrustResult.NoSignature ? VerifyByCatalog(filePath) : embedded",
+            source, StringComparison.Ordinal);
+
+        // SHA-256 by name. The older CryptCATAdminAcquireContext implies SHA-1 and must not come back.
+        Assert.Contains("CryptCATAdminAcquireContext2", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("CryptCATAdminAcquireContext(", source, StringComparison.Ordinal);
+        Assert.Contains("Sha256 = \"SHA256\"", source, StringComparison.Ordinal);
+
+        // Both handles released. Three of the five native steps can fail, so these belong in a finally and
+        // a leak here is once per unsigned file per refresh on a tab that polls.
+        Assert.Contains("CryptCATAdminReleaseCatalogContext(admin, catalog, 0)", source, StringComparison.Ordinal);
+        Assert.Contains("CryptCATAdminReleaseContext(admin, 0)", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The member tag is upper-case hex — the documented shape, and deliberately not claimed to be more.
+    /// </summary>
+    /// <remarks>
+    /// This started out asserting that upper case was load-bearing, on the reasoning that the tag is matched
+    /// against what the catalog stores. A mutation refuted it: forcing the tag to lower case left every real
+    /// catalog verification in <c>CatalogSignatureTests</c> passing, so the trust provider is not matching on
+    /// this string in the way its name suggests.
+    /// <para>Kept, because pinning the documented format is worth a line and a future change to it should be
+    /// deliberate — but the docstring says what the evidence supports rather than what sounded right. A test
+    /// whose stated reason is false is worse than no test, because it survives review on the strength of the
+    /// reason.</para>
+    /// </remarks>
+    [Fact]
+    public void TheMemberTag_IsUpperCaseHex()
+    {
+        var bytes = new byte[] { 0x0A, 0xBC, 0xDE, 0xF0, 0x00, 0xFF };
+        var buffer = System.Runtime.InteropServices.Marshal.AllocHGlobal(bytes.Length);
+        try
+        {
+            System.Runtime.InteropServices.Marshal.Copy(bytes, 0, buffer, bytes.Length);
+
+            var tag = WindowsTrust.HexTag(buffer, (uint)bytes.Length);
+
+            Assert.Equal("0ABCDEF000FF", tag);
+            Assert.Equal(tag.ToUpperInvariant(), tag);   // stated directly rather than left to the literal
+        }
+        finally { System.Runtime.InteropServices.Marshal.FreeHGlobal(buffer); }
+    }
+
+    /// <summary>
     /// The call asks for no revocation lookup and answers from this machine only.
     /// </summary>
     /// <remarks>

--- a/SysManager/SysManager/Helpers/WindowsTrust.cs
+++ b/SysManager/SysManager/Helpers/WindowsTrust.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace SysManager.Helpers;
@@ -49,19 +50,27 @@ internal enum TrustResult
 /// rather than fetching anything. That is the "local only" guarantee the offline chain policy was reached
 /// for and does not actually deliver — here it is a documented, supported mode rather than a side effect
 /// of a revocation setting.</para>
-/// <para><b>What this does NOT see: catalog signatures.</b> <c>WTD_CHOICE_FILE</c> verifies the signature
-/// embedded in the file, and Windows components are largely signed through a <c>.cat</c> catalog instead.
-/// 35 of the 82 images above fall in that group and still report <see cref="TrustResult.NoSignature"/>.
-/// Tracked separately; adding it means a catalog lookup before this call, not a change to it.</para>
+/// <para><b>Catalog signatures are read too, and they are not a detail.</b> <c>WTD_CHOICE_FILE</c> sees only
+/// the signature embedded in a file, and Windows signs most of its own components through a <c>.cat</c>
+/// catalogue instead — 35 of those 82 images carry no embedded signature, and 12 of the 35 are verified
+/// through a catalogue, including <c>powershell.exe</c>, <c>cmd.exe</c>, <c>conhost.exe</c> and the search
+/// host. Reporting those as unsigned understated them on the one tab whose question is "is this Windows?".
+/// The remaining 23 are genuinely unsigned third-party programs.</para>
+/// <para>The catalogue lookup is a second question asked only when the first finds nothing, so a file with
+/// its own signature pays nothing for it. Both cost roughly 25 ms and neither improves on a warm pass.</para>
 /// </remarks>
 internal static partial class WindowsTrust
 {
     /// <summary><c>WINTRUST_ACTION_GENERIC_VERIFY_V2</c> — the standard Authenticode policy provider.</summary>
     private static Guid _genericVerifyV2 = new("00AAC56B-CD44-11d0-8CC2-00C04FC295EE");
 
+    /// <summary>The hash algorithm the catalogue lookup asks for, by name and never by default.</summary>
+    private const string Sha256 = "SHA256";
+
     private const uint WtdUiNone = 2;
     private const uint WtdRevokeNone = 0;
     private const uint WtdChoiceFile = 1;
+    private const uint WtdChoiceCatalog = 2;
     private const uint WtdStateActionVerify = 1;
     private const uint WtdStateActionClose = 2;
     private const uint WtdSaferFlag = 0x100;
@@ -102,24 +111,92 @@ internal static partial class WindowsTrust
     }
 
     /// <summary>
+    /// <c>WINTRUST_CATALOG_INFO</c> — the union member for verifying a file as part of a catalogue.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WINTRUST_CATALOG_INFO
+    {
+        public uint cbStruct;
+        public uint dwCatalogVersion;
+        public IntPtr pcwszCatalogFilePath;
+        public IntPtr pcwszMemberTag;
+        public IntPtr pcwszMemberFilePath;
+        public IntPtr hMemberFile;
+        public IntPtr pbCalculatedFileHash;
+        public uint cbCalculatedFileHash;
+        public IntPtr pcCatalogContext;
+        public IntPtr hCatAdmin;
+    }
+
+    // CATALOG_INFO is { DWORD cbStruct; WCHAR wszCatalogFile[MAX_PATH]; }. The inline WCHAR array is not
+    // marshallable by a source-generated P/Invoke, so it is passed as raw memory and the path read out by
+    // hand. The offset is where the array starts: straight after the DWORD, no alignment padding for WCHAR.
+    private const int CatalogInfoSize = 4 + 260 * 2;
+    private const int CatalogInfoPathOffset = 4;
+
+    /// <summary>
     /// <c>WinVerifyTrust</c> has no A/W variants, so no <c>EntryPoint</c> suffix applies. It reports
     /// failure as a non-zero HRESULT return rather than by setting the last error, so there is no
-    /// <c>SetLastError</c> either.
+    /// <c>SetLastError</c> either. The same is true of the catalogue functions below, which report failure
+    /// through their return value.
     /// </summary>
     [LibraryImport("wintrust.dll")]
     private static partial int WinVerifyTrust(IntPtr window, ref Guid action, IntPtr data);
+
+    [LibraryImport("wintrust.dll", StringMarshalling = StringMarshalling.Utf16)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CryptCATAdminAcquireContext2(
+        out IntPtr admin, IntPtr subsystem, string hashAlgorithm, IntPtr policy, uint flags);
+
+    [LibraryImport("wintrust.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CryptCATAdminReleaseContext(IntPtr admin, uint flags);
+
+    [LibraryImport("wintrust.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CryptCATAdminCalcHashFromFileHandle2(
+        IntPtr admin, IntPtr file, ref uint hashSize, IntPtr hash, uint flags);
+
+    [LibraryImport("wintrust.dll")]
+    private static partial IntPtr CryptCATAdminEnumCatalogFromHash(
+        IntPtr admin, IntPtr hash, uint hashSize, uint flags, IntPtr previous);
+
+    [LibraryImport("wintrust.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CryptCATAdminReleaseCatalogContext(IntPtr admin, IntPtr catalog, uint flags);
+
+    [LibraryImport("wintrust.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CryptCATCatalogInfoFromContext(IntPtr catalog, IntPtr info, uint flags);
 
     /// <summary>
     /// Windows' verdict on the signature of the file at <paramref name="filePath"/>. Never throws.
     /// </summary>
     /// <remarks>
-    /// Costs roughly 25 ms per file and does not get cheaper on a second pass, so a caller covering a
-    /// whole list needs a cache and must keep this off the UI thread.
+    /// Two questions, asked in order. First the signature embedded in the file; if there is none, the
+    /// Windows catalogues, because that is how Windows signs most of its own components — and 12 of the 35
+    /// process images with no embedded signature on a stock Windows 11 machine are verified that way,
+    /// including <c>powershell.exe</c>, <c>cmd.exe</c>, <c>conhost.exe</c> and the search host. Reporting
+    /// those as unsigned understated them, on the one tab whose question is "is this Windows?".
+    /// <para>The catalogue lookup runs ONLY when the embedded check finds nothing, so a file carrying its
+    /// own signature pays nothing for it. Both steps cost roughly 25 ms and neither gets cheaper on a
+    /// second pass, so a caller covering a whole list needs a cache and must stay off the UI thread.</para>
     /// </remarks>
     internal static TrustResult Verify(string filePath)
     {
         if (string.IsNullOrWhiteSpace(filePath)) return TrustResult.NoSignature;
 
+        var embedded = VerifyEmbedded(filePath);
+
+        // Only "no signature in the file" is worth a second question. An expired or untrusted embedded
+        // signature is an answer, and going looking for a catalogue that might say otherwise would be
+        // choosing the more flattering of two verdicts.
+        return embedded is TrustResult.NoSignature ? VerifyByCatalog(filePath) : embedded;
+    }
+
+    /// <summary>The verdict on the signature embedded in the file itself.</summary>
+    private static TrustResult VerifyEmbedded(string filePath)
+    {
         var path = Marshal.StringToHGlobalUni(filePath);
         var file = Marshal.AllocHGlobal(Marshal.SizeOf<WINTRUST_FILE_INFO>());
         var data = Marshal.AllocHGlobal(Marshal.SizeOf<WINTRUST_DATA>());
@@ -162,6 +239,144 @@ internal static partial class WindowsTrust
             Marshal.FreeHGlobal(file);
             Marshal.FreeHGlobal(path);
         }
+    }
+
+    /// <summary>
+    /// The verdict from a Windows catalogue, for a file that carries no signature of its own.
+    /// </summary>
+    /// <remarks>
+    /// Four native steps: take a catalogue-admin context, hash the file the way the catalogues do, find the
+    /// catalogue holding that hash, then verify the file AS A MEMBER of it. The hash is both the lookup key
+    /// and the member tag, which is why it is computed once and passed to both.
+    /// <para><b>SHA-256, explicitly.</b> <c>CryptCATAdminAcquireContext2</c> takes the algorithm by name;
+    /// the older <c>CryptCATAdminAcquireContext</c> implies SHA-1 and has no place in new code.</para>
+    /// <para><b>Every handle is released on every path, including the failures</b>, and this is the
+    /// leak-prone part: there are two native handles and a native allocation, and three of the five steps
+    /// can fail. A leak here is once per unsigned file per refresh, on a tab that refreshes on a timer.</para>
+    /// <para>A file the app cannot open — locked, or access denied — is reported as unsigned rather than as
+    /// a problem, matching what the embedded check does for anything it cannot parse. "We could not look"
+    /// must not read as "we looked and it failed".</para>
+    /// </remarks>
+    private static TrustResult VerifyByCatalog(string filePath)
+    {
+        if (!CryptCATAdminAcquireContext2(out var admin, IntPtr.Zero, Sha256, IntPtr.Zero, 0))
+            return TrustResult.NoSignature;
+
+        FileStream? file = null;
+        var hash = IntPtr.Zero;
+        var catalog = IntPtr.Zero;
+        var info = IntPtr.Zero;
+
+        try
+        {
+            try { file = File.OpenRead(filePath); }
+            catch (IOException) { return TrustResult.NoSignature; }
+            catch (UnauthorizedAccessException) { return TrustResult.NoSignature; }
+            catch (ArgumentException) { return TrustResult.NoSignature; }
+
+            var handle = file.SafeFileHandle.DangerousGetHandle();
+
+            // First call sizes the hash, second fills it — the documented two-step.
+            uint size = 0;
+            CryptCATAdminCalcHashFromFileHandle2(admin, handle, ref size, IntPtr.Zero, 0);
+            if (size == 0) return TrustResult.NoSignature;
+
+            hash = Marshal.AllocHGlobal((int)size);
+            if (!CryptCATAdminCalcHashFromFileHandle2(admin, handle, ref size, hash, 0))
+                return TrustResult.NoSignature;
+
+            catalog = CryptCATAdminEnumCatalogFromHash(admin, hash, size, 0, IntPtr.Zero);
+            if (catalog == IntPtr.Zero) return TrustResult.NoSignature;   // genuinely in no catalogue
+
+            info = Marshal.AllocHGlobal(CatalogInfoSize);
+            Marshal.Copy(new byte[CatalogInfoSize], 0, info, CatalogInfoSize);
+            Marshal.WriteInt32(info, 0, CatalogInfoSize);
+
+            if (!CryptCATCatalogInfoFromContext(catalog, info, 0)) return TrustResult.NoSignature;
+
+            var catalogPath = Marshal.PtrToStringUni(info + CatalogInfoPathOffset);
+            if (string.IsNullOrEmpty(catalogPath)) return TrustResult.NoSignature;
+
+            return VerifyCatalogMember(catalogPath, HexTag(hash, size), filePath, hash, size, admin);
+        }
+        finally
+        {
+            if (info != IntPtr.Zero) Marshal.FreeHGlobal(info);
+            if (catalog != IntPtr.Zero) CryptCATAdminReleaseCatalogContext(admin, catalog, 0);
+            if (hash != IntPtr.Zero) Marshal.FreeHGlobal(hash);
+            file?.Dispose();
+            CryptCATAdminReleaseContext(admin, 0);
+        }
+    }
+
+    /// <summary>Verifies <paramref name="member"/> as a member of <paramref name="catalogPath"/>.</summary>
+    private static TrustResult VerifyCatalogMember(
+        string catalogPath, string memberTag, string member, IntPtr hash, uint hashSize, IntPtr admin)
+    {
+        var pCatalog = Marshal.StringToHGlobalUni(catalogPath);
+        var pTag = Marshal.StringToHGlobalUni(memberTag);
+        var pMember = Marshal.StringToHGlobalUni(member);
+        var catalogInfo = Marshal.AllocHGlobal(Marshal.SizeOf<WINTRUST_CATALOG_INFO>());
+        var data = Marshal.AllocHGlobal(Marshal.SizeOf<WINTRUST_DATA>());
+
+        try
+        {
+            Marshal.StructureToPtr(
+                new WINTRUST_CATALOG_INFO
+                {
+                    cbStruct = (uint)Marshal.SizeOf<WINTRUST_CATALOG_INFO>(),
+                    pcwszCatalogFilePath = pCatalog,
+                    pcwszMemberTag = pTag,
+                    pcwszMemberFilePath = pMember,
+                    pbCalculatedFileHash = hash,
+                    cbCalculatedFileHash = hashSize,
+                    hCatAdmin = admin,
+                },
+                catalogInfo, fDeleteOld: false);
+
+            Marshal.StructureToPtr(
+                new WINTRUST_DATA
+                {
+                    cbStruct = (uint)Marshal.SizeOf<WINTRUST_DATA>(),
+                    dwUIChoice = WtdUiNone,
+                    fdwRevocationChecks = WtdRevokeNone,
+                    dwUnionChoice = WtdChoiceCatalog,
+                    pFile = catalogInfo,
+                    dwStateAction = WtdStateActionVerify,
+                    dwProvFlags = WtdSaferFlag | WtdCacheOnlyUrlRetrieval | WtdRevocationCheckNone,
+                },
+                data, fDeleteOld: false);
+
+            var hr = WinVerifyTrust(IntPtr.Zero, ref _genericVerifyV2, data);
+            Close(data);
+
+            return Classify(hr);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(data);
+            Marshal.FreeHGlobal(catalogInfo);
+            Marshal.FreeHGlobal(pMember);
+            Marshal.FreeHGlobal(pTag);
+            Marshal.FreeHGlobal(pCatalog);
+        }
+    }
+
+    /// <summary>
+    /// The file hash as the upper-case hex string used for the catalogue member tag.
+    /// </summary>
+    /// <remarks>
+    /// Upper case is the conventional form and what the documentation shows. It is <b>not</b> load-bearing,
+    /// and that was measured rather than assumed: forcing the tag to lower case leaves every real catalogue
+    /// verification passing, so the trust provider is not matching on this string the way one would expect
+    /// from its name. Kept upper-case for consistency with the documented shape, and said plainly here so
+    /// nobody defends it as a correctness requirement.
+    /// </remarks>
+    internal static string HexTag(IntPtr hash, uint size)
+    {
+        var bytes = new byte[size];
+        Marshal.Copy(hash, bytes, 0, (int)size);
+        return Convert.ToHexString(bytes);
     }
 
     /// <summary>Releases the provider state the verify call allocated.</summary>

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.88.2</Version>
-    <FileVersion>1.88.2.0</FileVersion>
-    <AssemblyVersion>1.88.2.0</AssemblyVersion>
+    <Version>1.88.3</Version>
+    <FileVersion>1.88.3.0</FileVersion>
+    <AssemblyVersion>1.88.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #2230.

## Problem

Windows signs most of its own components in a `.cat` catalogue rather than inside the binary, and `WTD_CHOICE_FILE` sees only the embedded signature. So 35 of the 82 running process images reported no signature — and 12 of those 35 are signed:

```
powershell.exe   cmd.exe          conhost.exe      sihost.exe
SearchHost.exe   TextInputHost.exe   ShellHost.exe    unsecapp.exe
SecurityHealthSystray.exe   UserOOBEBroker.exe   CrossDeviceResume.exe   AppActions.exe
```

Explorer's *Digital Signatures* tab shows nothing for these either, which is why it is easy to miss — but `Get-AuthenticodeSignature` calls them Valid, and so do Autoruns and Process Explorer. Reporting them **Unsigned** understated them on the one tab whose question is "is this Windows, or something I installed?".

## Fix

A `NoSignature` answer now gets a second question:

1. `CryptCATAdminAcquireContext2` with **SHA-256 by name** — the older `CryptCATAdminAcquireContext` implies SHA-1 and has no place in new code.
2. `CryptCATAdminCalcHashFromFileHandle2`, sized then filled (the documented two-step).
3. `CryptCATAdminEnumCatalogFromHash` to find the catalogue holding that hash.
4. `WinVerifyTrust` again with `WTD_CHOICE_CATALOG`, verifying the file **as a member** of that catalogue.

**Only `NoSignature` falls through.** An expired or untrusted embedded signature is an answer; going looking for a catalogue that might disagree would be choosing the more flattering of two verdicts. A file with its own signature therefore pays nothing for any of this.

Still no network request — the same `WTD_REVOKE_NONE` + `WTD_CACHE_ONLY_URL_RETRIEVAL`. A file the app cannot open (locked, permission denied) reads as unsigned rather than as a problem, matching what the embedded path already does for anything unparseable.

### Result, end to end through the app's own code

| | Verified | Unsigned | "Check failed" |
|---|---|---|---|
| v1.85.0 – v1.88.1 | **1** | 34 | **47** |
| v1.88.2 (mechanism swap) | 46 | 33 | 1 |
| **this change** | **59** | **22** | **1** |

The 22 remaining are genuinely unsigned third-party programs. The one warning is a real expired certificate.

## Two of my own claims were refuted by the proof

Both corrected rather than shipped, because a claim the evidence does not support is worse than no claim — it survives review on the strength of the reasoning.

**1. Upper-case member tag is not load-bearing.** I wrote that a lower-case tag "finds nothing", since the tag is matched against what the catalogue stores. Mutation 2 forced it lower case and **every real catalogue verification still passed** — only the unit test asserting the format failed. The provider does not match on that string the way its name suggests. The format is kept for consistency with the documented shape, and the docstring now says exactly that.

**2. The handle-count leak test could not see the leak.** The first version counted `Process.HandleCount` across 200 verifications. Mutations 5 and 6 removed each release call and it stayed **green**: a catalogue context is a heap structure, not a kernel handle, so `HandleCount` never moves. It measured the wrong instrument, and a leak test that cannot see the leak is worse than none because it gets cited as coverage. Replaced with the property a repeated call actually has, and the release calls are pinned by source assertion — which both mutations do fail.

## An existing guard flagged the new import, and it was a false positive

`EveryStringMarshallingInterop_BindsTheWideEntryPoint` failed on `CryptCATAdminAcquireContext2` binding a bare name while marshalling UTF-16.

Refuted before acting on it: the `2` suffix **is** the wide-only revision. It takes the hash algorithm as a `PCWSTR` and `wintrust.dll` ships no A/W pair, so appending `W` would bind nothing. Confirmed by running it rather than by reading a header — a failed bind throws `EntryPointNotFoundException` at first use, and this one verifies 12 real Windows binaries.

Added to that guard's existing `noWideVariant` allowlist with the reason recorded, alongside the Restart Manager and `SHGetKnownFolderPath` entries already there. The guard has that mechanism precisely for this; renaming the import to satisfy it would have broken the feature.

## Tests, and why the real one is an integration test

**No file a unit test can create is catalog-signed.** A catalogue lookup that silently returned "no signature" for everything would pass the entire unit suite — which is the exact shape of what shipped for three releases. So:

- **Unit** — the HRESULT mapping, the tag format, and a source guard that the second question is asked, asked only for `NoSignature`, uses the SHA-256 API, and releases both contexts.
- **Integration** (`CatalogSignatureTests`) — real Windows binaries verify. It carries **its own vacuity guard**: `AtLeastOneOfThem_HasNoEmbeddedSignature_SoTheCatalogPathIsWhatAnswered` asserts at least one candidate still has no embedded certificate, so if Microsoft ever embedded signatures in `cmd.exe` the theory could not keep passing while exercising nothing. Each candidate is skipped rather than failed if absent, because the claim is about catalogue verification, not about which binaries ship.

## Red before, green after

`D:\rel-tmp\catalog-proof.py` — six mutations, both suites re-run per mutation, file restored hash-verified.

| Mutation | Result | Caught by |
|---|---|---|
| baseline | GREEN | — |
| 1. never ask the catalogues (**the shipped state**) | **RED** | unit source guard **+ both integration tests** |
| 2. lower-case member tag | **RED** | unit format test only — *this is what refuted claim 1* |
| 3. fall back for every embedded answer, not only no-signature | **RED** | unit source guard |
| 4. go back to the SHA-1 context | **RED** | unit source guard |
| 5. stop releasing the catalogue context | **RED** | unit source guard — *not the handle test; see claim 2* |
| 6. stop releasing the admin context | **RED** | unit source guard |
| restored | GREEN | — |

## Verification

- `dotnet build` — all four projects, **0 warnings, 0 errors**
- Unit suite: **5439 passed, 0 failed**
- `CatalogSignatureTests` run directly from the v3 test exe: **6 passed** (class-scoped, so no network test runs on this machine)
- `dotnet format --verify-no-changes` — all four projects, exit 0
- Leak scan — all 43 current terms against the 36801-byte staged diff, 0 hits
- Docs corrected in this PR, all of which said catalogues were not read: `README.md` (both tab sections), `SECURITY.md`, `ARCHITECTURE.md`, `CHANGELOG.md`

Version bumped to 1.88.3.

**Known limitation, in the changelog rather than left to be found:** first load of the Process Manager is now ~3.5 s on this machine, since the catalogue lookup costs a further ~25 ms for each file without an embedded signature. Steady-state refreshes are unaffected. **#2231** is the fix — take verification off the critical path — and its numbers are updated with this measurement.

**Deferred to the secondary workstation:** how the column reads live now that most rows are Verified.
