### PR TITLE
test: settle initialization before the chkdsk tests clear the drive list

### DIFF
--- a/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
+++ b/SysManager/SysManager.Tests/SystemHealthViewModelTests.cs
@@ -152,6 +152,7 @@ public class SystemHealthViewModelTests
     public async Task RunChkdsk_NullDrive_SetsStatusMessage()
     {
         var vm = NewVm();
+        await vm.InitializationComplete;
         await vm.RunChkdskCommand.ExecuteAsync(null);
         Assert.Contains("No drive", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
     }
@@ -160,6 +161,7 @@ public class SystemHealthViewModelTests
     public async Task RunChkdsk_EmptyDrive_SetsStatusMessage()
     {
         var vm = NewVm();
+        await vm.InitializationComplete;
         await vm.RunChkdskCommand.ExecuteAsync("");
         Assert.Contains("No drive", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
     }
@@ -168,6 +170,7 @@ public class SystemHealthViewModelTests
     public async Task RunChkdskOnSelected_NoneSelected_SetsStatusMessage()
     {
         var vm = NewVm();
+        await vm.InitializationComplete;
         vm.ChkdskDrives.Clear();
         await vm.RunChkdskOnSelectedCommand.ExecuteAsync(null);
         Assert.Contains("Select at least", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
@@ -290,6 +293,7 @@ public class SystemHealthViewModelTests
     {
         using var notElevated = AdminHelper.ForceElevation(false);
         var vm = NewVm();
+        await vm.InitializationComplete;
         var drive = new DriveTarget { Letter = "C:", Label = "Windows", IsSelected = true };
         vm.ChkdskDrives.Add(drive);
 
@@ -307,6 +311,7 @@ public class SystemHealthViewModelTests
     {
         using var notElevated = AdminHelper.ForceElevation(false);
         var vm = NewVm();
+        await vm.InitializationComplete;
 
         await vm.RunChkdskCommand.ExecuteAsync("D:");
 


### PR DESCRIPTION
Addresses #2201 for the five tests that survived triage. `test:` — no release.

### What the triage found

The issue asked for the counting first, and the counting kept being wrong in my favour until a known case caught it. Full numbers are on #2201; the short version is that the racy bucket shrank three times:

| after | racy tests |
|---|---|
| body-scoped scan for `await …InitializationComplete` | 37 |
| resolving how each test class settles init | 8 |
| reading what each test's doubles actually do | **5** |

The second drop is because **17 test classes** settle init inside their factory, synchronously:

```csharp
private static CpuAffinityViewModel NewVm()
{
    var vm = new CpuAffinityViewModel(new CpuAffinityService());
    vm.InitializationComplete.GetAwaiter().GetResult();
    return vm;
}
```

The third is because a race needs the init to *actually* yield at runtime, which depends on the test's own doubles. `DebloaterViewModel`'s three candidates use an `IPowerShellRunner` substitute returning `Task.FromResult(…)`, so `ListAsync` completes synchronously, `RefreshAsync` never suspends, and `InitializationComplete` is already finished when the constructor returns. I wrote the awaits for those three, measured that they were no-ops, and reverted them.

### The five that are real

`SystemHealthViewModelTests.NewVm()` builds the view model over **real** services, so `InitAsync` → `await _drives.EnumerateAsync()` genuinely suspends, and its **success** path then runs:

```csharp
ChkdskDrives.ReplaceWith(list.Select(d => new DriveTarget
{
    …
    IsSelected = string.Equals(d.Letter, "C:", StringComparison.OrdinalIgnoreCase),
}));
```

So the sharpest of the five:

```csharp
var vm = NewVm();
vm.ChkdskDrives.Clear();
await vm.RunChkdskOnSelectedCommand.ExecuteAsync(null);
Assert.Contains("Select at least", vm.StatusMessage, …);
```

Clear the list, assert the command refuses. If the enumeration lands between the `Clear()` and the command reading the collection, the list comes back with `C:` selected and the command runs a scan instead of refusing — and the assertion fails on a message neither the test nor the command produced. Note the race is on the **collection**, not on `StatusMessage`, even though a `StatusMessage` assertion is what fails; the framing in the issue title would not have found this one.

Fix is the seam `ViewModelBase` documents for exactly this:

> Production never awaits this — the window paints while init runs in the background — but tests can await it to observe the loaded state deterministically instead of racing the fire-and-forget load.

Five lines, no production change.

### On the absence of a red run

This is a determinism fix and I did not reproduce a red. The window is narrow in the direction that currently favours passing: real drive enumeration takes long enough that `Clear()` almost always wins, and the test has been green for as long as it existed. Forcing the failure would need a barrier between the `Clear()` and the command's read, which is more test machinery than the one-line fix it would justify.

What stands in for it is that the **identical shape already went red in CI**, in run 34466437026, on `DeepCleanupViewModelTests.ScanLargeFiles_NoLocation_SetsErrorStatus` — a test that clears `SelectedLocation` while the constructor's init assigns `SelectLocations.FirstOrDefault()`. That PR touched only the theme stack and an unrelated new test class; adding the class shifted timing enough to lose a race that had always been won. Same defect, same seam, same fix. I'd rather say that plainly than dress a timing argument up as a proof.

### Verification

- `dotnet build` unit project — 0 errors, 0 warnings
- `SystemHealthViewModelTests` + `DebloaterViewModelTests` — 45 passed
- Full unit suite — **5441 passed**, 0 failed
- `dotnet format --verify-no-changes` — clean
- Leak scan of the staged diff against all 43 current patterns — 0 hits

### Not done here

The remaining scope on #2201 is proposal 2 — inverting the factory default so pre-init tests opt out. It now looks less like a refactor and more like finishing something already half-done in 17 files, but the existing factory comment argues for the current default and that reasoning deserves an answer rather than a sweep. Left on the issue.
