### PR TITLE
test: stop the ping churn orphaning thousands of pings into the next test

### DIFF
--- a/SysManager/SysManager.IntegrationTests/PingMonitorStressTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PingMonitorStressTests.cs
@@ -50,33 +50,55 @@ public class PingMonitorStressTests
         svc.Start();
         Assert.True(svc.IsRunning);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
         // The churn deliberately never touches "base" — only 192.0.2.2-253 hosts — so
-        // it survives as a fixed point we can assert on after the storm settles.
+        // it survives as a fixed point we can assert on after the storm settles. "base"
+        // stays enabled, so the pump is genuinely pinging while the map churns under it.
         //
-        // The churned targets are DISABLED, and that is load-bearing rather than tidiness.
-        // PumpAsync snapshots `Targets.Values.Where(t => t.IsEnabled …)` every tick, so a
-        // disabled target is still enumerated — the concurrent add/remove still races the
-        // snapshot, which is the entire point of this test — but it is never pinged. With
-        // them enabled, an unthrottled two-second loop filled the map with ~250 hosts and
-        // the pump then fired ~4000 fire-and-forget ICMP operations at unroutable
-        // addresses, every one of them abandoned mid-flight when Stop() cancelled the
-        // token. The suite runs maxParallelThreads=1, so those continuations all drained
-        // through a single worker AFTER this test returned, and the bill landed on
-        // whichever test ran next: ToggleIsEnabled_MidFlight_IsRespected measured 283s on
-        // a healthy run and 336s on a slow one, against 1.2s of intended Task.Delay. Above
-        // 300s it crossed --hangdump-timeout 5m, so the runner wrote a 704 MB dump and the
-        // hang-dump extension's DisposeAsync then timed out, reporting `Failed!` with
-        // `failed: 0` — 13% of runs (8 of 60 measured). "base" stays enabled so the pump
-        // is genuinely pinging while the map churns underneath it. See #2195.
-        var churn = Task.Run(() =>
+        // Two things here are load-bearing rather than tidiness, and both were measured
+        // on #2195. This test used to spin unthrottled for two seconds against a
+        // CancellationTokenSource, with the churned targets left ENABLED.
+        //
+        // ENABLED was the expensive half. PumpAsync snapshots
+        // `Targets.Values.Where(t => t.IsEnabled …)` every tick, so a disabled target is
+        // still enumerated — the concurrent add/remove still races that snapshot, which
+        // is the entire point of this test — but it is never pinged. With them enabled the
+        // map filled with ~250 hosts and the pump fired thousands of fire-and-forget ICMP
+        // operations at unroutable addresses, all abandoned mid-flight when Stop()
+        // cancelled the token. The suite runs maxParallelThreads=1, so those continuations
+        // drained through one worker AFTER this test returned, and the bill landed on
+        // whichever test ran next: ToggleIsEnabled_MidFlight_IsRespected measured 283s
+        // against 1.2s of intended Task.Delay, and 336s on a slow run. Past 300s it
+        // crossed --hangdump-timeout 5m, the runner wrote a 704 MB dump, and the hang-dump
+        // extension's DisposeAsync then timed out and reported `Failed!` with `failed: 0`
+        // on 8 of 60 runs. Disabling them moved that test to 7.64s.
+        //
+        // UNTHROTTLED was the unstable half, and disabling the targets alone did not fix
+        // it — it relocated it. The two-second spin measured ~27 MILLION add/remove
+        // operations, i.e. ~14 million ConcurrentDictionary writes a second alongside a
+        // pump snapshotting the same dictionary every tick, and the cost of that was never
+        // stable: the same runner image measured this pair at 4s + 283s, then at 217s + 8s.
+        // Interleaving is what proves thread safety, not iteration count, so the churn is
+        // bounded on OPERATIONS and yields between batches — a fixed ~20k operations
+        // spread across several pump ticks, at a cost that does not depend on how fast the
+        // machine happens to be.
+        //
+        // Yes, that is an awaited delay in a test, which ArchitectureTests.NoTestWaitsBySleeping
+        // forbids — and that guard is scoped to the blocking unit suite, deliberately, not to
+        // this project. The rule exists because a unit test must not assert how fast the
+        // machine is. Here the subject under test IS a timer: PumpAsync ticks on Interval, so
+        // the churn has to span ticks to race the snapshot at all, and Task.Yield() would
+        // finish all 20k operations before the pump ticked once. The delay is what makes this
+        // test's cost machine-INdependent rather than dependent on it.
+        const int ChurnOperations = 20_000;
+        var churn = Task.Run(async () =>
         {
             var rnd = new Random(42);
-            while (!cts.IsCancellationRequested)
+            for (int i = 0; i < ChurnOperations; i++)
             {
                 var h = $"192.0.2.{rnd.Next(2, 254)}";
                 svc.AddOrUpdate(new PingTarget("x", h, "#111") { IsEnabled = false });
                 if (rnd.Next(2) == 0) svc.Remove(h);
+                if (i % 1_000 == 0) await Task.Delay(25);
             }
         });
 

--- a/SysManager/SysManager.IntegrationTests/PingMonitorStressTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PingMonitorStressTests.cs
@@ -53,13 +53,29 @@ public class PingMonitorStressTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
         // The churn deliberately never touches "base" — only 192.0.2.2-253 hosts — so
         // it survives as a fixed point we can assert on after the storm settles.
+        //
+        // The churned targets are DISABLED, and that is load-bearing rather than tidiness.
+        // PumpAsync snapshots `Targets.Values.Where(t => t.IsEnabled …)` every tick, so a
+        // disabled target is still enumerated — the concurrent add/remove still races the
+        // snapshot, which is the entire point of this test — but it is never pinged. With
+        // them enabled, an unthrottled two-second loop filled the map with ~250 hosts and
+        // the pump then fired ~4000 fire-and-forget ICMP operations at unroutable
+        // addresses, every one of them abandoned mid-flight when Stop() cancelled the
+        // token. The suite runs maxParallelThreads=1, so those continuations all drained
+        // through a single worker AFTER this test returned, and the bill landed on
+        // whichever test ran next: ToggleIsEnabled_MidFlight_IsRespected measured 283s on
+        // a healthy run and 336s on a slow one, against 1.2s of intended Task.Delay. Above
+        // 300s it crossed --hangdump-timeout 5m, so the runner wrote a 704 MB dump and the
+        // hang-dump extension's DisposeAsync then timed out, reporting `Failed!` with
+        // `failed: 0` — 13% of runs (8 of 60 measured). "base" stays enabled so the pump
+        // is genuinely pinging while the map churns underneath it. See #2195.
         var churn = Task.Run(() =>
         {
             var rnd = new Random(42);
             while (!cts.IsCancellationRequested)
             {
                 var h = $"192.0.2.{rnd.Next(2, 254)}";
-                svc.AddOrUpdate(new PingTarget("x", h, "#111"));
+                svc.AddOrUpdate(new PingTarget("x", h, "#111") { IsEnabled = false });
                 if (rnd.Next(2) == 0) svc.Remove(h);
             }
         });

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2901,6 +2901,10 @@ public partial class ArchitectureTests
     /// TRX comparison across two runs to find, so it gets a guard rather than a comment. This suite is
     /// blocking and the suite it guards is not, on purpose: a job cannot be trusted to report a defect whose
     /// symptom is that job timing out.</para>
+    /// <para>Disabling them alone did not fix it, it relocated it: the next CI run put
+    /// <c>ToggleIsEnabled_MidFlight_IsRespected</c> at 7.64s and this test at 217s, for a net saving of only
+    /// 59s. The unthrottled spin was the other half — ~27 million operations in two seconds — so the loop is
+    /// now bounded on operations and throttled, and this guard checks both.</para>
     /// </remarks>
     [Fact]
     public void ThePingChurn_BuildsDisabledTargets_SoItDoesNotOrphanThousandsOfPings()
@@ -2916,8 +2920,8 @@ public partial class ArchitectureTests
         var churn = ChurnLoopBody().Match(code);
         Assert.True(churn.Success,
             "the churn loop in ParallelAddRemoveWhileRunning_IsThreadSafe was not found, so this guard read "
-            + "nothing. It slices from the loop over the churn's CancellationTokenSource to the end of the "
-            + "enclosing Task.Run — if the test was restructured, re-point the slice rather than deleting it.");
+            + "nothing. It slices from the bounded `for` over ChurnOperations to the end of the enclosing "
+            + "Task.Run — if the test was restructured, re-point the slice rather than deleting it.");
 
         var body = churn.Groups["body"].Value;
         var built = NewPingTarget().Count(body);
@@ -2933,14 +2937,28 @@ public partial class ArchitectureTests
             "the churn slice does not reach the loop's Remove call, so it is truncated and can only "
             + "under-report. Re-point ChurnLoopBody at the real end of the loop body:\n" + body);
 
+        // The bound is half the fix and it regresses just as easily. The operation count is enforced by the
+        // slice anchor itself (a `while` spin no longer matches, and the guard says so), but the throttle
+        // inside the loop is one deletable line — and without it 20k operations run as fast as the machine
+        // allows, which is the unstable shape all over again.
+        //
+        // Needle split for the same reason NoTestWaitsBySleeping splits its own: that guard scans this file
+        // too, and written whole this literal made it report ArchitectureTests.cs as a test that sleeps.
+        var throttle = "await Task." + "Delay(";
+        Assert.True(body.Contains(throttle, StringComparison.Ordinal),
+            "the churn loop no longer yields between batches. Unthrottled, it measured ~27 million "
+            + "add/remove operations in two seconds against a live pump, and the cost of that was not "
+            + "stable — the same runner measured this test at 4s and at 217s. Keep a delay in the loop so "
+            + "the operations spread across pump ticks at a cost independent of machine speed (#2195).");
+
         var enabled = built - DisabledPingTarget().Count(body);
         Assert.True(enabled == 0,
             $"{enabled} of the {built} PingTargets built inside the churn loop are left enabled. The pump "
-            + "pings every enabled target every tick and Stop() abandons them in flight, so an unthrottled "
-            + "two-second churn orphans thousands of ICMP operations that drain into whichever test runs "
-            + "next — see #2195, where that cost one test 283s and tripped the 5-minute hang dump on 13% of "
-            + "runs. Build them as `new PingTarget(name, host, colour) { IsEnabled = false }`: the pump still "
-            + "enumerates them, so the concurrency this test exists to prove is unchanged.");
+            + "pings every enabled target every tick and Stop() abandons them in flight, so the churn orphans "
+            + "ICMP operations that drain into whichever test runs next — see #2195, where that cost one test "
+            + "283s and tripped the 5-minute hang dump on 13% of runs. Build them as "
+            + "`new PingTarget(name, host, colour) { IsEnabled = false }`: the pump still enumerates them, so "
+            + "the concurrency this test exists to prove is unchanged.");
     }
 
     /// <summary>The body of the stress test's churn loop, up to the end of the task that runs it.</summary>
@@ -2948,7 +2966,7 @@ public partial class ArchitectureTests
     /// The terminator is anchored to the start of a line. An object initializer also ends in <c>});</c>, so an
     /// unanchored one stops inside the very construction this slice exists to read.
     /// </remarks>
-    [GeneratedRegex(@"while \(!cts\.IsCancellationRequested\)(?<body>.*?)\n\s*\}\);",
+    [GeneratedRegex(@"for \(int i = 0; i < ChurnOperations; i\+\+\)(?<body>.*?)\n\s*\}\);",
         RegexOptions.Singleline | RegexOptions.Compiled)]
     private static partial Regex ChurnLoopBody();
 

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -2885,6 +2885,81 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"""(?<id>nav-[a-z0-9-]+)""", RegexOptions.Compiled)]
     private static partial Regex NavIdLiteral();
 
+    /// <summary>The ping stress test's add/remove churn builds targets that the pump will not ping.</summary>
+    /// <remarks>
+    /// <c>ParallelAddRemoveWhileRunning_IsThreadSafe</c> hammers the target map for two seconds with no
+    /// throttle, which is the point: the concurrent add/remove has to race <c>PumpAsync</c>'s snapshot. What
+    /// was not the point is that the churned hosts were ENABLED, so the pump fired roughly 4000
+    /// fire-and-forget ICMP operations at unroutable addresses and <c>Stop()</c> then abandoned all of them
+    /// mid-flight. The integration suite runs <c>maxParallelThreads=1</c>, so those continuations drained
+    /// through one worker after the test had already returned and the bill landed on the next test:
+    /// <c>ToggleIsEnabled_MidFlight_IsRespected</c> measured 283s against 1.2s of intended delay, and when it
+    /// crossed <c>--hangdump-timeout 5m</c> the runner wrote a 704 MB dump whose extension then failed
+    /// teardown, reporting <c>Failed!</c> with <c>failed: 0</c> on 8 of 60 runs (#2195).
+    /// <para>Disabling them costs the test nothing — the pump still enumerates every entry each tick, so the
+    /// race is identical — which is exactly why the line is so easy to "simplify" back. It took a per-test
+    /// TRX comparison across two runs to find, so it gets a guard rather than a comment. This suite is
+    /// blocking and the suite it guards is not, on purpose: a job cannot be trusted to report a defect whose
+    /// symptom is that job timing out.</para>
+    /// </remarks>
+    [Fact]
+    public void ThePingChurn_BuildsDisabledTargets_SoItDoesNotOrphanThousandsOfPings()
+    {
+        var path = Path.Combine(FindRepoRoot(), "SysManager", "SysManager.IntegrationTests",
+            "PingMonitorStressTests.cs");
+        Assert.True(File.Exists(path), $"{path} not found — this guard would read nothing.");
+
+        // Comment-stripped: the churn carries a long explanation that names IsEnabled, and matching prose
+        // instead of code is how two earlier guards in this file reported the wrong colour.
+        var code = string.Join('\n', File.ReadAllLines(path).Where(IsCode));
+
+        var churn = ChurnLoopBody().Match(code);
+        Assert.True(churn.Success,
+            "the churn loop in ParallelAddRemoveWhileRunning_IsThreadSafe was not found, so this guard read "
+            + "nothing. It slices from the loop over the churn's CancellationTokenSource to the end of the "
+            + "enclosing Task.Run — if the test was restructured, re-point the slice rather than deleting it.");
+
+        var body = churn.Groups["body"].Value;
+        var built = NewPingTarget().Count(body);
+        Assert.True(built >= 1,
+            $"the churn slice builds {built} PingTargets, so the slice is empty and a pass proves nothing.");
+
+        // Completeness, not just non-emptiness. The first version of this slice terminated on the first
+        // `});` and an object initializer ends in exactly that, so it cut off mid-construction — one
+        // PingTarget still inside it, its `IsEnabled = false` outside it, and the guard reporting a
+        // violation that was not there. A truncated slice can only ever under-report, so require the far
+        // end of the loop body as well as the near end.
+        Assert.True(body.Contains("svc.Remove(", StringComparison.Ordinal),
+            "the churn slice does not reach the loop's Remove call, so it is truncated and can only "
+            + "under-report. Re-point ChurnLoopBody at the real end of the loop body:\n" + body);
+
+        var enabled = built - DisabledPingTarget().Count(body);
+        Assert.True(enabled == 0,
+            $"{enabled} of the {built} PingTargets built inside the churn loop are left enabled. The pump "
+            + "pings every enabled target every tick and Stop() abandons them in flight, so an unthrottled "
+            + "two-second churn orphans thousands of ICMP operations that drain into whichever test runs "
+            + "next — see #2195, where that cost one test 283s and tripped the 5-minute hang dump on 13% of "
+            + "runs. Build them as `new PingTarget(name, host, colour) { IsEnabled = false }`: the pump still "
+            + "enumerates them, so the concurrency this test exists to prove is unchanged.");
+    }
+
+    /// <summary>The body of the stress test's churn loop, up to the end of the task that runs it.</summary>
+    /// <remarks>
+    /// The terminator is anchored to the start of a line. An object initializer also ends in <c>});</c>, so an
+    /// unanchored one stops inside the very construction this slice exists to read.
+    /// </remarks>
+    [GeneratedRegex(@"while \(!cts\.IsCancellationRequested\)(?<body>.*?)\n\s*\}\);",
+        RegexOptions.Singleline | RegexOptions.Compiled)]
+    private static partial Regex ChurnLoopBody();
+
+    /// <summary>A ping target being constructed.</summary>
+    [GeneratedRegex(@"new PingTarget\(", RegexOptions.Compiled)]
+    private static partial Regex NewPingTarget();
+
+    /// <summary>A ping target constructed with its pump participation switched off.</summary>
+    [GeneratedRegex(@"new PingTarget\([^)]*\)\s*\{\s*IsEnabled\s*=\s*false\s*\}", RegexOptions.Compiled)]
+    private static partial Regex DisabledPingTarget();
+
     /// <summary>A <c>DataGrid</c> or <c>ItemsControl</c> bound to a collection.</summary>
     [GeneratedRegex(@"<(?:DataGrid|ItemsControl)\b[^>]*ItemsSource=""\{Binding", RegexOptions.Compiled)]
     private static partial Regex CollectionItemsSource();


### PR DESCRIPTION
Root cause of #2195. The annotation half of that issue (proposal 1) shipped earlier; this is the other half, and it turned out not to be the knob the issue expected.

### What was actually happening

The recurrence measurement the issue asked for first: **8 of 60 completed integration jobs**, clustering at ~26 minutes against a median of 8.2, with **3.5 minutes of headroom** before the 30-minute ceiling turns it into a `cancelled` job that renders red. So it is a pattern, not a one-off.

Then per-test durations out of the TRX of one slow run and one healthy run:

```
slow run: 625 results, 546.5 s total
fast run: 625 results, 491.8 s total
per-test slow/fast ratio: median 1.00x, p90 1.51x
```

The tests are not slower. Nine minutes of tests in both cases, against a run duration of `8m 17s` on the healthy run and `24m 15s` on the slow one — so ~15 minutes is spent outside the tests entirely, writing a 704 MB dump and then timing out in `HangDumpProcessLifetimeHandler.DisposeAsync`.

What the same comparison did show is one test carrying 58% of the suite, on **every** run:

| test | healthy run | slow run | intended `Task.Delay` |
|---|---|---|---|
| `ToggleIsEnabled_MidFlight_IsRespected` | 283.50 s | 336.74 s | **1.2 s** |

283 s is under `--hangdump-timeout 5m`. 336 s is over it. That is the whole 13%.

### Why that test costs 283 s when it sleeps for 1.2

It doesn't. It pays for the test that runs immediately before it, in both runs: `ParallelAddRemoveWhileRunning_IsThreadSafe`.

That test churns the target map for two seconds in an unthrottled loop, adding hosts drawn from `192.0.2.2-253`. `PumpAsync` fires one ping per **enabled** target per tick, so with a full map at `Interval = 120 ms` it starts on the order of 4000 real ICMP operations to unroutable addresses — every one of them abandoned mid-flight when `Stop()` cancels the token, disposing its `Ping` while the native send is outstanding.

`SysManager.IntegrationTests/xunit.runner.json` sets `maxParallelThreads: 1` and `parallelMode: none`, so all of those continuations drain through a single worker, and they drain *after* the test that started them has already returned. The arithmetic holds across the neighbours too: `ManyTargets_NoExceptions` orphans ~150 pings and costs 5.8 s (~39 ms each); the churn orphans ~4000 and the next test costs 283 s (~71 ms each).

The reason it needed a TRX diff to find is that the mechanism defeats every signal pointed at it. The dump named no test, `longRunningTestSeconds: 120` produced no diagnostic, thread-pool starvation is ruled out because the test *after* the slow one takes 5 s, and the assertion passes cleanly the whole time.

### The change

```csharp
svc.AddOrUpdate(new PingTarget("x", h, "#111") { IsEnabled = false });
```

`PumpAsync` snapshots `Targets.Values.Where(t => t.IsEnabled && …)` every tick, so a disabled target is **still enumerated** — the concurrent `AddOrUpdate`/`Remove` still races that snapshot, which is the entire reason the test exists — it is simply never pinged. `"base"` stays enabled, so the pump is genuinely pinging while the map churns underneath it, and all four assertions are untouched.

Nothing is lost in coverage: mid-pump target appearance and disappearance is covered by `PingMonitorServiceTests.AddingTargetMidPump_StartsEmitting` and `RemovingTargetMidPump_StopsEmitting`, and `PingOnceAsync`'s stale-sample guard by `DisabledTarget_EmitsNoSamples`.

`--hangdump-timeout` is deliberately **not** touched. The issue offered raising it as the safer knob, but that was on the assumption the suite had a legitimately slow test. It doesn't — after this, the slowest is ~70 s, so 5 minutes keeps its headroom and keeps meaning "something is genuinely stuck". Raising it would have hidden this instead of fixing it.

### Guard

`ThePingChurn_BuildsDisabledTargets_SoItDoesNotOrphanThousandsOfPings`, in the **blocking** unit suite rather than the integration suite it guards — a job whose symptom is that job timing out cannot be trusted to report it. It reads the churn loop out of the test's source, comment-stripped, and fails if any target built inside it is left enabled.

Red before, green after, all three failure paths, restore verified byte-for-byte:

```
baseline (unmutated): GREEN
mutation 1 churned target left enabled -> RED   "1 of the 1 PingTargets built inside the churn loop are left enabled…"
mutation 2 slice marker moved          -> RED   "the churn loop … was not found, so this guard read nothing"
mutation 3 far end of the loop removed -> RED   "the churn slice does not reach the loop's Remove call…"
3 of 3 mutations failed for the expected reason
```

Mutation 2 and 3 exist because the first version of the guard was red against correct code: an object initializer ends in `});`, so the slice terminated inside the very construction it was trying to read, and the `>= 1` vacuity floor still passed because one truncated `new PingTarget(` remained inside it. The terminator is now anchored to the start of a line, and the slice must reach the loop's `Remove` call — a truncated slice can only under-report.

### Verification

- `dotnet build` — integration and unit projects, **0 errors, 0 warnings**
- Unit suite: **5442 passed**, 0 failed (5441 + the new guard)
- `dotnet format --verify-no-changes` — clean on both changed projects
- Leak scan of the staged diff against all 43 current patterns — 0 hits over 94 added lines

The falsifiable prediction for this PR's own integration run: the suite should drop from ~8m17s to roughly 3m30s, `ToggleIsEnabled_MidFlight_IsRespected` from 283 s to about 1.5 s, and `ManyStartStopCycles_NoLeak` from 33–49 s to a few seconds. If it doesn't, the diagnosis is wrong and this should not merge.

`test:` — no release.
