### PR TITLE
feat: show when each process started in the Process Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.89.0] - 2026-09-10
+
+**The Process Manager now shows when each program started.** When something is eating your CPU, the
+useful question is usually *when did this appear* — a program that started three minutes ago is a very
+different suspect from one that has been running since you turned the PC on. The tab already knew the
+answer and read it every second without ever showing you, so you could sort by memory and by CPU but
+not by age. There is now a **Started** column, and clicking its header groups everything that arrived
+recently.
+
+### Added
+
+- **Started column in the Process Manager**, sortable chronologically. Programs whose start time
+  Windows will not reveal — most system processes, unless you run SysManager as administrator — show a
+  dash rather than a made-up date.
+
 ## [1.88.4] - 2026-09-10
 
 **The Process Manager opens straight away again.** Checking who signed a program takes Windows about a

--- a/README.md
+++ b/README.md
@@ -563,9 +563,15 @@ a confirmation before it runs:
   scan. Stored only on this PC and never carried to another (folder sizes here mean nothing there)
 
 ### Process Manager
-- Lists running Windows processes with PID, memory, threads, and status
+- Lists running Windows processes with PID, memory, threads, status, and when each one started
 - Real-time filter by name, description, category, or PID
-- Sort by memory, CPU usage, name, category, or PID via clickable column headers
+- Sort by memory, CPU usage, name, category, PID, or start time via clickable column headers
+- **Started column** — when each process began. "Something is eating my CPU" is usually
+  answered by *when it appeared*: a process that started three minutes ago is a very
+  different suspect from one that has been running since you turned the PC on, and sorting
+  by it groups everything that arrived recently. Processes whose start time Windows will
+  not reveal — most system processes, unless you run as administrator — show a dash rather
+  than a made-up date
 - **Built-in description database** — 108 common Windows processes and popular
   applications with plain-language descriptions and categories (System, Browser,
   Development, Communication, Media, Gaming, etc.). The description sits under each

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.88.x   | :white_check_mark: |
-| < 1.88   | :x:                |
+| 1.89.x   | :white_check_mark: |
+| < 1.89   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -7391,6 +7391,89 @@ public partial class ArchitectureTests
         Assert.DoesNotContain("VerifySignatures", snapshot, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Every observable field on <c>ProcessEntry</c> is bound in <c>ProcessManagerView.xaml</c>, shown through
+    /// a computed property that is bound, or named here as logic-only. A new one is none of those, so it fails
+    /// until someone decides which it is.
+    /// </summary>
+    /// <remarks>
+    /// The <c>ProcessEntry</c> counterpart of
+    /// <see cref="EveryStartupFieldTheScanFillsIn_IsBoundInTheViewOrDeclaredLogicOnly"/>, and it exists
+    /// because this tab kept producing the same defect and no guard reached it. <c>Signature</c> was #1581 and
+    /// <c>StartTime</c> was #2224: the snapshot read each process's start time on every single tick and
+    /// displayed it nowhere, so a tab whose purpose is "what is my PC doing right now" could sort by CPU and
+    /// by memory but not by age.
+    /// <para><b>Why the global guards do not cover it.</b> <c>EveryModelProperty_IsBoundOrRead</c> accepts a
+    /// property that is merely written, and <c>StartTime</c> was written — by the snapshot, and read by
+    /// <c>ReconcileInto</c> to tell a genuinely-same process from a PID Windows reused. That is a real use, so
+    /// nothing was wrong by those guards' criteria; the datum was simply never shown. Only the tab's own view
+    /// can answer for the tab's own model.</para>
+    /// <para>Two fields are shown through a computed property rather than directly, which a name-based check
+    /// would call unbound: <c>MemoryBytes</c> through <c>MemoryDisplay</c> and <c>StartTime</c> through
+    /// <c>StartTimeDisplay</c>. Both are required as an actual binding, so deleting the column fails this even
+    /// though the underlying field is still assigned.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryProcessEntryField_IsBoundInTheViewOrDeclaredLogicOnly()
+    {
+        var appDir = FindAppProjectDir();
+        var model = DocComment().Replace(
+            File.ReadAllText(Path.Combine(appDir, "Models", "ProcessEntry.cs")), string.Empty);
+        var view = WithoutXamlComments(
+            File.ReadAllText(Path.Combine(appDir, "Views", "ProcessManagerView.xaml")));
+
+        var fields = ObservablePropertyField().Matches(model)
+            .Select(m => char.ToUpperInvariant(m.Groups[1].Value[0]) + m.Groups[1].Value[1..])
+            .ToList();
+
+        // Vacuity floor: 17 observable fields when measured. If the model is reshaped and this parses a
+        // handful, every check below passes over almost nothing.
+        Assert.True(fields.Count >= 15,
+            $"only {fields.Count} observable fields were parsed from ProcessEntry, out of 17 measured — the "
+            + "field detection is out of date, so a pass proves nothing. Found: " + string.Join(", ", fields));
+
+        // Shown, but through a computed property. The computed one is what the column binds, so that is what
+        // gets required — the field being assigned is not evidence anybody can see it.
+        var shownVia = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["MemoryBytes"] = "MemoryDisplay",
+            ["StartTime"] = "StartTimeDisplay",
+        };
+
+        // Not display, with the reason. Demanding a column for these would push this guard into asking for
+        // UI nobody wants, which is how the Startup guard's scope was drawn too.
+        var logicOnly = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["FilePath"] = "feeds the Open button and icon extraction; the path itself is not a column, and "
+                + "CanOpenFileLocation is what the button binds",
+            ["HasMainWindow"] = "drives the \"apps only\" filter, which is a control rather than a cell",
+        };
+
+        var undecided = new List<string>();
+        foreach (var field in fields)
+        {
+            if (logicOnly.ContainsKey(field)) continue;
+
+            var required = shownVia.TryGetValue(field, out var via) ? via : field;
+            if (view.Contains($"{{Binding {required}", StringComparison.Ordinal)) continue;
+
+            undecided.Add(field == required
+                ? field
+                : $"{field} (shown through {required}, which is not bound)");
+        }
+
+        Assert.True(undecided.Count == 0,
+            "these ProcessEntry fields are neither bound in ProcessManagerView.xaml nor declared logic-only "
+            + "here, so the snapshot pays to fill them in on every tick and the user cannot see them — the "
+            + "shape of #1581 and #2224. Add a column, or add the field to logicOnly with the reason it is "
+            + "not display:\n  " + string.Join("\n  ", undecided));
+
+        // And that sorting the Started column orders by the timestamp, not by the formatted string. Bound as
+        // StartTimeDisplay, a DataGrid sorts alphabetically on that text — which for "yyyy-MM-dd HH:mm:ss"
+        // happens to agree with chronological order, so the defect is invisible until the format changes.
+        Assert.Contains("SortMemberPath=\"StartTime\"", view, StringComparison.Ordinal);
+    }
+
     /// <summary>An <c>entry.Property =</c> assignment, capturing the property name.</summary>
     /// <remarks>
     /// Scoped to the <c>entry</c> local the post-passes all use, rather than any member assignment, so an

--- a/SysManager/SysManager.Tests/ProcessManagerServiceTests.cs
+++ b/SysManager/SysManager.Tests/ProcessManagerServiceTests.cs
@@ -220,6 +220,43 @@ public class ProcessManagerServiceTests
     }
 
     [Fact]
+    public void ProcessEntry_StartTimeDisplay_FormatsTheTimestamp()
+    {
+        var entry = new ProcessEntry { StartTime = new DateTime(2026, 3, 9, 14, 5, 7, DateTimeKind.Local) };
+        Assert.Equal("2026-03-09 14:05:07", entry.StartTimeDisplay);
+    }
+
+    /// <summary>
+    /// The case the em dash exists for. <c>Process.StartTime</c> throws for most system processes without
+    /// elevation and the snapshot swallows that, leaving the field at <c>default</c> — so binding the raw
+    /// value would print <c>0001-01-01 00:00:00</c>, which reads as a bug rather than "not available".
+    /// </summary>
+    [Fact]
+    public void ProcessEntry_StartTimeDisplay_WhenWindowsWouldNotSay_ShowsADashNotYearOne()
+    {
+        var entry = new ProcessEntry();
+
+        Assert.Equal("—", entry.StartTimeDisplay);
+        Assert.DoesNotContain("0001", entry.StartTimeDisplay, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The display string has to re-raise when the timestamp arrives, because the snapshot fills
+    /// <c>StartTime</c> in after construction — a computed property with no
+    /// <c>NotifyPropertyChangedFor</c> would leave the column showing the em dash for the row's whole life.
+    /// </summary>
+    [Fact]
+    public void ProcessEntry_StartTimeDisplay_NotifiesWhenTheTimestampArrives()
+    {
+        var entry = new ProcessEntry();
+        var changed = entry.RecordPropertyChanges();
+
+        entry.StartTime = new DateTime(2026, 3, 9, 14, 5, 7, DateTimeKind.Local);
+
+        Assert.Contains(nameof(ProcessEntry.StartTimeDisplay), changed);
+    }
+
+    [Fact]
     public void ProcessEntry_PropertyChange_Notifies()
     {
         var entry = new ProcessEntry();

--- a/SysManager/SysManager/Models/ProcessEntry.cs
+++ b/SysManager/SysManager/Models/ProcessEntry.cs
@@ -2,6 +2,7 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.Windows.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using SysManager.Helpers;
@@ -26,7 +27,9 @@ public sealed partial class ProcessEntry : ObservableObject
     // for other users' and most system processes unless elevated — so the choices were to implement it
     // properly or not to imply it exists. Dropped; the Safety column already answers the question this
     // tab is for ("is this Windows, or something I installed?").
-    [ObservableProperty] private DateTime _startTime;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(StartTimeDisplay))]
+    private DateTime _startTime;
     [ObservableProperty] private int _threadCount;
     [ObservableProperty] private string _filePath = "";
     [ObservableProperty] private ImageSource? _icon;
@@ -57,4 +60,22 @@ public sealed partial class ProcessEntry : ObservableObject
 
     /// <summary>Formatted memory for display.</summary>
     public string MemoryDisplay => FormatHelper.FormatSize(MemoryBytes);
+
+    /// <summary>When the process started, or <c>—</c> when Windows would not say.</summary>
+    /// <remarks>
+    /// Same format and same em-dash fallback as <see cref="FileLocker.StartTimeDisplay"/>, which was the only
+    /// place in the app showing a process start time before this one.
+    /// <para>The fallback is not cosmetic. <c>Process.StartTime</c> throws for most system processes without
+    /// elevation, and <see cref="ProcessManagerService"/> swallows that and leaves the field at
+    /// <c>default</c> — so binding the raw value would print <c>0001-01-01 00:00:00</c> in a column, which
+    /// reads as a bug rather than as "not available".</para>
+    /// <para>Absolute rather than a relative age ("4 min ago"), deliberately. The list refreshes through
+    /// <c>ProcessManagerViewModel.ReconcileInto</c>, which only writes properties whose value CHANGED — a
+    /// relative string derives from the clock rather than from the model, so it would be computed once when
+    /// the row appeared and then never raise a change again. It would silently freeze at the age the process
+    /// had when it was first seen, which is worse than an absolute timestamp that is simply always true.</para>
+    /// </remarks>
+    public string StartTimeDisplay => StartTime == default
+        ? "—"
+        : StartTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.88.4</Version>
-    <FileVersion>1.88.4.0</FileVersion>
-    <AssemblyVersion>1.88.4.0</AssemblyVersion>
+    <Version>1.89.0</Version>
+    <FileVersion>1.89.0.0</FileVersion>
+    <AssemblyVersion>1.89.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -173,6 +173,26 @@
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
 
+                    <!-- The snapshot has always read each process's start time, on every tick, and showed it
+                         nowhere. "Something is eating my CPU" is usually answered by WHEN it appeared — a
+                         process three minutes old is a different suspect from one up since boot — and the
+                         tab let you sort by CPU and by memory but not by age.
+                         SortMemberPath is StartTime, not StartTimeDisplay, so sorting is chronological
+                         rather than alphabetical on the formatted string. Placed here because Threads is the
+                         last plain fact about the process: Status, Safety and Signature after it are the
+                         judgement chips, and Category's own comment above reasons about that same split. -->
+                    <DataGridTextColumn Header="Started" Binding="{Binding StartTimeDisplay}"
+                                        Width="140" MinWidth="120" SortMemberPath="StartTime">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="FontFamily" Value="Consolas"/>
+                                <Setter Property="FontSize" Value="11"/>
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextMuted}"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+
                     <DataGridTemplateColumn Header="Status" Width="100" MinWidth="90" SortMemberPath="Status">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>


### PR DESCRIPTION
Closes #2224. `feat:` → v1.89.0.

### The gap

`ProcessManagerService.Snapshot` has read every process's start time on every tick since the tab existed, and shown it nowhere. Its only consumer is `ReconcileInto`, comparing it against the fresh snapshot to tell a genuinely-same process from a PID Windows reused — a real and necessary use, but internal bookkeeping, so a datum the app pays for every second was invisible.

The loss is specific: "something is eating my CPU" is usually answered by *when it appeared*. A process three minutes old is a very different suspect from one up since boot, and the tab let you sort by memory, CPU, name, category and PID but not by age.

### Three decisions worth stating

**Absolute timestamp, not a relative age.** The issue left this open and suggested "4 min ago" probably reads better for the target persona. It would — and it would also be wrong within a minute. `ReconcileInto` only writes properties whose value **changed**, and a relative string derives from the clock rather than from the model, so it would be computed once when the row appeared and never raise a change again. It would silently freeze at the age the process had when first seen, which is worse than a timestamp that is simply always true. Format and em-dash fallback copied from `FileLocker.StartTimeDisplay`, which was the only place in the app already showing a process start time.

**The em dash is not cosmetic.** `Process.StartTime` throws for most system processes without elevation, and `Snapshot` swallows that and leaves the field at `default`. Binding the raw value would print `0001-01-01 00:00:00` in a column, which reads as a bug rather than as "not available".

**Placed after Threads.** Threads is the last plain fact about the process; Status, Safety and Signature after it are the judgement chips. That is the same split `Category`'s own comment in the view already reasons about ("Safety is the column that carries the judgement, and two chips side by side would compete for the same attention"). `SortMemberPath="StartTime"` rather than the display string, so sorting is chronological rather than alphabetical — which for `yyyy-MM-dd HH:mm:ss` happens to agree today, meaning the defect would be invisible until someone changed the format. Hence the assertion for it.

### The guard, and why a per-tab one

`EveryProcessEntryField_IsBoundInTheViewOrDeclaredLogicOnly`, the `ProcessEntry` counterpart of the Startup Manager's field guard. It exists because neither global guard reaches this defect: `EveryModelProperty_IsBoundOrRead` accepts a property that is merely **written**, and `StartTime` was written. Nothing was wrong by those guards' criteria — the datum was simply never shown. Only the tab's own view can answer for the tab's own model.

Of `ProcessEntry`'s 17 observable fields: 13 bound directly, `MemoryBytes` and `StartTime` shown through computed properties (both required as actual bindings, so deleting a column fails even though the field is still assigned), and `FilePath` and `HasMainWindow` declared logic-only with the reason. So it passes the moment this column exists, and its value from here is preventive — it is the shape that produced #1581's `IsSigned` and #1587's `Location`.

### Proof

Four mutations, each RED for its own stated reason, both files restored byte-for-byte:

```
baseline guard        -> GREEN
baseline model tests  -> GREEN

mutation 1 column deleted             -> RED  "…the user cannot see them … StartTime (shown through
                                               StartTimeDisplay, which is not bound)"
mutation 2 SortMemberPath deleted     -> RED  Not found: "SortMemberPath="StartTime""
mutation 3 NotifyPropertyChangedFor   -> RED  Collection: ["StartTime"] Not found: "StartTimeDisplay"
mutation 4 default formatted anyway   -> RED  Expected: "—"  Actual: "0001-01-01 00:00:00"
```

Mutation 3 is the one worth a second look: without `[NotifyPropertyChangedFor]` the column would show the em dash for the row's whole life, because the snapshot fills `StartTime` in *after* construction. Every value would be correct and nothing would be displayed.

### Verification

- App and unit projects — **0 errors, 0 warnings**
- Unit suite **5446 passed**, 0 failed (5442 + 3 model tests + the guard)
- `dotnet format --verify-no-changes` clean on both projects
- Leak scan of the staged diff against all 43 current patterns — 0 hits
- Author headers present on both touched app files
- Docs in this same PR: README Process Manager section (the two bullets that enumerated columns and sort keys were both stale), CHANGELOG `[1.89.0]` with the plain-English opener CI requires, SECURITY supported versions → 1.89.x, csproj Version/FileVersion/AssemblyVersion → 1.89.0. ARCHITECTURE needs nothing — no new service or view-model.

### Deferred to the secondary workstation

The column's rendered width. 140px fits `2026-09-10 15:04:07` at FontSize 11 Consolas with room to spare, but this grid now carries ten columns and I cannot judge from here whether the total forces horizontal scrolling at a smaller window size. Worth a look alongside the signature-pill states already queued for that machine.
