### PR TITLE
feat: export the access history, settings drift and disk breakdown to CSV

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -291,6 +291,14 @@ Key services:
   since several entries pointing at one exe is normal. `ResolveExecutablePath` is the single
   answer to "which file is this entry", shared with `ExtractPublisher`, so the Publisher and
   the certificate can never describe different files.
+- `Helpers/Csv` — RFC 4180 field escaping for the Export CSV buttons, defined once. It exists
+  because the first exporter (`ResourceHistoryService.ToCsv`) writes its fields raw, which is
+  safe for numbers and fixed-format timestamps but not for the app names, setting descriptions
+  and folder paths the later exports carry: `C:\Users\me\Music\Grieg, Peer Gynt` is an ordinary
+  folder name that silently becomes two columns without quoting. `Field` quotes only when the
+  value contains a comma, a quote, CR or LF; `AppendRow` terminates with CRLF because this is a
+  file format rather than console output. Nothing is trimmed or substituted — a lossy export of
+  a path is worse than a quoted one.
 - `Helpers/Authenticode` — the two Authenticode operations, defined once: `ReadSigner`
   (three-way `Signed`/`Unsigned`/`Unreadable`, never throws) and `ValidateChain` (one strict
   policy — `ExcludeRoot`, `NoFlag`, fail-closed — with the revocation mode as a parameter).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.90.0] - 2026-09-11
+
+**Three more tabs can now save what they found to a file.** Camera/Mic/Location, Settings Watchdog and
+Disk Analyzer each produce a list that could only be read on screen, so the realistic move — sending it
+to whoever helps you with the PC — meant photographing the monitor. Each now has an **Export CSV**
+button that writes the list wherever you point it. On Settings Watchdog it deliberately sits to the left
+of Restore, because Restore overwrites the "now" column and the file is the only record of what Windows
+changed.
+
+### Added
+
+- **Export CSV on Camera/Mic/Location** — the camera, microphone and location access history, with both
+  the readable time and a raw timestamp a spreadsheet can sort.
+- **Export CSV on Settings Watchdog** — what changed, in the same plain language the tab uses, plus
+  whether each change can be restored.
+- **Export CSV on Disk Analyzer** — the folder breakdown with both the readable size and the raw byte
+  count, since "9.8 GB" sorts below "10 MB" as text.
+- Folder names and app names containing a comma now survive as a single column. The first CSV export
+  wrote its fields raw, which was fine for numbers; these three carry names Windows or you chose, and
+  `C:\Users\me\Music\Grieg, Peer Gynt` is an ordinary folder name.
+
+Every export goes only where you point the file dialog — nothing is written to a default location and
+nothing leaves your machine.
+
 ## [1.89.0] - 2026-09-10
 
 **The Process Manager now shows when each program started.** When something is eating your CPU, the

--- a/README.md
+++ b/README.md
@@ -549,6 +549,10 @@ a confirmation before it runs:
 - Drive usage bar with total/used/free
 - Preset paths (fixed drives, user profile, Program Files) or custom browse
 - Show in Explorer for each folder
+- **Export CSV** saves the breakdown to a file you choose the location for, with both the
+  readable size and the raw byte count — so a spreadsheet can sort it, which it cannot do with
+  "9.8 GB" and "10 MB" as text. Useful for comparing before and after a cleanup without
+  running a minutes-long scan twice from memory
 - **Says what it doesn't count** — four Windows system areas (`$Recycle.Bin`,
   `System Volume Information`, `Windows\WinSxS`, `Windows\CSC`) are skipped because they are
   slow or unreadable, and junctions are never followed, since following one would
@@ -668,6 +672,9 @@ a confirmation before it runs:
 - Devices **in use right now** are flagged and sorted to the top
 - Read-only: an **Open privacy settings** button hands off to Windows to grant or
   revoke a permission — SysManager never changes capability permissions itself
+- **Export CSV** saves the history to a file you choose the location for, so evidence about
+  which app used the camera can be sent to whoever helps you with the PC instead of
+  photographed off the screen. The file stays on your machine unless you move it
 
 ### Settings Watchdog
 - **Catch the settings Windows Update silently resets** — feature and quality
@@ -681,6 +688,9 @@ a confirmation before it runs:
 - **Check now** re-reads the live values and lists any drift in plain language —
   e.g. *"Diagnostic data: was 'Off (Security)', now 'Full'"* — with the category
   and a before/after comparison
+- **Export CSV** saves the list of changes before you restore them. Restore overwrites the
+  "now" column, so this file is the only record of what Windows changed — which is why the
+  button sits to the left of Restore
 - **Restore changed** writes the drifted settings back to your baseline values in
   one step (HKLM-backed settings need administrator rights, surfaced not crashed)
 - Strictly local: the baseline lives in your `%LocalAppData%\SysManager` folder and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.89.x   | :white_check_mark: |
-| < 1.89   | :x:                |
+| 1.90.x   | :white_check_mark: |
+| < 1.90   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -408,6 +408,72 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Every <c>ExportCsvCommand</c> is bound in ITS OWN view, not merely somewhere in the app's markup.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="EveryViewModelCommand_IsReachableFromTheUi"/> cannot answer this, and the difference is the
+    /// whole reason this exists. That guard tests a command NAME against every <c>.xaml</c> concatenated, so
+    /// once one tab binds <c>ExportCsvCommand</c> the name is present in the corpus and every other
+    /// view-model's identically-named command reads as reachable. Measured by mutation: deleting the
+    /// <c>Command</c> binding from the Camera/Mic/Location, Settings Watchdog and Disk Analyzer toolbars left
+    /// it GREEN all three times, because <c>ResourceHistoryView.xaml</c> still mentioned the name.
+    /// <para>Same shape as the <c>Location</c> collision documented on
+    /// <see cref="EveryStartupFieldTheScanFillsIn_IsBoundInTheViewOrDeclaredLogicOnly"/> — a name shared by
+    /// several types is satisfied by whichever tab happens to bind it. Only the tab's own view can answer for
+    /// the tab's own view-model.</para>
+    /// <para>Derived by reflection rather than from a list, so a fifth tab gaining an export is covered the
+    /// moment it compiles instead of when someone remembers to extend a table. An export is exactly the
+    /// feature this repo has shipped unreachable before: the command is unit-tested through its pure
+    /// formatter, so every test passes while the button does not exist.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryExportCommand_IsBoundInItsOwnView()
+    {
+        var appDir = FindAppProjectDir();
+        var viewsDir = Path.Combine(appDir, "Views");
+        var offenders = new List<string>();
+        var checked_ = 0;
+
+        foreach (var type in AppAssembly.GetTypes()
+                     .Where(t => t.Namespace == "SysManager.ViewModels" && !t.IsNested)
+                     .OrderBy(t => t.Name, StringComparer.Ordinal))
+        {
+            var command = type
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .FirstOrDefault(p => p.Name == "ExportCsvCommand"
+                                  && typeof(System.Windows.Input.ICommand).IsAssignableFrom(p.PropertyType));
+            if (command is null) continue;
+
+            var view = Path.Combine(viewsDir,
+                type.Name.Replace("ViewModel", "View", StringComparison.Ordinal) + ".xaml");
+            if (!File.Exists(view))
+            {
+                offenders.Add($"{type.Name} has an ExportCsvCommand but {Path.GetFileName(view)} does not "
+                            + "exist, so this guard cannot tell whether the button is there");
+                continue;
+            }
+
+            checked_++;
+            var markup = WithoutXamlComments(File.ReadAllText(view));
+            if (!markup.Contains("Command=\"{Binding ExportCsvCommand}\"", StringComparison.Ordinal))
+                offenders.Add($"{type.Name}.ExportCsvCommand is not bound in {Path.GetFileName(view)}");
+        }
+
+        // Vacuity floor: four tabs export CSV when measured — Resource History, Camera/Mic/Location,
+        // Settings Watchdog, Disk Analyzer. A collapse means the reflection stopped finding them and every
+        // absence below is an absence of looking.
+        Assert.True(checked_ >= 4,
+            $"only {checked_} view-models with an ExportCsvCommand were found, out of 4 measured — the "
+            + "reflection is out of date, so a pass proves nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "an Export CSV command exists on a view-model but its own view does not bind it, so the feature "
+            + "is unreachable on that tab. The general reachability guard cannot see this: another tab binds "
+            + "a command of the same name, which satisfies a corpus-wide search. Add the button, or remove "
+            + "the command:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
     /// Every way of setting a theme goes through the one path that keeps its text legible.
     /// </summary>
     /// <remarks>

--- a/SysManager/SysManager.Tests/CsvExportTests.cs
+++ b/SysManager/SysManager.Tests/CsvExportTests.cs
@@ -1,0 +1,224 @@
+// SysManager · CsvExportTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Text;
+using SysManager.Helpers;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="Csv"/> and the three <c>ToCsv</c> formatters behind the Export CSV buttons.
+/// </summary>
+/// <remarks>
+/// The formatters are pure static methods precisely so they can be tested without a file dialog, which is the
+/// shape <c>ResourceHistoryService.ToCsv</c> established. What is NOT covered here is the command itself:
+/// <c>SaveFileDialog.ShowDialog()</c> needs a window, so the export commands are exercised by the guard that
+/// checks each one is bound in its view, not by these tests.
+/// </remarks>
+public class CsvExportTests
+{
+    // ── Csv.Field: the escaping the older exporter did not need ──
+    //
+    // ResourceHistoryService.ToCsv writes its fields raw, and that is safe there because every one is a
+    // number or a fixed-format timestamp. These three exports carry app names, setting descriptions and
+    // folder paths, so the separator can legitimately appear inside a value.
+
+    [Theory]
+    [InlineData("plain", "plain")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    [InlineData("Grieg, Peer Gynt", "\"Grieg, Peer Gynt\"")]
+    [InlineData("say \"hello\"", "\"say \"\"hello\"\"\"")]
+    [InlineData("line\nbreak", "\"line\nbreak\"")]
+    [InlineData("carriage\rreturn", "\"carriage\rreturn\"")]
+    [InlineData("C:\\Users\\me\\Music", "C:\\Users\\me\\Music")]
+    public void Field_QuotesOnlyWhatHasTo(string? input, string expected)
+        => Assert.Equal(expected, Csv.Field(input));
+
+    /// <summary>
+    /// A folder name containing a comma must survive as ONE column. This is the whole reason the helper
+    /// exists: without quoting the row silently gains a column and every value after it shifts left, which a
+    /// spreadsheet reads without complaining.
+    /// </summary>
+    [Fact]
+    public void AppendRow_KeepsACommaInsideOneField()
+    {
+        var sb = new StringBuilder();
+        Csv.AppendRow(sb, "Grieg, Peer Gynt", "1024");
+
+        Assert.Equal("\"Grieg, Peer Gynt\",1024\r\n", sb.ToString());
+        // Three commas would mean four columns; the quoted one must not count as a separator.
+        Assert.Equal(1, sb.ToString().Count(c => c == ',') - 1);
+    }
+
+    /// <summary>CRLF, because this is a file format rather than console output. RFC 4180 names it.</summary>
+    [Fact]
+    public void AppendRow_TerminatesWithCrLf()
+    {
+        var sb = new StringBuilder();
+        Csv.AppendRow(sb, "a");
+        Assert.EndsWith("\r\n", sb.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AppendRow_WithNoFields_StillEndsTheRow()
+    {
+        var sb = new StringBuilder();
+        Csv.AppendRow(sb);
+        Assert.Equal("\r\n", sb.ToString());
+    }
+
+    // ── PrivacyMonitorService.ToCsv ──
+
+    [Fact]
+    public void PrivacyToCsv_WritesAHeaderAndOneRowPerEntry()
+    {
+        var csv = PrivacyMonitorService.ToCsv([
+            new PrivacyAccessEntry("Camera", "Contoso Meet", new DateTime(2026, 3, 9, 14, 5, 7), false),
+            new PrivacyAccessEntry("Microphone", "Contoso Meet", null, true),
+        ]);
+
+        var lines = csv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(3, lines.Length);
+        Assert.Equal("Capability,App,Last used,Last used (raw),In use now", lines[0]);
+        Assert.Contains("Camera,Contoso Meet,2026-03-09 14:05,2026-03-09 14:05:07,no", lines[1], StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// "In use now" is not a timestamp, so the raw column must be empty rather than invented — and the
+    /// readable column must still say what the tab says.
+    /// </summary>
+    [Fact]
+    public void PrivacyToCsv_WhenStillInUse_LeavesTheRawTimestampEmpty()
+    {
+        var csv = PrivacyMonitorService.ToCsv([new PrivacyAccessEntry("Location", "Maps", null, true)]);
+
+        var row = csv.Split("\r\n")[1];
+        Assert.Equal("Location,Maps,In use now,,yes", row);
+    }
+
+    [Fact]
+    public void PrivacyToCsv_WithNoEntries_IsHeaderOnly()
+    {
+        var csv = PrivacyMonitorService.ToCsv([]);
+        Assert.Equal("Capability,App,Last used,Last used (raw),In use now\r\n", csv);
+    }
+
+    /// <summary>An app name with a comma in it stays one column.</summary>
+    [Fact]
+    public void PrivacyToCsv_QuotesAnAppNameContainingAComma()
+    {
+        var csv = PrivacyMonitorService.ToCsv([
+            new PrivacyAccessEntry("Camera", "Acme, Inc. Camera", null, false)]);
+
+        Assert.Contains("\"Acme, Inc. Camera\"", csv, StringComparison.Ordinal);
+    }
+
+    // ── SettingsWatchdogService.ToCsv ──
+
+    /// <summary>A watched setting whose raw 0/3 read back as words, which is what the export must carry.</summary>
+    private static WatchedSetting TelemetrySetting() => new(
+        Key: "telemetry",
+        Name: "Telemetry",
+        Description: "How much diagnostic data Windows sends",
+        Category: "Privacy",
+        RegistryPath: @"HKLM\Software\Policies\Microsoft\Windows\DataCollection",
+        ValueName: "AllowTelemetry",
+        ValueLabels: new Dictionary<int, string> { [0] = "Off", [3] = "Full" });
+
+    [Fact]
+    public void DriftToCsv_WritesTheLabelsTheTabShows()
+    {
+        var csv = SettingsWatchdogService.ToCsv([new SettingDrift(TelemetrySetting(), 0, 3)]);
+
+        var lines = csv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("Setting,Category,Description,Was,Now,Can restore", lines[0]);
+        Assert.StartsWith("Telemetry,Privacy,", lines[1], StringComparison.Ordinal);
+        Assert.EndsWith(",yes", lines[1], StringComparison.Ordinal);
+        // The point of exporting labels rather than the raw integers: "Off"/"Full", not 0/3.
+        Assert.Contains(",Off,Full,", lines[1], StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A drift the app cannot undo is the one worth keeping a note of, so the column has to distinguish it.
+    /// </summary>
+    [Fact]
+    public void DriftToCsv_RecordsWhetherEachRowCanBeRestored()
+    {
+        var csv = SettingsWatchdogService.ToCsv([
+            new SettingDrift(TelemetrySetting(), 0, 3, CanRestore: false)]);
+
+        Assert.EndsWith(",no\r\n", csv, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DriftToCsv_WithNoDrifts_IsHeaderOnly()
+    {
+        var csv = SettingsWatchdogService.ToCsv([]);
+        Assert.Equal("Setting,Category,Description,Was,Now,Can restore\r\n", csv);
+    }
+
+    // ── DiskAnalyzerService.ToCsv ──
+
+    /// <summary>
+    /// Both the formatted size and the raw byte count, because "9.8 GB" sorts below "10 MB" as text — so a
+    /// spreadsheet given only the formatted column cannot answer "what is biggest", which is the question.
+    /// </summary>
+    [Fact]
+    public void DiskUsageToCsv_CarriesTheRawByteCountAlongsideTheFormattedSize()
+    {
+        var csv = DiskAnalyzerService.ToCsv([
+            new DiskUsageEntry { Name = "Music", FullPath = @"C:\Users\me\Music", SizeBytes = 52_428_800,
+                                 Percentage = 12.34, FileCount = 7, FolderCount = 2 }]);
+
+        var lines = csv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("Name,Full path,Size,Size (bytes),Share %,Files,Folders,Access denied", lines[0]);
+        Assert.Equal(@"Music,C:\Users\me\Music,50.0 MB,52428800,12.3,7,2,no", lines[1]);
+    }
+
+    /// <summary>The export most likely to meet a comma, since folder names are chosen by whoever made them.</summary>
+    [Fact]
+    public void DiskUsageToCsv_QuotesAFolderPathContainingAComma()
+    {
+        var csv = DiskAnalyzerService.ToCsv([
+            new DiskUsageEntry { Name = "Grieg, Peer Gynt", FullPath = @"C:\Music\Grieg, Peer Gynt",
+                                 SizeBytes = 1024 }]);
+
+        var row = csv.Split("\r\n")[1];
+        Assert.StartsWith("\"Grieg, Peer Gynt\",\"C:\\Music\\Grieg, Peer Gynt\",", row, StringComparison.Ordinal);
+        // Eight columns, so seven separators — the two commas inside the quoted fields must not add any.
+        Assert.Equal(7, row.Split('"')
+            .Where((_, i) => i % 2 == 0)
+            .Sum(outside => outside.Count(c => c == ',')));
+    }
+
+    [Fact]
+    public void DiskUsageToCsv_MarksAnAccessDeniedFolder()
+    {
+        var csv = DiskAnalyzerService.ToCsv([
+            new DiskUsageEntry { Name = "System Volume Information", SizeBytes = 0, IsAccessDenied = true }]);
+
+        Assert.EndsWith(",yes\r\n", csv, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DiskUsageToCsv_WithNoEntries_IsHeaderOnly()
+    {
+        var csv = DiskAnalyzerService.ToCsv([]);
+        Assert.Equal("Name,Full path,Size,Size (bytes),Share %,Files,Folders,Access denied\r\n", csv);
+    }
+
+    // ── Every formatter refuses null rather than throwing something unhelpful deep inside ──
+
+    [Fact]
+    public void EveryFormatter_RejectsANullSequence()
+    {
+        Assert.Throws<ArgumentNullException>(() => PrivacyMonitorService.ToCsv(null!));
+        Assert.Throws<ArgumentNullException>(() => SettingsWatchdogService.ToCsv(null!));
+        Assert.Throws<ArgumentNullException>(() => DiskAnalyzerService.ToCsv(null!));
+        Assert.Throws<ArgumentNullException>(() => Csv.AppendRow(null!, "a"));
+    }
+}

--- a/SysManager/SysManager/Helpers/Csv.cs
+++ b/SysManager/SysManager/Helpers/Csv.cs
@@ -1,0 +1,55 @@
+// SysManager · Csv
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Text;
+
+namespace SysManager.Helpers;
+
+/// <summary>
+/// Builds CSV a spreadsheet will read back correctly, including fields that contain the separator.
+/// </summary>
+/// <remarks>
+/// <see cref="Services.ResourceHistoryService.ToCsv"/> came first and writes its fields raw, which is safe
+/// there because every one of them is a number or a fixed-format timestamp. The exports that followed carry
+/// app names, setting descriptions and folder paths — text a user chose or Windows chose, and
+/// <c>C:\Users\me\Music\Grieg, Peer Gynt</c> is an ordinary folder name that silently becomes two columns
+/// without quoting. So the escaping lives here once rather than being re-derived per tab.
+/// <para>RFC 4180: a field is quoted when it contains a comma, a quote, CR or LF, and an embedded quote is
+/// doubled. Nothing else is altered — no trimming, no separator substitution — because a lossy export of a
+/// path is worse than a quoted one.</para>
+/// </remarks>
+public static class Csv
+{
+    /// <summary>The characters that force a field to be quoted.</summary>
+    private static readonly char[] MustQuote = [',', '"', '\r', '\n'];
+
+    /// <summary>One CSV field, quoted only when it has to be. A null becomes an empty field.</summary>
+    public static string Field(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return "";
+        if (value.IndexOfAny(MustQuote) < 0) return value;
+        return string.Concat("\"", value.Replace("\"", "\"\"", StringComparison.Ordinal), "\"");
+    }
+
+    /// <summary>
+    /// One CSV row, each field escaped, terminated with CRLF.
+    /// </summary>
+    /// <remarks>
+    /// CRLF rather than <c>AppendLine</c>'s platform default: this is a file format, not console output, and
+    /// RFC 4180 names CRLF. It also keeps the bytes identical if the export is ever produced somewhere other
+    /// than Windows.
+    /// </remarks>
+    public static void AppendRow(StringBuilder builder, params string?[] fields)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(fields);
+
+        for (var i = 0; i < fields.Length; i++)
+        {
+            if (i > 0) builder.Append(',');
+            builder.Append(Field(fields[i]));
+        }
+        builder.Append("\r\n");
+    }
+}

--- a/SysManager/SysManager/Services/DiskAnalyzerService.cs
+++ b/SysManager/SysManager/Services/DiskAnalyzerService.cs
@@ -2,8 +2,11 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.IO;
+using System.Text;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -207,5 +210,35 @@ public sealed class DiskAnalyzerService
     {
         // PERF-006: Use OrdinalIgnoreCase instead of allocating a lowercase copy.
         return SkipSegments.Any(seg => path.Contains(seg, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>Renders a folder-size breakdown as CSV with a header row.</summary>
+    /// <remarks>
+    /// Both the formatted size and the raw byte count are exported: the formatted one is what the user read
+    /// on screen, and the raw one is what a spreadsheet can sort — "9.8 GB" sorts below "10 MB" as text.
+    /// <para>This is the export most likely to contain a field needing quotes, since folder names are chosen
+    /// by whoever made them and a comma in one is unremarkable. Hence <see cref="Csv"/> rather than raw
+    /// concatenation.</para>
+    /// </remarks>
+    public static string ToCsv(IEnumerable<DiskUsageEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        var sb = new StringBuilder();
+        Csv.AppendRow(sb, "Name", "Full path", "Size", "Size (bytes)", "Share %", "Files", "Folders",
+            "Access denied");
+        foreach (var e in entries)
+        {
+            Csv.AppendRow(sb,
+                e.Name,
+                e.FullPath,
+                e.SizeDisplay,
+                e.SizeBytes.ToString(CultureInfo.InvariantCulture),
+                e.Percentage.ToString("F1", CultureInfo.InvariantCulture),
+                e.FileCount.ToString(CultureInfo.InvariantCulture),
+                e.FolderCount.ToString(CultureInfo.InvariantCulture),
+                e.IsAccessDenied ? "yes" : "no");
+        }
+        return sb.ToString();
     }
 }

--- a/SysManager/SysManager/Services/PrivacyMonitorService.cs
+++ b/SysManager/SysManager/Services/PrivacyMonitorService.cs
@@ -2,9 +2,12 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Globalization;
 using System.IO;
+using System.Text;
 using Microsoft.Win32;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;
@@ -134,5 +137,29 @@ public sealed class PrivacyMonitorService
         // Packaged: "Microsoft.WindowsCamera_8wekyb3d8bbwe" → "Microsoft.WindowsCamera"
         var underscore = keyName.IndexOf('_');
         return underscore > 0 ? keyName[..underscore] : keyName;
+    }
+
+    /// <summary>Renders an access history as CSV with a header row.</summary>
+    /// <remarks>
+    /// Both the raw timestamp and the on-screen label are exported. The label is what the user recognises
+    /// from the tab — including "In use now", which is not a time at all — and the raw column is what a
+    /// spreadsheet can sort and filter. Dropping either one makes the file worse than the screen it replaces.
+    /// </remarks>
+    public static string ToCsv(IEnumerable<PrivacyAccessEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        var sb = new StringBuilder();
+        Csv.AppendRow(sb, "Capability", "App", "Last used", "Last used (raw)", "In use now");
+        foreach (var e in entries)
+        {
+            Csv.AppendRow(sb,
+                e.Capability,
+                e.AppName,
+                e.LastUsedDisplay,
+                e.LastUsed?.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+                e.InUse ? "yes" : "no");
+        }
+        return sb.ToString();
     }
 }

--- a/SysManager/SysManager/Services/SettingsWatchdogService.cs
+++ b/SysManager/SysManager/Services/SettingsWatchdogService.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Security;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Win32;
 using Serilog;
@@ -267,6 +268,31 @@ public sealed class SettingsWatchdogService : ISettingsWatchdogService
                 "UI Declutter", @"HKCU\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager",
                 "SoftLandingEnabled", onOff),
         ];
+    }
+    /// <summary>Renders a drift table as CSV with a header row.</summary>
+    /// <remarks>
+    /// This export exists for a specific moment: Restore is about to overwrite the "now" column, so the file
+    /// is the only record of what Windows changed. It therefore carries the labels the tab shows rather than
+    /// the raw registry integers, plus whether each row can be restored — a drift the app cannot undo is the
+    /// one the user most needs to keep a note of.
+    /// </remarks>
+    public static string ToCsv(IEnumerable<SettingDrift> drifts)
+    {
+        ArgumentNullException.ThrowIfNull(drifts);
+
+        var sb = new StringBuilder();
+        Csv.AppendRow(sb, "Setting", "Category", "Description", "Was", "Now", "Can restore");
+        foreach (var d in drifts)
+        {
+            Csv.AppendRow(sb,
+                d.Setting.Name,
+                d.Setting.Category,
+                d.Setting.Description,
+                d.BaselineLabel,
+                d.CurrentLabel,
+                d.CanRestore ? "yes" : "no");
+        }
+        return sb.ToString();
     }
 }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.89.0</Version>
-    <FileVersion>1.89.0.0</FileVersion>
-    <AssemblyVersion>1.89.0.0</AssemblyVersion>
+    <Version>1.90.0</Version>
+    <FileVersion>1.90.0.0</FileVersion>
+    <AssemblyVersion>1.90.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -5,8 +5,10 @@
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
+using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
 using Serilog;
 using SysManager.Helpers;
 using SysManager.Models;
@@ -291,6 +293,48 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
         if (!PresetPaths.Contains(entry.FullPath))
             PresetPaths.Add(entry.FullPath);
         await AnalyzeAsync();
+    }
+
+    /// <summary>Whether there is a breakdown worth exporting.</summary>
+    /// <remarks>
+    /// Derived from <see cref="EntryCount"/> rather than being a second flag, so it cannot disagree with the
+    /// number the tab displays. <c>OnEntryCountChanged</c> below is what makes the button follow it.
+    /// </remarks>
+    public bool HasEntries => EntryCount > 0;
+
+    /// <summary>
+    /// Writes the folder-size breakdown to a CSV the user picks a location for.
+    /// </summary>
+    /// <remarks>
+    /// A scan of a large drive takes minutes and produced a number the user could only read on screen, so
+    /// comparing "before" with "after a cleanup" meant running it twice and remembering. The export carries
+    /// both the formatted size and the raw byte count, because "9.8 GB" sorts below "10 MB" as text.
+    /// </remarks>
+    [RelayCommand(CanExecute = nameof(HasEntries))]
+    private async Task ExportCsvAsync()
+    {
+        var dlg = new SaveFileDialog
+        {
+            FileName = $"SysManager-DiskUsage-{DateTime.Now.ToString("yyyy-MM-dd-HHmmss", CultureInfo.InvariantCulture)}.csv",
+            Filter = "CSV file (*.csv)|*.csv|All files (*.*)|*.*"
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        try
+        {
+            var csv = DiskAnalyzerService.ToCsv(Entries);
+            await File.WriteAllTextAsync(dlg.FileName, csv, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            StatusMessage = $"Exported {Entries.Count} folder(s) to {Path.GetFileName(dlg.FileName)}.";
+            ToastService.Instance.Show("Disk usage exported", Path.GetFileName(dlg.FileName));
+        }
+        catch (IOException ex) { StatusMessage = $"Export failed: {ex.Message}"; }
+        catch (UnauthorizedAccessException ex) { StatusMessage = $"Export failed (access denied): {ex.Message}"; }
+    }
+
+    partial void OnEntryCountChanged(int value)
+    {
+        OnPropertyChanged(nameof(HasEntries));
+        ExportCsvCommand.NotifyCanExecuteChanged();
     }
 
     [RelayCommand]

--- a/SysManager/SysManager/ViewModels/PrivacyMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/PrivacyMonitorViewModel.cs
@@ -3,8 +3,12 @@
 // License: MIT
 
 using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
 using Serilog;
 using SysManager.Helpers;
 using SysManager.Models;
@@ -90,6 +94,37 @@ public sealed partial class PrivacyMonitorViewModel : ViewModelBase
             StatusMessage = "Couldn't open Windows privacy settings.";
         }
     }
+
+    /// <summary>
+    /// Writes the access history to a CSV the user picks a location for.
+    /// </summary>
+    /// <remarks>
+    /// The tab's whole output is a list that could only be read on screen, so the realistic move — showing
+    /// someone which app used the camera — meant photographing the monitor. The file goes only where the
+    /// dialog is pointed; nothing is written to a default location and nothing leaves the machine.
+    /// </remarks>
+    [RelayCommand(CanExecute = nameof(HasEntries))]
+    private async Task ExportCsvAsync()
+    {
+        var dlg = new SaveFileDialog
+        {
+            FileName = $"SysManager-Privacy-{DateTime.Now.ToString("yyyy-MM-dd-HHmmss", CultureInfo.InvariantCulture)}.csv",
+            Filter = "CSV file (*.csv)|*.csv|All files (*.*)|*.*"
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        try
+        {
+            var csv = PrivacyMonitorService.ToCsv(Entries);
+            await File.WriteAllTextAsync(dlg.FileName, csv, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            StatusMessage = $"Exported {Entries.Count} entry(ies) to {Path.GetFileName(dlg.FileName)}.";
+            ToastService.Instance.Show("Access history exported", Path.GetFileName(dlg.FileName));
+        }
+        catch (IOException ex) { StatusMessage = $"Export failed: {ex.Message}"; }
+        catch (UnauthorizedAccessException ex) { StatusMessage = $"Export failed (access denied): {ex.Message}"; }
+    }
+
+    partial void OnHasEntriesChanged(bool value) => ExportCsvCommand.NotifyCanExecuteChanged();
 
     protected override void Dispose(bool disposing)
     {

--- a/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
+++ b/SysManager/SysManager/ViewModels/SettingsWatchdogViewModel.cs
@@ -3,8 +3,11 @@
 // License: MIT
 
 using System.Globalization;
+using System.IO;
+using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
 using Serilog;
 using SysManager.Helpers;
 using SysManager.Models;
@@ -138,6 +141,38 @@ public sealed partial class SettingsWatchdogViewModel : ViewModelBase
             ? $"Restored {restored} setting(s) to your baseline."
             : $"Restored {restored} setting(s) · {failed} could not be written (try running as administrator).";
     }
+
+    /// <summary>
+    /// Writes the drift table to a CSV the user picks a location for.
+    /// </summary>
+    /// <remarks>
+    /// The one export on this tab with a deadline attached: Restore overwrites the "now" column, so once it
+    /// has run there is no record left of what Windows changed. Saving first is the only way to keep the
+    /// before-picture, which is why this sits beside Restore rather than in a menu. The file goes only where
+    /// the dialog is pointed.
+    /// </remarks>
+    [RelayCommand(CanExecute = nameof(HasDrift))]
+    private async Task ExportCsvAsync()
+    {
+        var dlg = new SaveFileDialog
+        {
+            FileName = $"SysManager-SettingsDrift-{DateTime.Now.ToString("yyyy-MM-dd-HHmmss", CultureInfo.InvariantCulture)}.csv",
+            Filter = "CSV file (*.csv)|*.csv|All files (*.*)|*.*"
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        try
+        {
+            var csv = SettingsWatchdogService.ToCsv(Drifts.Select(r => r.Drift));
+            await File.WriteAllTextAsync(dlg.FileName, csv, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            StatusMessage = $"Exported {Drifts.Count} change(s) to {Path.GetFileName(dlg.FileName)}.";
+            ToastService.Instance.Show("Settings drift exported", Path.GetFileName(dlg.FileName));
+        }
+        catch (IOException ex) { StatusMessage = $"Export failed: {ex.Message}"; }
+        catch (UnauthorizedAccessException ex) { StatusMessage = $"Export failed (access denied): {ex.Message}"; }
+    }
+
+    partial void OnHasDriftChanged(bool value) => ExportCsvCommand.NotifyCanExecuteChanged();
 
     /// <summary>One drifted setting, wrapping the immutable <see cref="SettingDrift"/> for binding.</summary>
     public sealed partial class DriftRow(SettingDrift drift) : ObservableObject

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -44,6 +44,10 @@
                 <Button Content="Cancel" AutomationProperties.Name="Cancel analysis" Command="{Binding CancelAnalysisCommand}"
                         Style="{StaticResource GhostButton}"
                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+                <Button Content="Export CSV" AutomationProperties.Name="Export CSV — the folder breakdown"
+                        Command="{Binding ExportCsvCommand}"
+                        Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"
+                        ToolTip="Save this breakdown to a CSV file you choose the location for."/>
             </WrapPanel>
         </Border>
 

--- a/SysManager/SysManager/Views/PrivacyMonitorView.xaml
+++ b/SysManager/SysManager/Views/PrivacyMonitorView.xaml
@@ -31,6 +31,10 @@
                 <Button Content="Refresh" Command="{Binding RefreshCommand}"
                         AutomationProperties.Name="Refresh access history"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"/>
+                <Button Content="Export CSV" Command="{Binding ExportCsvCommand}"
+                        AutomationProperties.Name="Export CSV — the access history"
+                        Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
+                        ToolTip="Save this list to a CSV file you choose the location for."/>
                 <Button Content="Open privacy settings" Command="{Binding OpenPrivacySettingsCommand}"
                         AutomationProperties.Name="Open privacy settings — in Windows"
                         Style="{StaticResource GhostButton}"

--- a/SysManager/SysManager/Views/SettingsWatchdogView.xaml
+++ b/SysManager/SysManager/Views/SettingsWatchdogView.xaml
@@ -43,6 +43,12 @@
                 <Button Content="Check now" Command="{Binding RefreshCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"
                         AutomationProperties.Name="Check now — for setting changes"/>
+                <!-- Before Restore, not after it. Restore overwrites the "Now" column, so this file is the
+                     only record of what Windows changed — the left-to-right order is the order to use it in. -->
+                <Button Content="Export CSV" Command="{Binding ExportCsvCommand}"
+                        Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"
+                        AutomationProperties.Name="Export CSV — the settings that changed"
+                        ToolTip="Save the list of changes before restoring — Restore overwrites it."/>
                 <Button Content="Restore changed" Command="{Binding RestoreSelectedCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="6,0,0,0"
                         AutomationProperties.Name="Restore changed settings to baseline"/>


### PR DESCRIPTION
Closes #1611. `feat:` → v1.90.0.

### Premise re-measured first

The issue is from an older audit, so I re-derived its counts before trusting them. Unchanged — occurrences of `Export|CopyPath|Clipboard|SaveFileDialog` per view-model:

```
6  ResourceHistoryViewModel        0  ProcessManagerViewModel     0  FileLockViewModel
2  DuplicateFileViewModel          0  PrivacyMonitorViewModel     0  DiskAnalyzerViewModel
                                   0  SettingsWatchdogViewModel   0  BandwidthMonitorViewModel
                                   0  AppAlertsViewModel          0  ShortcutCleanerViewModel
```

Scoped to the three the issue names as highest value, for the reasons it gives: Camera/Mic/Location produces evidence about which app used the camera, Settings Watchdog produces the before-picture Restore is about to erase, and Disk Analyzer produces a breakdown that costs minutes to recompute.

### Following the existing idiom

Each command copies `ResourceHistoryViewModel`'s shape rather than inventing one — `[RelayCommand(CanExecute = …)]`, `SaveFileDialog`, `File.WriteAllTextAsync` with a BOM-less `UTF8Encoding`, the same `IOException`/`UnauthorizedAccessException` pair, the same toast — with the row formatting in a pure static `ToCsv` next to the service so it is testable without a window.

**One genuine departure.** `ResourceHistoryService.ToCsv` writes its fields raw, which is safe there because every one is a number or a fixed-format timestamp. These three carry app names, setting descriptions and folder paths, and `C:\Users\me\Music\Grieg, Peer Gynt` is an ordinary folder name that silently becomes two columns — with every value after it shifting left, which a spreadsheet reads without complaining. So `Helpers/Csv` holds RFC 4180 escaping once: quote only when the field contains a comma, quote, CR or LF; double an embedded quote; CRLF row terminator because this is a file format rather than console output. Nothing is trimmed or substituted, because a lossy export of a path is worse than a quoted one.

I left `ResourceHistoryService.ToCsv` alone. Routing it through the shared escaper would be a no-op on numeric fields, so it is churn in a `feat:` PR rather than a fix.

**Settings Watchdog's button sits to the LEFT of Restore**, deliberately and with a comment saying so. Restore overwrites the "now" column, so the file is the only record of what Windows changed, and the left-to-right order is the order to use them in.

### The guard is not the one I expected

I assumed `EveryViewModelCommand_IsReachableFromTheUi` already covered this and set out to prove it. It does not:

```
baseline: GREEN
mutation: PrivacyMonitorView loses its Export button   -> GREEN   <-- NOT CAUGHT
mutation: SettingsWatchdogView loses its Export button -> GREEN   <-- NOT CAUGHT
mutation: DiskAnalyzerView loses its Export button     -> GREEN   <-- NOT CAUGHT
0 of 3 mutations were caught
```

That guard tests a command **name** against every `.xaml` concatenated, so once `ResourceHistoryView.xaml` binds `ExportCsvCommand` the name is present in the corpus and every other view-model's identically-named command reads as reachable. It is the same collision the Startup field guard already documents for `Location`, met from a new direction — and it would have let three buttons ship missing while every test passed, since the formatters are unit-tested through their pure `ToCsv`.

So `EveryExportCommand_IsBoundInItsOwnView` requires the binding in the tab's **own** view, derived by reflection rather than from a table so a fifth export is covered the moment it compiles. Re-run against it:

```
baseline: GREEN
mutation: PrivacyMonitorView   -> RED  "PrivacyMonitorViewModel.ExportCsvCommand is not bound in PrivacyMonitorView.xaml"
mutation: SettingsWatchdogView -> RED  "SettingsWatchdogViewModel.ExportCsvCommand is not bound in SettingsWatchdogView.xaml"
mutation: DiskAnalyzerView     -> RED  "DiskAnalyzerViewModel.ExportCsvCommand is not bound in DiskAnalyzerView.xaml"
3 of 3 mutations were caught
```

All three views restored byte-for-byte. Both directions are proven, which is what makes the new guard worth its lines rather than a duplicate of the old one.

### Verification

- App and unit projects — **0 errors, 0 warnings**
- Unit suite **5470 passed**, 0 failed (5446 + 23 formatter/escaping tests + the guard)
- `dotnet format --verify-no-changes` clean on both projects
- Leak scan of the staged diff against all 43 current patterns — 0 hits
- Author headers on both new files
- Docs in this same PR: README sections for all three tabs, ARCHITECTURE entry for `Helpers/Csv` explaining why it exists, CHANGELOG `[1.90.0]` with the plain-English opener CI requires, SECURITY supported versions → 1.90.x, csproj → 1.90.0

### Notes on scope

One PR rather than three, because the three tabs share the escaper and separate PRs would collide on `CHANGELOG.md` and the csproj version — a conflict pattern this repo has hit before. 224 of the 606 added lines are tests.

What the tests cannot cover: `SaveFileDialog.ShowDialog()` needs a window, so the commands themselves are covered by the binding guard rather than by execution. The privacy note from the issue holds — every export goes only where the dialog is pointed, never a default location.

### Deferred to the secondary workstation

Whether a fourth button crowds the Disk Analyzer toolbar, which already has five controls and a `ComboBox`. It is a `WrapPanel`, so it wraps rather than clipping, but whether it wraps at the default 820px height is a look-at-it question.
