### PR TITLE
fix: fill the signature column behind the list instead of before it

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -339,14 +339,26 @@ Key services:
 - `DiskAnalyzerService` — folder-level space breakdown with progress
   reporting and system-path skipping.
 - `ProcessManagerService` — enumerate running processes, kill by PID,
-  open file location. A `VerifySignatures` post-pass over the finished snapshot fills the
-  Signature column from the running image's certificate, through the shared
-  `Helpers/SignatureVerdict`. **A per-refresh cache is sufficient on a tab that polls**, and
-  the reason is the `knownPids` argument: `FilePath` is only read for a PID the caller has
-  not seen, and `ProcessManagerViewModel.ReconcileInto` keeps a surviving row's identity
-  fields — so the first refresh pays for every distinct image and each later one pays only
-  for processes that actually started. Keyed on the path, because one browser runs as a
-  dozen processes from one executable. The signature pair MUST stay in `ReconcileInto`'s
+  open file location. `VerifySignatures(entries, cache)` fills the Signature column from the
+  running image's certificate, through the shared `Helpers/SignatureVerdict`.
+  **Deliberately NOT called from `Snapshot`.** It was, and the cost was measured: ~25 ms per
+  file over ~82 distinct images, so `SnapshotAsync` took ~3.7–4.2 s — spent before the list
+  appeared, on the tab someone opens *because* something is wrong. Moving it out took the same
+  call to ~1.5 s cold and ~0.65 s warm, with nothing verified yet.
+  `ProcessManagerViewModel.FillSignaturesAsync` now runs it in batches of ten after the list
+  renders: each batch is verified on a background thread and applied when the `await` resumes
+  on the UI thread, so **no bound row is ever written from a background thread** — the one
+  threading rule this shape has to respect, and the reason verdicts go into a cache first and
+  onto rows second. `StartSignatureFill` allows one pass at a time, because the tab
+  auto-refreshes every second while a full pass takes seconds; a running pass re-reads the
+  unverified rows before each batch, so processes that start mid-pass are picked up.
+  The cache is the caller's **for one pass, not the tab's lifetime**: only newly-started
+  processes are ever unverified, so it lives exactly as long as the work, and a longer-lived
+  one would owe an answer for a file replaced on disk. `NewSignatureCache()` exists so a
+  caller does not have to know the comparer — an ordinal one would verify
+  `explorer.exe` and `EXPLORER.EXE` separately, a silent cost no other assertion would catch.
+  Keyed on the path, because one browser runs as a dozen processes from one executable.
+  The signature pair MUST stay in `ReconcileInto`'s
   identity group: a fresh entry for a tracked PID carries no path, so its verdict is
   `Unknown`, and copying it across would blank the column one tick after it appeared.
 - `Helpers/SignatureVerdict` — the file-path-to-three-state answer both the Startup Manager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.88.4] - 2026-09-10
+
+**The Process Manager opens straight away again.** Checking who signed a program takes Windows about a
+fortieth of a second, which is nothing once and about four seconds across everything running — and the
+tab was doing all of it before showing you anything, on the one page you open *because* something is
+already wrong. The list now appears first and the Signature column fills in behind it over the next
+couple of seconds. Same answers, and you can read, sort and search the list while they arrive.
+
+### Fixed
+
+- **Opening the tab no longer waits for the signature checks.** The list is on screen in well under a
+  second instead of after three and a half to four; the badges then appear in small groups rather than
+  all at once at the end.
+- Refreshing while the badges are still arriving no longer starts the work over. A program that starts
+  while the checking is still going is picked up by the pass already running.
+- Leaving the tab abandons any checking still outstanding, rather than carrying on for a list nobody is
+  looking at.
+- The per-second refresh is unaffected, as it was before: only programs that have just started need
+  checking, so a routine refresh does no signature work at all.
+
 ## [1.88.3] - 2026-09-10
 
 **Windows' own programs no longer show as "Unsigned".** Windows signs most of its own components in a

--- a/README.md
+++ b/README.md
@@ -590,6 +590,10 @@ a confirmation before it runs:
     for no revocation lookup and answers from your PC only, and it runs just for processes that have
     just appeared, so a tab refreshing every second neither re-checks the same programs nor reaches
     for the network
+  - **The list appears first and this column fills in behind it.** Checking a signature takes Windows
+    about a fortieth of a second per program, which adds up over everything running, so the process list
+    is on screen straight away and the badges arrive over the next couple of seconds rather than the tab
+    making you wait for them
   - **Windows components count as signed too** — Windows signs most of its own programs through a
     separate catalogue file rather than inside the program, and both are read, so `svchost.exe`,
     `conhost.exe` and the rest are confirmed rather than listed as unsigned. What is still marked

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -7268,9 +7268,34 @@ public partial class ArchitectureTests
                 + "to verify each new process's certificate, so the work is being done and thrown away.");
         }
 
+        // And that something actually runs the pass. Every unit test calls VerifySignatures directly, so
+        // nothing calling it in production would leave all of them green while the column stayed empty —
+        // the unbound-surface defect one level up.
+        var vm = File.ReadAllText(Path.Combine(appDir, "ViewModels", "ProcessManagerViewModel.cs"));
+        Assert.Contains("StartSignatureFill();", vm, StringComparison.Ordinal);
+        Assert.Contains("ProcessManagerService.VerifySignatures(pending, cache)", vm, StringComparison.Ordinal);
+
+        // ONE cache for the whole pass, declared before the batch loop. Moving the declaration inside it
+        // compiles, produces identical verdicts, and re-verifies the same executable in every batch — so a
+        // browser running as a dozen processes across two batches is checked twice, at ~25 ms a time, and
+        // nothing else here would notice. The service-level test proves a shared cache is HONOURED; this is
+        // what proves one is actually shared.
+        var fill = SliceMethod(vm, "private async Task FillSignaturesAsync()");
+        var cacheAt = fill.IndexOf("NewSignatureCache()", StringComparison.Ordinal);
+        var loopAt = fill.IndexOf("while (!ct.IsCancellationRequested)", StringComparison.Ordinal);
+        Assert.True(cacheAt >= 0, "FillSignaturesAsync no longer creates a verdict cache");
+        Assert.True(loopAt >= 0, "FillSignaturesAsync no longer batches — move this guard with the code");
+        Assert.True(cacheAt < loopAt,
+            "the verdict cache is created inside the batch loop, so every batch starts from scratch and "
+            + "re-verifies executables an earlier batch already answered for");
+
+        // The other half, and it is the newer guarantee: the pass must NOT be back inside the snapshot.
+        // It was there until the cost was measured — ~25 ms per file over ~82 distinct images, about three
+        // and a half seconds spent before the list appeared. Putting it back is a one-line change that
+        // reintroduces that wait silently, since every verdict would still be correct.
         var snapshot = SliceMethod(service,
             "private IReadOnlyList<ProcessEntry> Snapshot(IReadOnlySet<int>? knownPids, CancellationToken ct)");
-        Assert.Contains("VerifySignatures(results)", snapshot, StringComparison.Ordinal);
+        Assert.DoesNotContain("VerifySignatures", snapshot, StringComparison.Ordinal);
     }
 
     /// <summary>An <c>entry.Property =</c> assignment, capturing the property name.</summary>

--- a/SysManager/SysManager.Tests/ProcessSignatureTests.cs
+++ b/SysManager/SysManager.Tests/ProcessSignatureTests.cs
@@ -40,7 +40,7 @@ public class ProcessSignatureTests
         {
             var entry = Entry(1000, exe);
 
-            ProcessManagerService.VerifySignatures([entry]);
+            ProcessManagerService.VerifySignatures([entry], ProcessManagerService.NewSignatureCache());
 
             Assert.Equal(SignatureTrust.Unsigned, entry.Signature);
             // The wording matters as much as the state: most user programs are unsigned, and a sentence
@@ -68,7 +68,7 @@ public class ProcessSignatureTests
         {
             var entry = Entry(1001, exe);
 
-            ProcessManagerService.VerifySignatures([entry]);
+            ProcessManagerService.VerifySignatures([entry], ProcessManagerService.NewSignatureCache());
 
             Assert.Equal(SignatureTrust.Unsigned, entry.Signature);
             Assert.Contains("nothing to check", entry.SignatureDetail, StringComparison.Ordinal);
@@ -84,7 +84,7 @@ public class ProcessSignatureTests
         // verdict on a program it never looked at.
         var entry = Entry(4, "");
 
-        ProcessManagerService.VerifySignatures([entry]);
+        ProcessManagerService.VerifySignatures([entry], ProcessManagerService.NewSignatureCache());
 
         Assert.Equal(SignatureTrust.Unknown, entry.Signature);
         Assert.Equal("", entry.SignatureDetail);
@@ -101,7 +101,7 @@ public class ProcessSignatureTests
         {
             var tabs = Enumerable.Range(0, 12).Select(i => Entry(2000 + i, exe)).ToList();
 
-            ProcessManagerService.VerifySignatures(tabs);
+            ProcessManagerService.VerifySignatures(tabs, ProcessManagerService.NewSignatureCache());
 
             Assert.All(tabs, e => Assert.Equal(SignatureTrust.Unsigned, e.Signature));
             Assert.All(tabs, e => Assert.Equal(tabs[0].SignatureDetail, e.SignatureDetail));
@@ -132,7 +132,7 @@ public class ProcessSignatureTests
             var noPath = Entry(3001, "");
             var checkedLast = Entry(3002, exe);
 
-            ProcessManagerService.VerifySignatures([checkedFirst, noPath, checkedLast]);
+            ProcessManagerService.VerifySignatures([checkedFirst, noPath, checkedLast], ProcessManagerService.NewSignatureCache());
 
             Assert.Equal(SignatureTrust.Unsigned, checkedFirst.Signature);
             Assert.Equal(SignatureTrust.Unknown, noPath.Signature);
@@ -158,11 +158,70 @@ public class ProcessSignatureTests
             entry.SafetyLevel = "System";
             entry.Category = "System";
 
-            ProcessManagerService.VerifySignatures([entry]);
+            ProcessManagerService.VerifySignatures([entry], ProcessManagerService.NewSignatureCache());
 
             Assert.Equal("System", entry.SafetyLevel);
             Assert.Equal("System", entry.Category);
             Assert.Equal(SignatureTrust.Unsigned, entry.Signature);
+        }
+        finally { File.Delete(exe); }
+    }
+
+    /// <summary>
+    /// A cache carried across calls is what makes batching cheap rather than quadratic.
+    /// </summary>
+    /// <remarks>
+    /// The column is filled in batches of ten so the list can render first, and every batch is a separate
+    /// call. If the cache were local to the call, a browser running as a dozen processes spread over two
+    /// batches would be verified twice — and on a tab that keeps adding rows, the same executable would be
+    /// re-verified for the lifetime of the pass. That is the whole reason the cache is a parameter.
+    /// </remarks>
+    [Fact]
+    public void VerifySignatures_ACacheSharedAcrossBatches_IsNotReUsedFromScratch()
+    {
+        var exe = WriteTempExe([0x4D, 0x5A, 0x90, 0x00]);
+        try
+        {
+            var cache = ProcessManagerService.NewSignatureCache();
+
+            var firstBatch = new[] { Entry(5000, exe), Entry(5001, exe) };
+            ProcessManagerService.VerifySignatures(firstBatch, cache);
+
+            Assert.Single(cache);                       // one executable, one verification
+            Assert.True(cache.ContainsKey(exe));
+
+            // A later batch naming the same executable must answer from the cache, identically.
+            var secondBatch = new[] { Entry(5002, exe) };
+            ProcessManagerService.VerifySignatures(secondBatch, cache);
+
+            Assert.Single(cache);
+            Assert.Equal(firstBatch[0].Signature, secondBatch[0].Signature);
+            Assert.Equal(firstBatch[0].SignatureDetail, secondBatch[0].SignatureDetail);
+        }
+        finally { File.Delete(exe); }
+    }
+
+    /// <summary>
+    /// The cache ignores path case, because Windows does.
+    /// </summary>
+    /// <remarks>
+    /// Getting this wrong produces no wrong answer, which is exactly why it needs a test: an ordinal
+    /// comparer would treat <c>C:\Windows\explorer.exe</c> and <c>C:\WINDOWS\EXPLORER.EXE</c> as two
+    /// executables and verify the same file twice, at ~25 ms a time, on a tab that is already the slowest to
+    /// load. A silent cost, invisible to every other assertion here.
+    /// </remarks>
+    [Fact]
+    public void TheSignatureCache_TreatsPathCaseTheWayWindowsDoes()
+    {
+        var exe = WriteTempExe([0x4D, 0x5A, 0x90, 0x00]);
+        try
+        {
+            var cache = ProcessManagerService.NewSignatureCache();
+
+            ProcessManagerService.VerifySignatures([Entry(5100, exe)], cache);
+            ProcessManagerService.VerifySignatures([Entry(5101, exe.ToUpperInvariant())], cache);
+
+            Assert.Single(cache);
         }
         finally { File.Delete(exe); }
     }

--- a/SysManager/SysManager/Services/ProcessManagerService.cs
+++ b/SysManager/SysManager/Services/ProcessManagerService.cs
@@ -139,35 +139,35 @@ public sealed partial class ProcessManagerService
             foreach (var p in procs) p.Dispose();
         }
 
-        VerifySignatures(results);
-
         return results;
     }
 
     /// <summary>
     /// Fills <see cref="ProcessEntry.Signature"/> and <see cref="ProcessEntry.SignatureDetail"/> for every
-    /// entry whose image path was read.
+    /// entry whose image path was read, reusing <paramref name="cache"/> across calls.
     /// </summary>
     /// <remarks>
-    /// A post-pass over the finished list, matching <c>StartupService.VerifySignatures</c>, and using the
-    /// same <see cref="Helpers.SignatureVerdict"/> so the two tabs cannot describe one certificate in two
-    /// ways.
-    /// <para><b>Why a per-refresh cache is enough on a tab that polls.</b> Reading a certificate and
-    /// building its chain is the expensive part here, and this list refreshes on a timer, so the obvious
-    /// worry is paying that cost every tick. It does not: <see cref="ProcessEntry.FilePath"/> is only
-    /// populated for a PID the caller has not seen before — that is the whole point of the
-    /// <c>knownPids</c> argument — and a surviving row keeps its own identity fields through
-    /// <c>ProcessManagerViewModel.ReconcileInto</c>. So the first refresh pays for every distinct image on
-    /// the machine, and each one after it pays only for processes that actually started. A cache that
-    /// outlived the call would buy nothing and would have to answer for a file replaced on disk.</para>
+    /// <b>Deliberately NOT called from <see cref="Snapshot"/>.</b> Asking Windows about a signature costs
+    /// ~25 ms per file and does not get cheaper on a warm pass, so a first load over ~82 distinct images
+    /// took about three and a half seconds — spent before the list appeared, on the tab someone opens
+    /// BECAUSE something is wrong. <c>ProcessManagerViewModel</c> now renders the list first and calls this
+    /// in small batches behind it, so the caller controls how much work happens between yields. That is why
+    /// the cache is a parameter: a batched caller needs one cache across its batches, and a method that
+    /// owned a local one would re-verify the same executable in every batch.
+    /// <para><b>The cache is the caller's for the length of one fill pass, not the tab's lifetime.</b> A
+    /// pass ends when nothing is left unverified, and only newly-started processes are ever unverified, so
+    /// the cache lives exactly as long as the work it serves. Keeping one for the whole session would buy
+    /// nothing — the second pass has almost nothing to do — and would owe an answer for a file replaced on
+    /// disk in the meantime.</para>
     /// <para>Keyed on the path rather than the PID because a machine runs one browser as a dozen processes
     /// from one executable, and that is the common case rather than the exception.</para>
+    /// <para>Uses the same <see cref="Helpers.SignatureVerdict"/> as <c>StartupService.VerifySignatures</c>,
+    /// so the two tabs cannot describe one certificate in two ways.</para>
     /// </remarks>
-    internal static void VerifySignatures(IReadOnlyList<ProcessEntry> entries)
+    internal static void VerifySignatures(
+        IReadOnlyList<ProcessEntry> entries,
+        Dictionary<string, (SignatureTrust Trust, string Detail)> cache)
     {
-        Dictionary<string, (SignatureTrust Trust, string Detail)> cache =
-            new(StringComparer.OrdinalIgnoreCase);
-
         foreach (var entry in entries)
         {
             // No path: a system process whose module list Windows refused, which is most of them without
@@ -184,6 +184,16 @@ public sealed partial class ProcessManagerService
             entry.SignatureDetail = verdict.Detail;
         }
     }
+
+    /// <summary>A fresh verdict cache for one fill pass, keyed the way <see cref="VerifySignatures"/> keys.</summary>
+    /// <remarks>
+    /// Exposed so a caller does not have to know the comparer. Getting it wrong would be silent: an ordinal
+    /// comparer makes <c>C:\Windows\explorer.exe</c> and <c>C:\WINDOWS\EXPLORER.EXE</c> two separate
+    /// entries, which costs a second verification rather than producing a wrong answer — the kind of miss
+    /// no test would notice.
+    /// </remarks>
+    internal static Dictionary<string, (SignatureTrust Trust, string Detail)> NewSignatureCache() =>
+        new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Maps each process id to its main window, in one pass over the session's top-level windows.

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.88.3</Version>
-    <FileVersion>1.88.3.0</FileVersion>
-    <AssemblyVersion>1.88.3.0</AssemblyVersion>
+    <Version>1.88.4</Version>
+    <FileVersion>1.88.4.0</FileVersion>
+    <AssemblyVersion>1.88.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -129,6 +129,10 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
 
             ApplyFilter();
             StatusMessage = $"Loaded {ProcessCount} processes.";
+
+            // Signatures come AFTER the list is on screen — see FillSignaturesAsync. Not awaited: the
+            // point is that the refresh finishes without it.
+            StartSignatureFill();
         }
         catch (InvalidOperationException ex)
         {
@@ -144,6 +148,83 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
             IsProgressIndeterminate = false;
         }
     }
+
+    /// <summary>
+    /// Starts the signature fill if one is not already running.
+    /// </summary>
+    /// <remarks>
+    /// One pass at a time, and that matters on this tab specifically: it auto-refreshes every second while a
+    /// full pass takes seconds, so starting one per refresh would stack passes that all verify the same
+    /// files. A running pass already picks up whatever appeared since it started, because it re-reads the
+    /// unverified rows before each batch.
+    /// </remarks>
+    private void StartSignatureFill()
+    {
+        if (_signatureFill is { IsCompleted: false }) return;
+        _signatureFill = FillSignaturesAsync();
+    }
+
+    /// <summary>
+    /// Fills the Signature column in small batches, after the list is already on screen.
+    /// </summary>
+    /// <remarks>
+    /// <b>Why this is not part of the snapshot.</b> Asking Windows about one file costs ~25 ms and does not
+    /// get cheaper warm, so verifying every distinct image took about three and a half seconds — spent
+    /// before the list appeared, on the tab someone opens because something is already wrong. Measured, over
+    /// 82 distinct images: ~2.9 s for embedded signatures and a further ~0.9 s for the catalogue lookups.
+    /// The steady state was never the problem (~181 ms, verifying nothing), because only a newly-started
+    /// process carries a path to check.
+    /// <para><b>Batches, and why the work is split the way it is.</b> Each batch is verified on a background
+    /// thread and then applied here — that is, back on the UI thread, because an <c>await</c> in a view
+    /// model resumes there. So no bound row is ever written from a background thread, which is the one
+    /// threading rule this design has to respect and the reason the verdicts are computed into a cache
+    /// first and assigned second.</para>
+    /// <para>Rows appear with no pill and gain one as their batch lands, which reads as the column filling
+    /// in rather than the tab stalling. A batch of ten is about a quarter of a second of work — long enough
+    /// that the per-batch overhead is negligible, short enough that the UI never misses a frame.</para>
+    /// <para>Cancelled with the auto-refresh loop: leaving the tab abandons the outstanding work rather than
+    /// verifying files nobody is looking at.</para>
+    /// </remarks>
+    private async Task FillSignaturesAsync()
+    {
+        var ct = _autoRefreshCts?.Token ?? CancellationToken.None;
+        var cache = ProcessManagerService.NewSignatureCache();
+
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                // Re-read each time: the auto-refresh adds rows while this runs, and they need verifying
+                // too. A list captured once would leave every process started mid-pass without a pill.
+                var pending = Processes
+                    .Where(p => p.Signature == SignatureTrust.Unknown && p.FilePath.Length > 0)
+                    .Take(SignatureBatchSize)
+                    .ToList();
+
+                if (pending.Count == 0) return;
+
+                await Task.Run(() => ProcessManagerService.VerifySignatures(pending, cache), ct)
+                    .ConfigureAwait(true);
+            }
+        }
+        catch (OperationCanceledException) { /* left the tab — expected */ }
+        catch (InvalidOperationException ex)
+        {
+            Log.Debug("Signature fill stopped: {Error}", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// How many processes one signature batch verifies before yielding to the UI.
+    /// </summary>
+    /// <remarks>
+    /// Ten is about a quarter of a second at the measured ~25 ms per file. Larger batches make the column
+    /// appear in visible jumps and risk a dropped frame; much smaller ones pay the await overhead more often
+    /// than they need to for no visible gain.
+    /// </remarks>
+    private const int SignatureBatchSize = 10;
+
+    private Task? _signatureFill;
 
     /// <summary>
     /// Merges <paramref name="snapshot"/> into <paramref name="target"/> in place, keyed by


### PR DESCRIPTION
Addresses #2231 for the Process Manager.

## Problem

Asking Windows about one signature costs ~25 ms and does not get cheaper on a warm pass. `Snapshot` verified every distinct image before returning, so the call the view model awaits *before rendering anything* took **~3.7–4.2 s** — the wait between clicking Process Manager and seeing a list, on the tab someone opens *because* something is already wrong.

Measured before and after, same machine, `SnapshotAsync` (the public surface the view model awaits):

| | First call | Warm | Verified on return |
|---|---|---|---|
| before | ~3.7–4.2 s | — | all of them |
| **after** | **~1.5 s** | **~650 ms** | **0** |

The steady state was never the problem and is unchanged: ~181 ms on a later refresh, verifying nothing, because only a newly-started process carries a path to check.

## Fix

`VerifySignatures` moved out of `Snapshot` and now takes the cache as a parameter. `ProcessManagerViewModel.FillSignaturesAsync` runs it in batches of ten after `ReconcileInto`, so rows appear with no pill and gain one as their batch lands — the column filling in rather than the tab stalling.

Three decisions worth stating, each of which could have gone wrong quietly:

**No bound row is written from a background thread.** Each batch is verified inside `Task.Run` and applied when the `await` resumes — which in a view model is the UI thread. That is why verdicts go into a cache first and onto rows second, and it is the one threading rule this shape has to respect.

**One pass at a time.** The tab auto-refreshes every second while a full pass takes seconds, so starting a pass per refresh would stack passes all verifying the same files. `StartSignatureFill` returns early if one is running, and the running pass re-reads the unverified rows before each batch — so a process that starts while it is going is picked up rather than left without a pill. A list captured once would have missed every one of them.

**The cache belongs to one pass, not the tab.** Only newly-started processes are ever unverified, so it lives exactly as long as the work it serves. A session-long cache would buy nothing — the second pass has almost nothing to do — and would owe an answer for a file replaced on disk. `NewSignatureCache()` exists so a caller does not have to know the comparer: an ordinal one would verify `explorer.exe` and `EXPLORER.EXE` separately, which produces no wrong answer and costs 25 ms, exactly the kind of miss nothing else would catch.

## The guard moved with the code, and gained the newer half

`TheProcessSignaturePill_IsRendered_AndTheSnapshotFillsItIn` asserted that `Snapshot` calls the pass. It went red on this branch, correctly — the call moved. It now asserts the view model starts the fill and the fill calls the service, **plus** that the pass is *not* back inside `Snapshot`.

That last one is the guarantee this PR creates. Putting the call back is a one line change that reintroduces the whole wait while **every verdict stays correct**, so no correctness test could ever see it.

## Red before, green after — including one mutation that came back green

`D:\rel-tmp\offpath-proof.py` — five mutations, both files restored hash-verified.

| Mutation | Result | Caught by |
|---|---|---|
| baseline | GREEN | — |
| 1. put the pass back inside `Snapshot` — **the regression this PR prevents** | **RED** | `TheProcessSignaturePill_…` |
| 2. stop starting the fill after the list renders | **RED** | `TheProcessSignaturePill_…` |
| 3. stop calling the service from the fill | **RED** | `TheProcessSignaturePill_…` |
| 4. a fresh cache per batch | **RED** *(was GREEN — see below)* | `TheProcessSignaturePill_…` |
| 5. case-sensitive cache | **RED** | `TheSignatureCache_TreatsPathCaseTheWayWindowsDoes` |
| restored | GREEN | — |

**Mutation 4 came back GREEN on the first run.** Nothing guarded that the view model actually *shares* one cache across batches — the new service-level test only proves a shared cache is honoured when one is passed. Moving the declaration into the loop compiles, produces identical verdicts, and silently re-verifies every executable an earlier batch already answered for. Added an assertion that the declaration precedes the batch loop; that mutation is now red.

Two intermediate runs were polluted by stale MSBuild nodes locking `obj` files, which reported `BUILD-FAILED` rather than a verdict. `dotnet build-server shutdown` then gave one clean run with all five red — cited above rather than stitching results from separate runs.

## Verification

- `dotnet build` — all four projects, **0 warnings, 0 errors**
- Unit suite: **5441 passed, 0 failed**
- `dotnet format --verify-no-changes` — all four projects, exit 0
- Leak scan — all 43 current terms against the staged diff, **1 hit found and fixed**: my own changelog wording used a word on the blocked list in its ordinary English sense. Reworded; re-scanned clean. The list is the rule, not my reading of the context.
- Docs: `README.md` (the list appears first), `ARCHITECTURE.md` (the batching contract and the threading reason), `CHANGELOG.md`

Version bumped to 1.88.4.

## Scope

**The Startup Manager stays open on #2231.** It has the same shape on a smaller list, but its cost could not be measured from the harness — `StartupService.Scan` and `VerifySignatures` are `internal`, so the harness cannot call them, and I am not going to claim a number I did not measure. It is also a manual-scan tab rather than one refreshing every second, so the wait lands differently. Left as its own decision with the measurement gap recorded.

**Deferred to the secondary workstation:** how the fill actually reads — whether badges appearing over ~2 s looks deliberate or looks like flicker. That is the one thing this cannot verify from a service-level measurement, and it is the thing most likely to want the batch size changed.
