### PR TITLE
docs: record what the winget publishing credential can and cannot reach

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -322,6 +322,24 @@ reviews, and who approves a release for signing.
 - All GitHub Actions used in the release pipeline are pinned to full commit
   SHAs, and release builds are deterministic
   (`ContinuousIntegrationBuild` + `Deterministic`).
+- **The winget publishing credential, and what it cannot reach.** Publishing to winget
+  means opening a pull request against `microsoft/winget-pkgs`, which no token belonging
+  to this repository can do — so the release workflow uses a separate maintainer-held
+  token (`WINGET_TOKEN`) whose only job is to sync a fork of that repository and open the
+  manifest pull request. It is the only credential in the whole pipeline that is not
+  either the ephemeral, repo-scoped `GITHUB_TOKEN` or the coverage upload token.
+  - **It acts only after the release already exists.** Every step that uses it runs after
+    `Create GitHub Release` has published the `.exe`, its SHA256 sum, the SBOM and the
+    build-provenance attestation. So it cannot alter, replace or re-hash the asset that
+    [Verifying a release](#verifying-a-release) describes, and it cannot influence what
+    the app's own update check validates — that check only ever reads the GitHub Releases
+    asset and its hash.
+  - **What it could affect** is the winget manifest: the URL and hash that a
+    `winget install laurentiu021.SysManager` reads. Microsoft's own review sits between
+    that pull request and users, but the manifest is the one place where the download
+    users receive is asserted outside this repository, which is why it is called out here
+    rather than left implicit. Verifying a download against the published SHA256 and the
+    attestation is what makes that channel checkable independently of the token.
 
 ## Scope
 

--- a/SysManager/SysManager.Tests/SecurityPromiseTests.cs
+++ b/SysManager/SysManager.Tests/SecurityPromiseTests.cs
@@ -324,9 +324,77 @@ public class SecurityPromiseTests
         return StripComments(File.ReadAllText(path));
     }
 
+    // ── 8. The winget credential cannot reach the release asset ──
+
+    /// <summary>
+    /// Promise: the winget publishing token "acts only after the release already exists", so it cannot alter
+    /// the asset or hash that the verification instructions and the app's own update check rely on.
+    /// </summary>
+    /// <remarks>
+    /// <c>WINGET_TOKEN</c> is the only credential in the pipeline that is neither the ephemeral, repo-scoped
+    /// <c>GITHUB_TOKEN</c> nor the coverage token, and it necessarily carries write access to a fork of
+    /// <c>microsoft/winget-pkgs</c>. What bounds it is ORDERING, not scope: every step that uses it runs
+    /// after <c>Create GitHub Release</c> has published the exe, its SHA256, the SBOM and the attestation.
+    /// <para>That is a property of step order in one YAML file, which makes it exactly the kind of claim that
+    /// stops being true without anyone noticing — moving one step, or adding a new winget step earlier for a
+    /// pre-flight check, would falsify a published security statement while every test stayed green. Six
+    /// steps reference the token today (a fork sync, three publish attempts and two re-syncs between them),
+    /// so the count is also the floor: if the detection stops finding them, this fails rather than reporting
+    /// clean.</para>
+    /// <para>Deliberately NOT asserted here: that the token is fine-grained, scoped to the single fork, or
+    /// carries an expiry. None of that is visible from the repository — it lives in the maintainer's account
+    /// settings — and SECURITY.md does not claim it, because a security document should not state a posture
+    /// nobody can check from the outside.</para>
+    /// </remarks>
+    [Fact]
+    public void TheWingetToken_IsOnlyUsedAfterTheReleaseIsPublished()
+    {
+        var workflow = Path.Combine(RepoRoot(), ".github", "workflows", "release.yml");
+        Assert.True(File.Exists(workflow), $"release.yml not found at {workflow}");
+
+        var lines = File.ReadAllLines(workflow);
+        var publish = Array.FindIndex(lines, l => l.Contains("- name: Create GitHub Release", StringComparison.Ordinal));
+        Assert.True(publish >= 0,
+            "the 'Create GitHub Release' step was not found in release.yml, so this guard cannot tell what "
+            + "runs before the asset exists. If the step was renamed, re-point this rather than deleting it.");
+
+        var uses = lines
+            .Select((line, i) => (Line: line, Number: i + 1, Index: i))
+            .Where(l => l.Line.Contains("WINGET_TOKEN", StringComparison.Ordinal))
+            .ToList();
+
+        // Floor: six references when measured — one fork sync, three publish attempts, two re-syncs.
+        Assert.True(uses.Count >= 6,
+            $"only {uses.Count} WINGET_TOKEN references were found, out of 6 measured — the detection is out "
+            + "of date, so the ordering check below reads a short list.");
+
+        var early = uses
+            .Where(u => u.Index < publish)
+            .Select(u => $"line {u.Number}: {u.Line.Trim()}")
+            .ToList();
+
+        Assert.True(early.Count == 0,
+            $"the winget token is referenced before 'Create GitHub Release' (line {publish + 1}). "
+            + "SECURITY.md, \"Dependencies and supply chain\", states that it acts only after the release, "
+            + "its SHA256, the SBOM and the attestation are already published — which is what stops it from "
+            + "being able to alter the asset the verification instructions describe. Move the step after the "
+            + "release, or correct SECURITY.md:\n  " + string.Join("\n  ", early));
+    }
+
     private static string StripComments(string source)
         => Regex.Replace(Regex.Replace(source, @"/\*.*?\*/", "", RegexOptions.Singleline),
                          @"//.*?$", "", RegexOptions.Multiline);
+
+    // Walks up to the repository root — one level above the app project's solution folder.
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, ".github", "workflows")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);   // else the assertions above would silently test nothing
+        return dir!.FullName;
+    }
 
     // Walks up to the app project — source is not copied to the test output.
     private static string AppProjectDir()


### PR DESCRIPTION
Addresses #1676 — the documentation half. `docs:` — no release. The token-scope audit needs the account owner and stays on the issue.

### Premise re-derived, and two corrections

`WINGET_TOKEN` is still the only secret in the pipeline that is neither the ephemeral repo-scoped `GITHUB_TOKEN` nor the coverage token:

```
auto-release.yml:37,169   GITHUB_TOKEN
ci.yml:355,415            CODECOV_TOKEN
release.yml:562,606,613,629,636,652   WINGET_TOKEN
```

Two things had drifted since the issue was written:

- **The supply-chain section *does* now document a privileged token** — but that is the *attestation* token ("scoped to the build job alone; the workflow's default permission is read-only"), not this one. So the gap the issue names is real, and it would have been easy to read that bullet and think it was already covered.
- **Six references, not one.** The issue cites a single `release.yml:186`. There are six: a fork sync, three publish attempts, and two re-syncs between them — the retry chain that exists because the fork drifts behind upstream.

### What the bullet says, and what it deliberately does not

The substantive finding is that what bounds this credential is **ordering, not scope**. Every step that uses it runs after `Create GitHub Release` (line 532) has published the exe, its SHA256, the SBOM and the attestation. So it cannot alter, replace or re-hash the asset the verification instructions describe, and it cannot influence what the app's own update check validates — that check only ever reads the Releases asset and its hash.

What it *could* affect is the winget manifest: the URL and hash a `winget install laurentiu021.SysManager` reads. Microsoft's review sits between that PR and users, but the manifest is the one place where the download users receive is asserted outside this repository, so it is now stated plainly rather than left implicit.

**Not documented, on purpose:** that the token is fine-grained, limited to the single fork, or carries an expiry. The issue proposes writing exactly that, with the caveat "verify the live token actually matches that description before documenting it" — and I cannot. That lives in the account settings, and no API introspects another PAT's scope. Publishing an unverifiable posture in a security document is worse than publishing nothing, so the bullet describes only what a reader can check from the repository.

### Guard

`TheWingetToken_IsOnlyUsedAfterTheReleaseIsPublished`, joining the seven existing `SECURITY.md` promise guards. A claim about step order in one YAML file is exactly the kind that stops being true without anyone noticing — a winget pre-flight step added earlier would falsify a published security statement while every test stayed green.

```
baseline: GREEN
mutation 1 token used before the release -> RED  "…referenced before 'Create GitHub Release' (line 534) …
                                                  line 42: GH_TOKEN: ${{ secrets.WINGET_TOKEN }}"
mutation 2 anchor step renamed           -> RED  "the 'Create GitHub Release' step was not found …"
2 of 2 mutations failed for the expected reason
```

`release.yml` restored byte-for-byte. Mutation 2 matters as much as mutation 1: without it the guard could pass over an anchor it failed to find, which is how a source-slicing check goes quietly vacuous. Floor of six token references for the same reason.

### Verification

- Unit suite **5471 passed**, 0 failed
- 0 errors, 0 warnings; `dotnet format --verify-no-changes` clean
- Leak scan of the staged diff against all 43 current patterns — 0 hits
- The internal link `#verifying-a-release` resolves to `## Verifying a release` (line 259), matching the existing usage

### What stays open on #1676

Auditing the live token: whether it is a fine-grained PAT limited to the one fork with contents-write, or a classic full-`repo` token, and whether it has an expiry. If it turns out to be classic and full-scope, narrowing it is a small change with real risk reduction — but the issue's own risk note is right that it should be validated with a manual `workflow_dispatch` rather than discovered during an automated release.
