### PR TITLE
feat: finish Export CSV across the remaining list tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.91.0] - 2026-09-11
+
+**Every tab whose output is a list can now save it to a file.** Five more got an **Export CSV** button —
+Process Manager, New App Alerts, File Lock Detector, Bandwidth Monitor and Shortcut Cleaner — which
+finishes what the last release started. Nine tabs in total now export. On the two tabs where a button
+destroys the list you would want to keep (Clear History, and deleting shortcuts), Export sits to the left
+of it, so reading order matches the order to use them in.
+
+### Added
+
+- **Export CSV on the Process Manager**, saving the list *as currently filtered* rather than all of it —
+  if you have typed a filter to isolate a suspect, that is the list you want.
+- **Export CSV on New App Alerts**, File Lock Detector, Bandwidth Monitor and Shortcut Cleaner.
+- Each export carries the raw values beside the readable ones — byte counts next to "50.0 MB", real
+  timestamps next to "2 days ago" — because a spreadsheet sorts text, and "9.8 GB" sorts below "10 MB".
+- The File Lock export keeps the flag that marks a process Windows will not let you safely end, so the
+  one row nobody should act on stays marked in a file someone else may read.
+
 ## [1.90.0] - 2026-09-11
 
 **Three more tabs can now save what they found to a file.** Camera/Mic/Location, Settings Watchdog and

--- a/README.md
+++ b/README.md
@@ -570,6 +570,9 @@ a confirmation before it runs:
 - Lists running Windows processes with PID, memory, threads, status, and when each one started
 - Real-time filter by name, description, category, or PID
 - Sort by memory, CPU usage, name, category, PID, or start time via clickable column headers
+- **Export CSV** saves the list **as currently filtered** to a file you choose the location for —
+  someone who has typed a filter to isolate a suspect gets that list, not all ~470 rows. Both the
+  readable and the raw values are included, so a spreadsheet can sort by size and by start time
 - **Started column** — when each process began. "Something is eating my CPU" is usually
   answered by *when it appeared*: a process that started three minutes ago is a very
   different suspect from one that has been running since you turned the PC on, and sorting
@@ -644,6 +647,9 @@ a confirmation before it runs:
   mode; it uses a Windows kernel trace and so **needs administrator**. The tab
   offers it only when you're already running as administrator and falls back to the
   no-admin view automatically if the trace can't start — it never breaks the tab
+- **Export CSV** saves the per-app list to a file you choose the location for, with the raw
+  bytes-per-second and byte totals beside the readable figures — a file whose only numbers are
+  "1.2 MB/s" cannot be sorted or added up
 - **Threshold alert** — set a Mbps limit and the tab warns you when total download
   or upload goes over it (handy for catching a runaway background upload); set it to
   0 to turn the alert off
@@ -660,6 +666,8 @@ a confirmation before it runs:
   browse to a file/folder path and see which process(es) are using it, via the
   Windows Restart Manager (the same mechanism Explorer's own dialog uses)
 - Shows process name, PID, type, and start time for each locker
+- **Export CSV** saves the list to a file you choose the location for, including the flag that
+  marks a process Windows will not let you safely end — the one row nobody should act on
 - **End process** — terminate a selected locker (with confirmation) to release
   the file; critical system processes are protected from termination
 - Detection works as a standard user; ending a process owned by SYSTEM or
@@ -717,6 +725,8 @@ a confirmation before it runs:
 - Scans Desktop, Start Menu, Quick Launch, and Recent Items for broken .lnk
   shortcuts whose targets no longer exist
 - Lists results with name, location, and missing target path
+- **Export CSV** saves the list before you delete anything, naming both the shortcut and its
+  missing target, so the change is reviewable rather than a batch of deletions nobody can audit
 - Select all / deselect individual items
 - Move to Recycle Bin or permanent delete, with confirmation dialog
 - COM-based IShellLink resolution for accurate target validation
@@ -868,6 +878,8 @@ a confirmation before it runs:
 - FileSystemWatcher on install directories + 30-second registry poll cycle
 - Shows timestamped install history with app name, publisher, path, and
   detection source
+- **Export CSV** saves the history to a file you choose the location for. Worth doing before
+  **Clear History**, which erases it — the button sits to the left of it for that reason
 - Start/stop monitoring, acknowledge alerts, show all currently installed
   apps, clear history
 - Notifies you when a new install is detected, so you find out even when you are

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.90.x   | :white_check_mark: |
-| < 1.90   | :x:                |
+| 1.91.x   | :white_check_mark: |
+| < 1.91   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -459,11 +459,13 @@ public partial class ArchitectureTests
                 offenders.Add($"{type.Name}.ExportCsvCommand is not bound in {Path.GetFileName(view)}");
         }
 
-        // Vacuity floor: four tabs export CSV when measured — Resource History, Camera/Mic/Location,
-        // Settings Watchdog, Disk Analyzer. A collapse means the reflection stopped finding them and every
-        // absence below is an absence of looking.
-        Assert.True(checked_ >= 4,
-            $"only {checked_} view-models with an ExportCsvCommand were found, out of 4 measured — the "
+        // Vacuity floor: NINE tabs export CSV when measured — Resource History, Camera/Mic/Location,
+        // Settings Watchdog, Disk Analyzer, Process Manager, App Alerts, File Lock Detector, Bandwidth
+        // Monitor, Shortcut Cleaner. A collapse means the reflection stopped finding them and every absence
+        // below is an absence of looking. The floor tracks the population deliberately: left at the original
+        // four it would have let five exports disappear while still reporting that it had checked something.
+        Assert.True(checked_ >= 9,
+            $"only {checked_} view-models with an ExportCsvCommand were found, out of 9 measured — the "
             + "reflection is out of date, so a pass proves nothing.");
 
         Assert.True(offenders.Count == 0,

--- a/SysManager/SysManager.Tests/CsvExportTests.cs
+++ b/SysManager/SysManager.Tests/CsvExportTests.cs
@@ -211,6 +211,137 @@ public class CsvExportTests
         Assert.Equal("Name,Full path,Size,Size (bytes),Share %,Files,Folders,Access denied\r\n", csv);
     }
 
+    // ── The five that followed: Process Manager, App Alerts, File Lock, Shortcut Cleaner, Bandwidth ──
+
+    /// <summary>
+    /// Raw start time beside the display string, and an em dash rather than year one when Windows would not
+    /// say — the same reason the column itself needs it (#2224).
+    /// </summary>
+    [Fact]
+    public void ProcessToCsv_CarriesRawValuesBesideTheDisplayedOnes()
+    {
+        var csv = ProcessManagerService.ToCsv([
+            new ProcessEntry
+            {
+                Pid = 4242, Name = "target.exe", PlainDescription = "A test process",
+                // 3.7, not a .x5 value: "F1" rounds midpoints to even, so 3.25 formats as 3.2 and a test
+                // asserting 3.3 fails on the formatter being right.
+                MemoryBytes = 52_428_800, CpuPercent = 3.7, ThreadCount = 7, Status = "Running",
+                StartTime = new DateTime(2026, 3, 9, 14, 5, 7), Category = "System",
+                SafetyLevel = "Known app", FilePath = @"C:\Program Files\Test\target.exe",
+            }]);
+
+        var lines = csv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+        Assert.StartsWith("PID,Name,Description,Memory,Memory (bytes),CPU %,Threads,Status,Started,", lines[0],
+            StringComparison.Ordinal);
+        Assert.Contains("50.0 MB,52428800,3.7,7,Running,2026-03-09 14:05:07,2026-03-09 14:05:07,", lines[1],
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProcessToCsv_WhenWindowsWithheldTheStartTime_LeavesTheRawColumnEmpty()
+    {
+        var csv = ProcessManagerService.ToCsv([new ProcessEntry { Pid = 4, Name = "System" }]);
+
+        // Display column is the em dash; the raw column is empty rather than 0001-01-01.
+        Assert.Contains(",—,,", csv, StringComparison.Ordinal);
+        Assert.DoesNotContain("0001", csv, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An unchecked signature must export as blank, not as the enum's name. <c>Unknown</c> means "not
+    /// checked", and writing that word into a file reads as a verdict the app never reached.
+    /// </summary>
+    [Fact]
+    public void ProcessToCsv_LeavesTheSignatureBlankWhenNothingWasChecked()
+    {
+        // Asserted on the signature COLUMN, not on the whole row: Category and SafetyLevel both default to
+        // the literal "Unknown" and are legitimately exported that way, so a row-wide DoesNotContain would
+        // fail on two columns that are correct.
+        const int signature = 12;   // PID,Name,Description,Memory,Memory(bytes),CPU,Threads,Status,Started,
+                                    // Started(raw),Category,Safety,Signature,Path
+        var row = ProcessManagerService.ToCsv([new ProcessEntry { Pid = 4, Name = "System" }])
+            .Split("\r\n")[1].Split(',');
+        Assert.Equal("", row[signature]);
+
+        var verified = ProcessManagerService.ToCsv([
+            new ProcessEntry { Pid = 9, Name = "signed.exe", Signature = SignatureTrust.Verified,
+                               SignatureDetail = "Windows can confirm this comes from Contoso Ltd" }])
+            .Split("\r\n")[1].Split(',');
+        Assert.Equal("Verified", verified[signature]);
+    }
+
+    [Fact]
+    public void AlertsToCsv_WritesTheHeaderAndTheAcknowledgedFlag()
+    {
+        var csv = AppAlertService.ToCsv([
+            new AppInstallEntry { Name = "Contoso Toolbar", Publisher = "Contoso, Inc.",
+                                  DetectedAt = new DateTime(2026, 3, 9, 14, 5, 7), Source = "Registry",
+                                  InstallPath = @"C:\Program Files\Contoso", IsAcknowledged = true }]);
+
+        var lines = csv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("App,Publisher,Detected,Source,Install path,Acknowledged", lines[0]);
+        // The publisher's comma must not split the row.
+        Assert.Equal(@"Contoso Toolbar,""Contoso, Inc."",2026-03-09 14:05:07,Registry,C:\Program Files\Contoso,yes",
+            lines[1]);
+    }
+
+    /// <summary>
+    /// The critical flag gets its own column because it is the one row nobody should be told to end, and that
+    /// warning has to survive into a file someone else may act on.
+    /// </summary>
+    [Fact]
+    public void LockersToCsv_MarksACriticalProcessInItsOwnColumn()
+    {
+        var csv = FileLockService.ToCsv([
+            new FileLocker(4, "System", "RmCritical", null),
+            new FileLocker(4242, "notepad.exe", "RmMainWindow", new DateTime(2026, 3, 9, 14, 5, 7)),
+        ]);
+
+        var lines = csv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("PID,Process,Type,Started,Started (raw),Critical", lines[0]);
+        Assert.EndsWith(",yes", lines[1], StringComparison.Ordinal);
+        Assert.EndsWith(",no", lines[2], StringComparison.Ordinal);
+        // No start time available: em dash in the display column, empty in the raw one.
+        Assert.Equal("4,System,RmCritical,—,,yes", lines[1]);
+    }
+
+    /// <summary>Both paths, because one names what would be deleted and the other is the evidence why.</summary>
+    [Fact]
+    public void ShortcutsToCsv_CarriesBothTheShortcutAndItsMissingTarget()
+    {
+        var csv = ShortcutCleanerService.ToCsv([
+            new BrokenShortcut { Name = "Old Game", Location = "Desktop",
+                                 ShortcutPath = @"C:\Users\me\Desktop\Old Game.lnk",
+                                 TargetPath = @"D:\Games\Old, Game\game.exe", IsSelected = true }]);
+
+        var lines = csv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("Name,Location,Shortcut path,Missing target,Selected", lines[0]);
+        Assert.Contains(@"C:\Users\me\Desktop\Old Game.lnk", lines[1], StringComparison.Ordinal);
+        Assert.Contains(@"""D:\Games\Old, Game\game.exe""", lines[1], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BandwidthToCsv_CarriesRatesAndTotalsWithRawNumbers()
+    {
+        var csv = BandwidthHistoryService.ToCsv([
+            new ProcessNetworkUsage
+            {
+                ProcessId = 4242, ProcessName = "browser.exe", ConnectionCount = 12,
+                DownBytesPerSec = 1_048_576, UpBytesPerSec = 131_072,
+                TotalDownBytes = 52_428_800, TotalUpBytes = 1_048_576,
+                RemoteSummary = "contoso.example, 3 more",
+            }]);
+
+        var lines = csv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("PID,Process,Connections,Down,Down (bytes/s),Up,Up (bytes/s),Total,Total (bytes),Remote",
+            lines[0]);
+        Assert.Contains(",1048576,", lines[1], StringComparison.Ordinal);
+        // Total bytes is the sum of both directions, and the remote summary's comma stays quoted.
+        Assert.Contains(",53477376,", lines[1], StringComparison.Ordinal);
+        Assert.EndsWith("\"contoso.example, 3 more\"", lines[1], StringComparison.Ordinal);
+    }
+
     // ── Every formatter refuses null rather than throwing something unhelpful deep inside ──
 
     [Fact]
@@ -219,6 +350,43 @@ public class CsvExportTests
         Assert.Throws<ArgumentNullException>(() => PrivacyMonitorService.ToCsv(null!));
         Assert.Throws<ArgumentNullException>(() => SettingsWatchdogService.ToCsv(null!));
         Assert.Throws<ArgumentNullException>(() => DiskAnalyzerService.ToCsv(null!));
+        Assert.Throws<ArgumentNullException>(() => ProcessManagerService.ToCsv(null!));
+        Assert.Throws<ArgumentNullException>(() => AppAlertService.ToCsv(null!));
+        Assert.Throws<ArgumentNullException>(() => FileLockService.ToCsv(null!));
+        Assert.Throws<ArgumentNullException>(() => ShortcutCleanerService.ToCsv(null!));
+        Assert.Throws<ArgumentNullException>(() => BandwidthHistoryService.ToCsv(null!));
         Assert.Throws<ArgumentNullException>(() => Csv.AppendRow(null!, "a"));
+    }
+
+    /// <summary>
+    /// Every export starts with a header row, so a file opened months later says what its columns are.
+    /// </summary>
+    /// <remarks>
+    /// Written as one test over all eight rather than eight assertions, because the thing being pinned is the
+    /// convention, and a ninth export added without a header should fail this rather than pass unnoticed.
+    /// </remarks>
+    [Fact]
+    public void EveryExport_StartsWithAHeaderRow()
+    {
+        var empty = new (string Name, string Csv)[]
+        {
+            ("Privacy", PrivacyMonitorService.ToCsv([])),
+            ("SettingsDrift", SettingsWatchdogService.ToCsv([])),
+            ("DiskUsage", DiskAnalyzerService.ToCsv([])),
+            ("Processes", ProcessManagerService.ToCsv([])),
+            ("AppAlerts", AppAlertService.ToCsv([])),
+            ("FileLocks", FileLockService.ToCsv([])),
+            ("BrokenShortcuts", ShortcutCleanerService.ToCsv([])),
+            ("Bandwidth", BandwidthHistoryService.ToCsv([])),
+        };
+
+        foreach (var (name, csv) in empty)
+        {
+            Assert.EndsWith("\r\n", csv, StringComparison.Ordinal);
+            var header = csv.Split("\r\n")[0];
+            Assert.False(string.IsNullOrWhiteSpace(header), $"{name} exported an empty header row");
+            Assert.Contains(',', header);   // a single-column export would be a formatting mistake
+            Assert.Single(csv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries));
+        }
     }
 }

--- a/SysManager/SysManager/Services/AppAlertService.cs
+++ b/SysManager/SysManager/Services/AppAlertService.cs
@@ -2,13 +2,13 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using SysManager.Helpers;
-using System.Text;
-using System.Globalization;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.IO;
+using System.Text;
 using Microsoft.Win32;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;

--- a/SysManager/SysManager/Services/AppAlertService.cs
+++ b/SysManager/SysManager/Services/AppAlertService.cs
@@ -2,6 +2,9 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
+using System.Text;
+using System.Globalization;
 using System.Collections.Concurrent;
 using System.IO;
 using Microsoft.Win32;
@@ -244,5 +247,32 @@ public sealed class AppAlertService : IDisposable
         if (_disposed) return;
         _disposed = true;
         Stop();
+    }
+
+    /// <summary>Renders the newly-installed-app alerts as CSV with a header row.</summary>
+    /// <remarks>
+    /// The install path is included because it is the column that answers "is this the real thing", and the
+    /// acknowledged flag because an exported list is usually being sent to someone who needs to know which
+    /// entries the user has already looked at.
+    /// </remarks>
+    public static string ToCsv(IEnumerable<AppInstallEntry> alerts)
+    {
+        ArgumentNullException.ThrowIfNull(alerts);
+
+        var sb = new StringBuilder();
+        Csv.AppendRow(sb, "App", "Publisher", "Detected", "Source", "Install path", "Acknowledged");
+        foreach (var a in alerts)
+        {
+            Csv.AppendRow(sb,
+                a.Name,
+                a.Publisher,
+                a.DetectedAt == default
+                    ? null
+                    : a.DetectedAt.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+                a.Source,
+                a.InstallPath,
+                a.IsAcknowledged ? "yes" : "no");
+        }
+        return sb.ToString();
     }
 }

--- a/SysManager/SysManager/Services/BandwidthHistoryService.cs
+++ b/SysManager/SysManager/Services/BandwidthHistoryService.cs
@@ -2,9 +2,9 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Text;
 using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Text.Json;
 using Serilog;
 using SysManager.Helpers;

--- a/SysManager/SysManager/Services/BandwidthHistoryService.cs
+++ b/SysManager/SysManager/Services/BandwidthHistoryService.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Text;
+using System.Globalization;
 using System.IO;
 using System.Text.Json;
 using Serilog;
@@ -176,5 +178,35 @@ public sealed class BandwidthHistoryService
             result.Add(new BandwidthSample(mid, down / n, up / n));
         }
         return result;
+    }
+
+    /// <summary>Renders per-app network usage as CSV with a header row.</summary>
+    /// <remarks>
+    /// Rates are a snapshot and totals are cumulative, so both are exported with the raw numbers beside the
+    /// formatted ones. The remote summary is included because "which app is using the network" is usually
+    /// followed by "talking to what", and that column is the only place the tab answers it.
+    /// </remarks>
+    public static string ToCsv(IEnumerable<ProcessNetworkUsage> usage)
+    {
+        ArgumentNullException.ThrowIfNull(usage);
+
+        var sb = new StringBuilder();
+        Csv.AppendRow(sb, "PID", "Process", "Connections", "Down", "Down (bytes/s)", "Up", "Up (bytes/s)",
+            "Total", "Total (bytes)", "Remote");
+        foreach (var u in usage)
+        {
+            Csv.AppendRow(sb,
+                u.ProcessId.ToString(CultureInfo.InvariantCulture),
+                u.ProcessName,
+                u.ConnectionCount.ToString(CultureInfo.InvariantCulture),
+                u.DownDisplay,
+                u.DownBytesPerSec.ToString("F0", CultureInfo.InvariantCulture),
+                u.UpDisplay,
+                u.UpBytesPerSec.ToString("F0", CultureInfo.InvariantCulture),
+                u.TotalDisplay,
+                (u.TotalDownBytes + u.TotalUpBytes).ToString(CultureInfo.InvariantCulture),
+                u.RemoteSummary);
+        }
+        return sb.ToString();
     }
 }

--- a/SysManager/SysManager/Services/FileLockService.cs
+++ b/SysManager/SysManager/Services/FileLockService.cs
@@ -2,13 +2,13 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using SysManager.Helpers;
-using System.Globalization;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 

--- a/SysManager/SysManager/Services/FileLockService.cs
+++ b/SysManager/SysManager/Services/FileLockService.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
+using System.Globalization;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -203,5 +205,30 @@ public sealed class FileLockService : IFileLockService
 
         [DllImport("rstrtmgr.dll")]
         public static extern int RmEndSession(uint pSessionHandle);
+    }
+
+    /// <summary>Renders the locking-process list as CSV with a header row.</summary>
+    /// <remarks>
+    /// <c>IsCritical</c> is exported as its own column rather than left inside <c>AppType</c>: a process the
+    /// Restart Manager flags as critical is the one the user must NOT be told to end, and that warning has to
+    /// survive into a file someone else may act on.
+    /// </remarks>
+    public static string ToCsv(IEnumerable<FileLocker> lockers)
+    {
+        ArgumentNullException.ThrowIfNull(lockers);
+
+        var sb = new StringBuilder();
+        Csv.AppendRow(sb, "PID", "Process", "Type", "Started", "Started (raw)", "Critical");
+        foreach (var l in lockers)
+        {
+            Csv.AppendRow(sb,
+                l.ProcessId.ToString(CultureInfo.InvariantCulture),
+                l.ProcessName,
+                l.AppType,
+                l.StartTimeDisplay,
+                l.StartTime?.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+                l.IsCritical ? "yes" : "no");
+        }
+        return sb.ToString();
     }
 }

--- a/SysManager/SysManager/Services/ProcessManagerService.cs
+++ b/SysManager/SysManager/Services/ProcessManagerService.cs
@@ -2,6 +2,8 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using System.Text;
+using System.Globalization;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -301,5 +303,42 @@ public sealed partial class ProcessManagerService
         }
         catch (InvalidOperationException ex) { Log.Warning(ex, "Failed to open file location: {Path}", filePath); }
         catch (System.ComponentModel.Win32Exception ex) { Log.Warning(ex, "Failed to open file location: {Path}", filePath); }
+    }
+
+    /// <summary>Renders a process list as CSV with a header row.</summary>
+    /// <remarks>
+    /// Both the raw byte count and the formatted size are exported, and the raw start time alongside its
+    /// display string, because a spreadsheet sorts text: "9.8 GB" lands below "10 MB" and an em dash sorts
+    /// against real dates. The display columns are what the user recognises from the tab; the raw ones are
+    /// what makes the file answer questions the screen already answered.
+    /// </remarks>
+    public static string ToCsv(IEnumerable<ProcessEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        var sb = new StringBuilder();
+        Csv.AppendRow(sb, "PID", "Name", "Description", "Memory", "Memory (bytes)", "CPU %", "Threads",
+            "Status", "Started", "Started (raw)", "Category", "Safety", "Signature", "Path");
+        foreach (var e in entries)
+        {
+            Csv.AppendRow(sb,
+                e.Pid.ToString(CultureInfo.InvariantCulture),
+                e.Name,
+                e.PlainDescription.Length > 0 ? e.PlainDescription : e.Description,
+                e.MemoryDisplay,
+                e.MemoryBytes.ToString(CultureInfo.InvariantCulture),
+                e.CpuPercent.ToString("F1", CultureInfo.InvariantCulture),
+                e.ThreadCount.ToString(CultureInfo.InvariantCulture),
+                e.Status,
+                e.StartTimeDisplay,
+                e.StartTime == default
+                    ? null
+                    : e.StartTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+                e.Category,
+                e.SafetyLevel,
+                e.SignatureDetail.Length > 0 ? e.Signature.ToString() : "",
+                e.FilePath);
+        }
+        return sb.ToString();
     }
 }

--- a/SysManager/SysManager/Services/ProcessManagerService.cs
+++ b/SysManager/SysManager/Services/ProcessManagerService.cs
@@ -2,11 +2,11 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Text;
-using System.Globalization;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using Serilog;
 using SysManager.Helpers;
 using SysManager.Models;

--- a/SysManager/SysManager/Services/ShortcutCleanerService.cs
+++ b/SysManager/SysManager/Services/ShortcutCleanerService.cs
@@ -2,13 +2,13 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using SysManager.Helpers;
-using System.Text;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+using System.Text;
 using Serilog;
+using SysManager.Helpers;
 using SysManager.Models;
 
 namespace SysManager.Services;

--- a/SysManager/SysManager/Services/ShortcutCleanerService.cs
+++ b/SysManager/SysManager/Services/ShortcutCleanerService.cs
@@ -2,6 +2,9 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using SysManager.Helpers;
+using System.Text;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
@@ -269,5 +272,25 @@ public sealed partial class ShortcutCleanerService
         void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, uint dwReserved);
         void Resolve(IntPtr hwnd, uint fFlags);
         void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
+    }
+
+    /// <summary>Renders the broken-shortcut list as CSV with a header row.</summary>
+    /// <remarks>
+    /// Both paths matter and neither is optional: the shortcut path is what would be deleted, and the target
+    /// path is the evidence for why — a file that no longer exists. An export naming only one of them cannot
+    /// be checked by whoever reads it.
+    /// </remarks>
+    public static string ToCsv(IEnumerable<BrokenShortcut> shortcuts)
+    {
+        ArgumentNullException.ThrowIfNull(shortcuts);
+
+        var sb = new StringBuilder();
+        Csv.AppendRow(sb, "Name", "Location", "Shortcut path", "Missing target", "Selected");
+        foreach (var s in shortcuts)
+        {
+            Csv.AppendRow(sb, s.Name, s.Location, s.ShortcutPath, s.TargetPath,
+                s.IsSelected ? "yes" : "no");
+        }
+        return sb.ToString();
     }
 }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.90.0</Version>
-    <FileVersion>1.90.0.0</FileVersion>
-    <AssemblyVersion>1.90.0.0</AssemblyVersion>
+    <Version>1.91.0</Version>
+    <FileVersion>1.91.0.0</FileVersion>
+    <AssemblyVersion>1.91.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
@@ -2,14 +2,14 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using Microsoft.Win32;
-using System.Text;
-using System.IO;
 using System.Globalization;
+using System.IO;
+using System.Text;
 using System.Windows;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
 using Serilog;
 using SysManager.Helpers;
 using SysManager.Models;

--- a/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
+++ b/SysManager/SysManager/ViewModels/AppAlertsViewModel.cs
@@ -2,6 +2,10 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using Microsoft.Win32;
+using System.Text;
+using System.IO;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -162,6 +166,40 @@ public sealed partial class AppAlertsViewModel : ViewModelBase
             ToastService.Instance.Show("New app installed", entry.Name);
         });
     }
+
+    /// <summary>Whether there are alerts worth exporting.</summary>
+    public bool HasAlerts => AlertCount > 0;
+
+    /// <summary>
+    /// Writes the new-app alerts to a CSV the user picks a location for.
+    /// </summary>
+    /// <remarks>
+    /// The list exists to answer "what appeared on this PC without me installing it", which is exactly the question someone asks a more technical friend — so it needs to leave the screen.
+    /// <para>The file goes only where the dialog is pointed — nothing is written to a default location and
+    /// nothing leaves the machine.</para>
+    /// </remarks>
+    [RelayCommand(CanExecute = nameof(HasAlerts))]
+    private async Task ExportCsvAsync()
+    {
+        var dlg = new SaveFileDialog
+        {
+            FileName = $"SysManager-AppAlerts-{DateTime.Now.ToString("yyyy-MM-dd-HHmmss", CultureInfo.InvariantCulture)}.csv",
+            Filter = "CSV file (*.csv)|*.csv|All files (*.*)|*.*"
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        try
+        {
+            var csv = AppAlertService.ToCsv(Alerts);
+            await File.WriteAllTextAsync(dlg.FileName, csv, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            StatusMessage = $"Exported {Alerts.Count} alert(s) to {Path.GetFileName(dlg.FileName)}.";
+            ToastService.Instance.Show("App alerts exported", Path.GetFileName(dlg.FileName));
+        }
+        catch (IOException ex) { StatusMessage = $"Export failed: {ex.Message}"; }
+        catch (UnauthorizedAccessException ex) { StatusMessage = $"Export failed (access denied): {ex.Message}"; }
+    }
+
+    partial void OnAlertCountChanged(int value) => ExportCsvCommand.NotifyCanExecuteChanged();
 
     protected override void Dispose(bool disposing)
     {

--- a/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
@@ -2,17 +2,17 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using Microsoft.Win32;
-using System.Text;
-using System.IO;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.IO;
+using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using LiveChartsCore;
 using LiveChartsCore.Defaults;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Painting;
+using Microsoft.Win32;
 using Serilog;
 using SkiaSharp;
 using SysManager.Helpers;

--- a/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
+++ b/SysManager/SysManager/ViewModels/BandwidthMonitorViewModel.cs
@@ -2,6 +2,9 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using Microsoft.Win32;
+using System.Text;
+using System.IO;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -649,6 +652,37 @@ public sealed partial class BandwidthMonitorViewModel : ViewModelBase
         // here — but clear a stale alert when leaving so it doesn't linger on the hidden tab.
         if (!value) AlertMessage = "";
     }
+
+    /// <summary>
+    /// Writes per-app network usage to a CSV the user picks a location for.
+    /// </summary>
+    /// <remarks>
+    /// Rates are a snapshot of the moment the button was pressed and totals are cumulative for the session, so the export carries both with raw numbers beside the formatted ones — a file whose only figures are "1.2 MB/s" cannot be sorted or added up.
+    /// <para>The file goes only where the dialog is pointed — nothing is written to a default location and
+    /// nothing leaves the machine.</para>
+    /// </remarks>
+    [RelayCommand(CanExecute = nameof(HasProcesses))]
+    private async Task ExportCsvAsync()
+    {
+        var dlg = new SaveFileDialog
+        {
+            FileName = $"SysManager-Bandwidth-{DateTime.Now.ToString("yyyy-MM-dd-HHmmss", CultureInfo.InvariantCulture)}.csv",
+            Filter = "CSV file (*.csv)|*.csv|All files (*.*)|*.*"
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        try
+        {
+            var csv = BandwidthHistoryService.ToCsv(Processes);
+            await File.WriteAllTextAsync(dlg.FileName, csv, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            StatusMessage = $"Exported {Processes.Count} app(s) to {Path.GetFileName(dlg.FileName)}.";
+            ToastService.Instance.Show("Bandwidth usage exported", Path.GetFileName(dlg.FileName));
+        }
+        catch (IOException ex) { StatusMessage = $"Export failed: {ex.Message}"; }
+        catch (UnauthorizedAccessException ex) { StatusMessage = $"Export failed (access denied): {ex.Message}"; }
+    }
+
+    partial void OnHasProcessesChanged(bool value) => ExportCsvCommand.NotifyCanExecuteChanged();
 
     protected override void Dispose(bool disposing)
     {

--- a/SysManager/SysManager/ViewModels/FileLockViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileLockViewModel.cs
@@ -2,12 +2,12 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using Microsoft.Win32;
-using System.Text;
-using System.IO;
 using System.Globalization;
+using System.IO;
+using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
 using Serilog;
 using SysManager.Helpers;
 using SysManager.Models;

--- a/SysManager/SysManager/ViewModels/FileLockViewModel.cs
+++ b/SysManager/SysManager/ViewModels/FileLockViewModel.cs
@@ -2,6 +2,10 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using Microsoft.Win32;
+using System.Text;
+using System.IO;
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -29,6 +33,19 @@ public sealed partial class FileLockViewModel : ViewModelBase
     [ObservableProperty] private bool _isElevated;
     [ObservableProperty] private string _path = "";
     [ObservableProperty] private bool _hasScanned;
+
+    /// <summary>How many lockers the last scan found. Drives the export button's enabled state.</summary>
+    /// <remarks>
+    /// A count rather than a bool, and assigned where <c>Lockers</c> is replaced, because
+    /// <c>CanExecute</c> cannot observe a collection: <c>BulkObservableCollection</c> raises
+    /// <c>CollectionChanged</c>, which no generated command listens to. Deriving the button's state from a
+    /// property the scan already has to set keeps the two from disagreeing.
+    /// </remarks>
+    [ObservableProperty] private int _lockerCount;
+
+    /// <summary>Whether the last scan found anything worth exporting.</summary>
+    public bool HasLockers => LockerCount > 0;
+
     [ObservableProperty] private FileLocker? _selectedLocker;
 
     public FileLockViewModel(IFileLockService service)
@@ -85,6 +102,7 @@ public sealed partial class FileLockViewModel : ViewModelBase
             var lockers = await Task.Run(() => _service.FindLockers(target)).ConfigureAwait(true);
             Lockers.ReplaceWith(lockers);
             HasScanned = true;
+            LockerCount = lockers.Count;
             StatusMessage = lockers.Count == 0
                 ? "No process is currently using that path."
                 : $"{lockers.Count} process(es) are using that path.";
@@ -135,6 +153,40 @@ public sealed partial class FileLockViewModel : ViewModelBase
             StatusMessage = $"Couldn't end {locker.Display} — it may need administrator rights, or it already exited.";
         }
     }
+
+    /// <summary>
+    /// Writes the list of processes holding the scanned path to a CSV the user picks a location for.
+    /// </summary>
+    /// <remarks>
+    /// "What is using this file" is usually asked because something cannot be deleted or ejected, and the answer often has to be passed on — including the critical flag, which is the one row nobody should be told to end.
+    /// <para>The file goes only where the dialog is pointed — nothing is written to a default location and
+    /// nothing leaves the machine.</para>
+    /// </remarks>
+    [RelayCommand(CanExecute = nameof(HasLockers))]
+    private async Task ExportCsvAsync()
+    {
+        var dlg = new SaveFileDialog
+        {
+            FileName = $"SysManager-FileLocks-{DateTime.Now.ToString("yyyy-MM-dd-HHmmss", CultureInfo.InvariantCulture)}.csv",
+            Filter = "CSV file (*.csv)|*.csv|All files (*.*)|*.*"
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        try
+        {
+            var csv = FileLockService.ToCsv(Lockers);
+            await File.WriteAllTextAsync(dlg.FileName, csv, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            // System.IO.Path in full: this view-model has its own `Path` property — the file being
+            // scanned — which shadows the static class, so the unqualified call binds to a string.
+            var saved = System.IO.Path.GetFileName(dlg.FileName);
+            StatusMessage = $"Exported {Lockers.Count} process(es) to {saved}.";
+            ToastService.Instance.Show("Lock list exported", saved);
+        }
+        catch (IOException ex) { StatusMessage = $"Export failed: {ex.Message}"; }
+        catch (UnauthorizedAccessException ex) { StatusMessage = $"Export failed (access denied): {ex.Message}"; }
+    }
+
+    partial void OnLockerCountChanged(int value) => ExportCsvCommand.NotifyCanExecuteChanged();
 
     protected override void Dispose(bool disposing)
     {

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -2,6 +2,9 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using Microsoft.Win32;
+using System.Text;
+using System.Globalization;
 using System.Collections.ObjectModel;
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -491,6 +494,40 @@ public sealed partial class ProcessManagerViewModel : ViewModelBase
 
     private static bool MatchesPid(ProcessEntry p, string filter) =>
         p.Pid.ToString().Contains(filter);
+
+    /// <summary>Whether a snapshot has produced anything worth exporting.</summary>
+    public bool HasProcesses => ProcessCount > 0;
+
+    /// <summary>
+    /// Writes the process list, as filtered on screen to a CSV the user picks a location for.
+    /// </summary>
+    /// <remarks>
+    /// Exports FilteredProcesses rather than Processes, so the file matches what the user is looking at: someone who has typed a filter to isolate a suspect wants that list, not all ~470 rows.
+    /// <para>The file goes only where the dialog is pointed — nothing is written to a default location and
+    /// nothing leaves the machine.</para>
+    /// </remarks>
+    [RelayCommand(CanExecute = nameof(HasProcesses))]
+    private async Task ExportCsvAsync()
+    {
+        var dlg = new SaveFileDialog
+        {
+            FileName = $"SysManager-Processes-{DateTime.Now.ToString("yyyy-MM-dd-HHmmss", CultureInfo.InvariantCulture)}.csv",
+            Filter = "CSV file (*.csv)|*.csv|All files (*.*)|*.*"
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        try
+        {
+            var csv = ProcessManagerService.ToCsv(FilteredProcesses);
+            await File.WriteAllTextAsync(dlg.FileName, csv, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            StatusMessage = $"Exported {FilteredProcesses.Count} process(es) to {Path.GetFileName(dlg.FileName)}.";
+            ToastService.Instance.Show("Process list exported", Path.GetFileName(dlg.FileName));
+        }
+        catch (IOException ex) { StatusMessage = $"Export failed: {ex.Message}"; }
+        catch (UnauthorizedAccessException ex) { StatusMessage = $"Export failed (access denied): {ex.Message}"; }
+    }
+
+    partial void OnProcessCountChanged(int value) => ExportCsvCommand.NotifyCanExecuteChanged();
 
     protected override void Dispose(bool disposing)
     {

--- a/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ProcessManagerViewModel.cs
@@ -2,13 +2,13 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using Microsoft.Win32;
-using System.Text;
-using System.Globalization;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
+using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
 using Serilog;
 using SysManager.Helpers;
 using SysManager.Models;

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -2,13 +2,13 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using Microsoft.Win32;
-using System.Text;
-using System.IO;
 using System.Globalization;
+using System.IO;
+using System.Text;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
 using Serilog;
 using SysManager.Helpers;
 using SysManager.Models;

--- a/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/ShortcutCleanerViewModel.cs
@@ -2,6 +2,9 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
+using Microsoft.Win32;
+using System.Text;
+using System.IO;
 using System.Globalization;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -175,6 +178,40 @@ public sealed partial class ShortcutCleanerViewModel : ViewModelBase
         if (e.PropertyName == nameof(BrokenShortcut.IsSelected))
             SelectedCount = BrokenShortcuts.Count(x => x.IsSelected);
     }
+
+    /// <summary>Whether a scan found anything worth exporting.</summary>
+    public bool HasBrokenShortcuts => BrokenCount > 0;
+
+    /// <summary>
+    /// Writes the broken-shortcut list to a CSV the user picks a location for.
+    /// </summary>
+    /// <remarks>
+    /// This is a delete list, so being able to save it before acting is the difference between a reviewable change and a batch of deletions nobody can audit afterwards.
+    /// <para>The file goes only where the dialog is pointed — nothing is written to a default location and
+    /// nothing leaves the machine.</para>
+    /// </remarks>
+    [RelayCommand(CanExecute = nameof(HasBrokenShortcuts))]
+    private async Task ExportCsvAsync()
+    {
+        var dlg = new SaveFileDialog
+        {
+            FileName = $"SysManager-BrokenShortcuts-{DateTime.Now.ToString("yyyy-MM-dd-HHmmss", CultureInfo.InvariantCulture)}.csv",
+            Filter = "CSV file (*.csv)|*.csv|All files (*.*)|*.*"
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        try
+        {
+            var csv = ShortcutCleanerService.ToCsv(BrokenShortcuts);
+            await File.WriteAllTextAsync(dlg.FileName, csv, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            StatusMessage = $"Exported {BrokenShortcuts.Count} shortcut(s) to {Path.GetFileName(dlg.FileName)}.";
+            ToastService.Instance.Show("Broken shortcuts exported", Path.GetFileName(dlg.FileName));
+        }
+        catch (IOException ex) { StatusMessage = $"Export failed: {ex.Message}"; }
+        catch (UnauthorizedAccessException ex) { StatusMessage = $"Export failed (access denied): {ex.Message}"; }
+    }
+
+    partial void OnBrokenCountChanged(int value) => ExportCsvCommand.NotifyCanExecuteChanged();
 
     protected override void Dispose(bool disposing)
     {

--- a/SysManager/SysManager/Views/AppAlertsView.xaml
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml
@@ -40,6 +40,12 @@
                     <Button Content="Acknowledge All" Command="{Binding AcknowledgeAllCommand}"
                             AutomationProperties.Name="Acknowledge all alerts"
                             Style="{StaticResource SecondaryButton}" Padding="12,8" Margin="0,0,8,0"/>
+                    <!-- Before Clear History for the same reason Export sits left of Restore on the Settings
+                         Watchdog: clearing erases the list, so saving it has to come first in reading order. -->
+                    <Button Content="Export CSV" Command="{Binding ExportCsvCommand}"
+                            AutomationProperties.Name="Export CSV — the new-app alerts"
+                            Style="{StaticResource SecondaryButton}" Padding="12,8" Margin="0,0,8,0"
+                            ToolTip="Save this list before clearing it — Clear History erases it."/>
                     <Button Content="Clear History" Command="{Binding ClearHistoryCommand}"
                             AutomationProperties.Name="Clear History — app alerts"
                             Style="{StaticResource DangerButton}" Padding="12,8"/>

--- a/SysManager/SysManager/Views/BandwidthMonitorView.xaml
+++ b/SysManager/SysManager/Views/BandwidthMonitorView.xaml
@@ -79,6 +79,10 @@
                         <Button Content="Refresh" Command="{Binding ReloadHistoryCommand}"
                                 Style="{StaticResource GhostButton}" Margin="8,0,0,0"
                                 AutomationProperties.Name="Refresh throughput chart"/>
+                        <Button Content="Export CSV" Command="{Binding ExportCsvCommand}"
+                                Style="{StaticResource SecondaryButton}" Margin="8,0,0,0"
+                                AutomationProperties.Name="Export CSV — per-app network usage"
+                                ToolTip="Save the per-app usage list to a CSV file you choose the location for."/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Right">
                         <TextBlock Text="Alert over" Style="{StaticResource Subtle}" VerticalAlignment="Center"/>

--- a/SysManager/SysManager/Views/FileLockView.xaml
+++ b/SysManager/SysManager/Views/FileLockView.xaml
@@ -85,6 +85,7 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <DockPanel Grid.Column="0" VerticalAlignment="Center">
                 <ProgressBar AutomationProperties.Name="File lock scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
@@ -92,7 +93,14 @@
                              Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
                 <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" TextWrapping="Wrap"/>
             </DockPanel>
-            <Button Grid.Column="1" Content="End process" Command="{Binding KillSelectedCommand}"
+            <!-- Export before End process, so the destructive button stays rightmost where the eye expects
+                 it, and the safe one is not the thing a hurried click lands on. The path toolbar above is a
+                 fixed three-column Grid, which is why this sits with the results rather than beside Scan. -->
+            <Button Grid.Column="1" Content="Export CSV" Command="{Binding ExportCsvCommand}"
+                    Style="{StaticResource SecondaryButton}" Padding="14,8" Margin="0,0,8,0"
+                    AutomationProperties.Name="Export CSV — the locking processes"
+                    ToolTip="Save this list to a CSV file you choose the location for."/>
+            <Button Grid.Column="2" Content="End process" Command="{Binding KillSelectedCommand}"
                     Style="{StaticResource DangerButton}" Padding="14,8"
                     AutomationProperties.Name="End process — the selected process"/>
         </Grid>

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -38,6 +38,12 @@
                 <Button Content="Refresh" Command="{Binding RefreshCommand}"
                         Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
                         AutomationProperties.Name="Refresh process list"/>
+                <!-- Exports FilteredProcesses, not Processes: someone who has typed a filter to isolate a
+                     suspect wants that list, not all ~470 rows. -->
+                <Button Content="Export CSV" Command="{Binding ExportCsvCommand}"
+                        Style="{StaticResource SecondaryButton}" Margin="0,0,8,0"
+                        AutomationProperties.Name="Export CSV — the process list as filtered"
+                        ToolTip="Save the list as currently filtered to a CSV file you choose the location for."/>
                 <TextBlock Text="Search:" VerticalAlignment="Center" Margin="8,0,8,0"
                            Style="{StaticResource Subtle}"/>
                 <Grid Width="200" Margin="0,0,12,0">

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -54,7 +54,13 @@
                         Style="{StaticResource GhostButton}" Margin="0,0,4,0"/>
                 <Button Content="Deselect All" Command="{Binding DeselectAllCommand}"
                         AutomationProperties.Name="Deselect all shortcuts"
-                        Style="{StaticResource GhostButton}" Margin="0,0,16,0"/>
+                        Style="{StaticResource GhostButton}" Margin="0,0,8,0"/>
+                <!-- This is a delete list, so saving it before acting is the difference between a reviewable
+                     change and a batch of deletions nobody can audit afterwards. -->
+                <Button Content="Export CSV" Command="{Binding ExportCsvCommand}"
+                        AutomationProperties.Name="Export CSV — the broken shortcuts"
+                        Style="{StaticResource SecondaryButton}" Margin="0,0,16,0"
+                        ToolTip="Save this list before deleting — it names both the shortcut and its missing target."/>
                 <CheckBox Content="Move to Recycle Bin" IsChecked="{Binding MoveToRecycleBin}"
                           AutomationProperties.Name="Move to Recycle Bin — deleted shortcuts go there"
                           VerticalAlignment="Center" Foreground="{DynamicResource TextSecondary}"/>


### PR DESCRIPTION
Follow-up to #1611. `feat:` -> v1.91.0.

v1.90.0 covered the three tabs the issue named as highest value; this finishes the other five it listed, so all **nine** list-producing tabs export and none is the odd one out.

| tab | collection | notes |
|---|---|---|
| Process Manager | `FilteredProcesses` | exports **as filtered**, not all ~470 rows |
| New App Alerts | `Alerts` | Export sits left of Clear History |
| File Lock Detector | `Lockers` | keeps the critical flag as its own column |
| Bandwidth Monitor | `Processes` | raw bytes/s and byte totals beside the rates |
| Shortcut Cleaner | `BrokenShortcuts` | Export sits left of Delete Selected |

Generated from a table rather than hand-copied five times, so all five are byte-identical in shape to the three that shipped.

### Decisions worth stating

- **Raw values beside readable ones** everywhere, because a spreadsheet sorts text and `9.8 GB` lands below `10 MB`. The Process Manager raw start-time column is empty rather than `0001-01-01` when Windows withheld it, matching the Started column from #2224.
- **An unchecked signature exports blank, not `Unknown`.** Unknown means *not checked*; that word in a file reads as a verdict the app never reached.
- **Export sits LEFT of the button that destroys the list** on App Alerts and Shortcut Cleaner, same reasoning as the Settings Watchdog: reading order should match the order to use them in.
- **File Lock got its button in the results footer**, not the toolbar, because that toolbar is a fixed three-column Grid. It is left of *End process* so the destructive button stays rightmost.

### Two of my own tests failed first, both my fault

Worth recording because each is a trap rather than a typo:

- `Category` and `SafetyLevel` legitimately default to the literal `"Unknown"`, so a row-wide `DoesNotContain("Unknown")` fails on two columns that are correct. The assertion now scopes to the signature column by index.
- `"F1"` rounds midpoints to even, so `3.25` formats as `3.2`. Asserting `3.3` fails on the formatter being right. The fixture now uses `3.7`.

### The guard floor had to move

`EveryExportCommand_IsBoundInItsOwnView` had a vacuity floor of 4, measured when four tabs exported. With nine, that floor would have let **five exports disappear** while the guard still reported it had checked something. Raised to 9, with a comment saying the floor tracks the population rather than the population at the time it was written.

Mutation run extended from 3 views to 8:

```
baseline: GREEN
ProcessManagerView / AppAlertsView / FileLockView / BandwidthMonitorView /
ShortcutCleanerView / PrivacyMonitorView / SettingsWatchdogView / DiskAnalyzerView
  -> RED, each naming its own view-model and file
8 of 8 mutations were caught
```

All views restored byte-for-byte.

### Verification

- App and unit projects — **0 errors, 0 warnings**
- Unit suite **5479 passed**, 0 failed (5471 + 8 formatter tests)
- `dotnet format --verify-no-changes` clean on both projects
- Leak scan of the staged diff against all 43 current patterns — 0 hits
- Docs in this PR: README bullets for all five tabs, CHANGELOG `[1.91.0]`, SECURITY -> 1.91.x, csproj -> 1.91.0. ARCHITECTURE needs nothing: no new service or helper, `Helpers/Csv` is already documented.

### Deferred to the secondary workstation

Whether the Bandwidth Monitor and Shortcut Cleaner toolbars still read comfortably with one more button. Both are horizontal `StackPanel`s rather than `WrapPanel`s, so they clip rather than wrap if the window is narrow — that is a look-at-it question, and the same one already queued for the Disk Analyzer toolbar.