### PR TITLE
refactor: share the status footer the views had copied verbatim

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,10 +17,11 @@ SysManager/
 │   ├── Models/                 # POCOs (snapshots, samples, reports, cleanup categories)
 │   ├── Services/               # Windows / PowerShell / CLI wrappers
 │   ├── ViewModels/             # one VM per tab + MainWindowViewModel
-│   ├── Views/                  # XAML views + code-behind, plus three shared controls:
+│   ├── Views/                  # XAML views + code-behind, plus four shared controls:
 │   │                           #   AdminBanner (the elevation banner, 30 tabs)
 │   │                           #   EmptyState  (icon + title + message for an empty list)
 │   │                           #   DevelopmentBanner (the PREVIEW notice)
+│   │                           #   StatusFooter (progress bar + status line, 21 tabs)
 │   ├── Helpers/                # AdminHelper, converters, collections, parsers
 │   ├── Resources/              # icons and assets
 │   ├── App.xaml(.cs)

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -476,6 +476,103 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Every <c>StatusFooter</c> names its own progress bar, and no view re-inlines the block it replaced.
+    /// </summary>
+    /// <remarks>
+    /// The footer was copied verbatim into 21 views. Sharing it removes the duplication and creates two new
+    /// ways to get it wrong, both of which this pins.
+    /// <para><b>An unnamed progress bar.</b> Every view named its own — "Cleanup progress", "Uninstall
+    /// progress", "Startup item scan progress" — and the tempting version of this control had no dependency
+    /// property at all, which would have collapsed 21 distinct names into one shared "Progress". That is an
+    /// accessibility regression dressed up as deduplication, so <c>ProgressName</c> has no default and every
+    /// call site has to supply it. A default would have made the omission silent, which is precisely the
+    /// failure mode.</para>
+    /// <para><b>Re-inlining.</b> The copied block is five lines of unremarkable markup; the natural thing for
+    /// someone adding tab 60 is to copy it from the neighbour, which is how there came to be 21 of them. Once
+    /// the control exists, a fresh copy is a regression rather than a starting point — so the exact attribute
+    /// run is banned outside the control itself.</para>
+    /// <para>The 16 footers that carry extra content — a docked Cancel or Refresh button, an ETA line, a
+    /// trimmed path with a tooltip, a literal <c>IsIndeterminate="True"</c> — are deliberately NOT converted
+    /// and are deliberately NOT covered by the ban: they are not the shape this control replaces. The ban is
+    /// scoped to the plain form for that reason, and widening it would demand slots that make the control
+    /// more complicated than the duplication it removes (#1630).</para>
+    /// </remarks>
+    [Fact]
+    public void EveryStatusFooter_NamesItsProgressBar_AndNobodyReInlinesIt()
+    {
+        var viewsDir = Path.Combine(FindAppProjectDir(), "Views");
+        var control = Path.Combine(viewsDir, "StatusFooter.xaml");
+        Assert.True(File.Exists(control),
+            $"{control} not found — the shared footer is gone, so this guard would police nothing.");
+
+        var unnamed = new List<string>();
+        var reInlined = new List<string>();
+        var callSites = 0;
+
+        foreach (var file in Directory.GetFiles(viewsDir, "*.xaml"))
+        {
+            var markup = WithoutXamlComments(File.ReadAllText(file));
+            var view = Path.GetFileName(file);
+
+            foreach (var element in StatusFooterElement().Matches(markup).Cast<Match>())
+            {
+                callSites++;
+                if (!element.Value.Contains("ProgressName=\"", StringComparison.Ordinal))
+                    unnamed.Add($"{view}: {Collapse(element.Value)}");
+                else if (element.Value.Contains("ProgressName=\"\"", StringComparison.Ordinal))
+                    unnamed.Add($"{view}: ProgressName is empty");
+            }
+
+            // The control itself is the one place the markup is allowed to live.
+            if (view.Equals("StatusFooter.xaml", StringComparison.OrdinalIgnoreCase)) continue;
+            // Collapsed before matching: an exact string would carry this file's indentation and line
+            // endings, so a re-inlined copy wrapped differently would slip past a guard that looked strict.
+            if (InlinedPlainFooter().IsMatch(Collapse(markup)))
+                reInlined.Add(view);
+        }
+
+        // Re-inlining is asserted FIRST, before the call-site floor. Replacing a call site with an inlined
+        // copy lowers the count by one, so a floor checked first fires on "the element match is out of date"
+        // and sends the reader hunting a broken regex instead of the block they just pasted back. Measured:
+        // that is exactly what the mutation run reported until this order was fixed.
+        Assert.True(reInlined.Count == 0,
+            "these views inline the status-footer markup the shared StatusFooter replaced. Copying it from a "
+            + "neighbour is how there came to be 21 copies; use <v:StatusFooter Grid.Row=\"…\" Margin=\"…\" "
+            + "ProgressName=\"… progress\"/> instead:\n  " + string.Join("\n  ", reInlined));
+
+        // Vacuity floor for the naming check below, and only for it: if the element match breaks, `unnamed`
+        // is empty for the wrong reason. 21 call sites when converted.
+        Assert.True(callSites >= 21,
+            $"only {callSites} StatusFooter call sites were found, out of 21 converted — the element match is "
+            + "out of date, so the naming check below proves nothing.");
+
+        Assert.True(unnamed.Count == 0,
+            "these StatusFooter call sites do not name their progress bar, so a screen reader announces an "
+            + "unnamed bar. Every view had its own name before the control existed and none of them should "
+            + "lose it — ProgressName has no default precisely so this cannot pass unnoticed:\n  "
+            + string.Join("\n  ", unnamed));
+    }
+
+    /// <summary>The plain status footer, inlined — the exact shape <c>StatusFooter</c> replaced.</summary>
+    /// <remarks>
+    /// Runs against whitespace-collapsed markup, so re-indenting a copy does not evade it. It matches the
+    /// WHOLE block through the closing <c>DockPanel</c>, not just the <c>ProgressBar</c> attributes: the 16
+    /// unconverted footers legitimately open with the same attributes and differ only in what follows, so a
+    /// shorter needle would report every one of them as a violation.
+    /// </remarks>
+    [GeneratedRegex(@"<DockPanel[^>]*>\s*<ProgressBar AutomationProperties\.Name=""[^""]*"" "
+        + @"DockPanel\.Dock=""Left"" Width=""120"" Height=""4"" Margin=""0,0,12,0"" "
+        + @"IsIndeterminate=""\{Binding IsProgressIndeterminate\}"" "
+        + @"Visibility=""\{Binding IsBusy, Converter=\{StaticResource BoolToVis\}\}""/>\s*"
+        + @"<TextBlock Text=""\{Binding StatusMessage\}"" Style=""\{StaticResource StatusLine\}""/>\s*"
+        + @"</DockPanel>", RegexOptions.Compiled)]
+    private static partial Regex InlinedPlainFooter();
+
+    /// <summary>A <c>&lt;v:StatusFooter …/&gt;</c> call site.</summary>
+    [GeneratedRegex(@"<v:StatusFooter\b[^>]*/>", RegexOptions.Compiled)]
+    private static partial Regex StatusFooterElement();
+
+    /// <summary>
     /// Every way of setting a theme goes through the one path that keeps its text legible.
     /// </summary>
     /// <remarks>
@@ -5705,6 +5802,19 @@ public partial class ArchitectureTests
                 }
             }
 
+            // A <v:StatusFooter ProgressName="…"/> puts a progress bar on this page whose markup lives in
+            // another file, so without this the guard stopped seeing 21 of them the moment the footer was
+            // shared — and worse, could no longer catch a view whose OWN bar is announced the same way as
+            // its footer's. Counted here as the bar it renders.
+            foreach (var footer in root.DescendantsAndSelf()
+                         .Where(e => e.Name.LocalName == "StatusFooter"))
+            {
+                barsSeen++;
+                var name = Attr(footer, "ProgressName");
+                if (string.IsNullOrWhiteSpace(name)) unnamed++;
+                else named.Add(name.Trim());
+            }
+
             foreach (var group in named.GroupBy(n => n, StringComparer.Ordinal).Where(g => g.Count() > 1))
                 ambiguous.Add($"{file} — {group.Count()} bars all announced \"{group.Key}\"");
 
@@ -5831,6 +5941,13 @@ public partial class ArchitectureTests
                                           + "coarse status line and the final verdict are announced.");
                 }
             }
+
+            // A <v:StatusFooter/> renders this tab's StatusMessage line from another file, so without this
+            // the guard stopped counting 21 of them when the footer was shared. It needs no announcement
+            // check of its own: the control uses Style="{StaticResource StatusLine}", and the loop below
+            // already asserts that style still carries AutomationProperties.LiveSetting — which is what
+            // keeps all 21 announced through one definition instead of twenty-one.
+            statusLinesSeen += root.DescendantsAndSelf().Count(e => e.Name.LocalName == "StatusFooter");
         }
 
         // Both shared styles must exist AND both must carry the setting. Checking only one would let the

--- a/SysManager/SysManager/Views/AppAlertsView.xaml
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml
@@ -135,11 +135,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="3" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="App alert scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="3" Margin="0,8,0,0" ProgressName="App alert scan progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/AudioMixerView.xaml
+++ b/SysManager/SysManager/Views/AudioMixerView.xaml
@@ -196,11 +196,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="3" Margin="28,12,28,24">
-            <ProgressBar AutomationProperties.Name="Audio device refresh progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="3" Margin="28,12,28,24" ProgressName="Audio device refresh progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/BatteryHealthView.xaml
+++ b/SysManager/SysManager/Views/BatteryHealthView.xaml
@@ -2,6 +2,7 @@
 <UserControl x:Class="SysManager.Views.BatteryHealthView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:SysManager.Views"
              xmlns:vm="clr-namespace:SysManager.ViewModels"
              d:DataContext="{d:DesignInstance vm:BatteryHealthViewModel}"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -176,11 +177,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Refresh progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="4" Margin="0,8,0,0" ProgressName="Refresh progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/BrowserCleanerView.xaml
+++ b/SysManager/SysManager/Views/BrowserCleanerView.xaml
@@ -98,11 +98,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="3" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Browser cleanup progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="3" Margin="0,8,0,0" ProgressName="Browser cleanup progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/ContextMenuView.xaml
+++ b/SysManager/SysManager/Views/ContextMenuView.xaml
@@ -296,11 +296,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="5" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Context menu scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="5" Margin="0,8,0,0" ProgressName="Context menu scan progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/DefenderView.xaml
+++ b/SysManager/SysManager/Views/DefenderView.xaml
@@ -133,11 +133,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="6" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Defender operation progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="6" Margin="0,8,0,0" ProgressName="Defender operation progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -189,11 +189,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="4" Margin="0,8,0,0" ProgressName="Scan progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/DriversView.xaml
+++ b/SysManager/SysManager/Views/DriversView.xaml
@@ -136,12 +136,7 @@
             </Border>
 
             <!-- Status bar -->
-            <DockPanel Grid.Row="4" Margin="0,8,0,0">
-                <ProgressBar AutomationProperties.Name="Driver scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                             IsIndeterminate="{Binding IsProgressIndeterminate}"
-                             Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-            </DockPanel>
+            <v:StatusFooter Grid.Row="4" Margin="0,8,0,0" ProgressName="Driver scan progress"/>
         </Grid>
     </ScrollViewer>
 </UserControl>

--- a/SysManager/SysManager/Views/EdgeOneDriveView.xaml
+++ b/SysManager/SysManager/Views/EdgeOneDriveView.xaml
@@ -93,11 +93,6 @@
         </ScrollViewer>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="3" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Edge and OneDrive operation progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="3" Margin="0,8,0,0" ProgressName="Edge and OneDrive operation progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -478,11 +478,6 @@
         </Grid>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="4" Margin="28,12,28,24">
-            <ProgressBar AutomationProperties.Name="Log loading progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="4" Margin="28,12,28,24" ProgressName="Log loading progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/NotificationBlockerView.xaml
+++ b/SysManager/SysManager/Views/NotificationBlockerView.xaml
@@ -135,11 +135,6 @@
                       Visibility="{Binding FilteredApps.Count, Converter={StaticResource FlexVis}, ConverterParameter=Inverse}"/>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="5" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Notification setting progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="5" Margin="0,8,0,0" ProgressName="Notification setting progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/PerformanceView.xaml
+++ b/SysManager/SysManager/Views/PerformanceView.xaml
@@ -309,11 +309,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="5" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Performance tweak progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="5" Margin="0,8,0,0" ProgressName="Performance tweak progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -108,11 +108,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Privacy setting progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="4" Margin="0,8,0,0" ProgressName="Privacy setting progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -332,11 +332,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="5" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Process list progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="5" Margin="0,8,0,0" ProgressName="Process list progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/ProfileView.xaml
+++ b/SysManager/SysManager/Views/ProfileView.xaml
@@ -75,11 +75,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Profile import and export progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="4" Margin="0,8,0,0" ProgressName="Profile import and export progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/RestorePointsView.xaml
+++ b/SysManager/SysManager/Views/RestorePointsView.xaml
@@ -93,11 +93,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Restore point progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="4" Margin="0,8,0,0" ProgressName="Restore point progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -283,11 +283,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Service list progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="4" Margin="0,8,0,0" ProgressName="Service list progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/StartupView.xaml
+++ b/SysManager/SysManager/Views/StartupView.xaml
@@ -313,11 +313,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="4" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Startup item scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="4" Margin="0,8,0,0" ProgressName="Startup item scan progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/StatusFooter.xaml
+++ b/SysManager/SysManager/Views/StatusFooter.xaml
@@ -1,0 +1,34 @@
+<!-- SysManager · Author: laurentiu021 · https://github.com/laurentiu021/SystemManager · License: MIT -->
+<UserControl x:Class="SysManager.Views.StatusFooter"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root">
+
+    <!-- The scan-progress + status-line footer that 21 views had copied verbatim. Single source of
+         truth for the idiom, so the progress colour, the a11y wiring and the "Done" affordance the
+         colour contract asks for become one edit instead of twenty-one.
+
+         Bindings are unqualified on purpose: the three members all live on ViewModelBase
+         (IsProgressIndeterminate, IsBusy, StatusMessage), so the control inherits the view's
+         DataContext and needs no plumbing. Only the accessible NAME differs per view, which is why
+         it is the one dependency property — every view names its own bar ("Cleanup progress",
+         "Uninstall progress"), and collapsing 21 distinct names into one shared "Progress" would be
+         an accessibility regression dressed up as deduplication.
+
+         Grid.Row and Margin stay on the call site: the two layout strategies disagree about the
+         footer's gutter (28,12,28,24 for per-section views, 0,8,0,0 under a root gutter) and the row
+         index differs per view. Usage:
+           <v:StatusFooter Grid.Row="4" Margin="0,8,0,0" ProgressName="Cleanup progress"/>
+
+         NOT converted, deliberately: the 16 footers that carry extra content — a docked Cancel or
+         Refresh button, an ETA line, a trimmed path with a tooltip, or a literal
+         IsIndeterminate="True". Giving this control enough slots to absorb those would make it more
+         complicated than the duplication it removes. See #1630. -->
+    <DockPanel>
+        <ProgressBar AutomationProperties.Name="{Binding ProgressName, ElementName=Root}"
+                     DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                     IsIndeterminate="{Binding IsProgressIndeterminate}"
+                     Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+        <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
+    </DockPanel>
+</UserControl>

--- a/SysManager/SysManager/Views/StatusFooter.xaml.cs
+++ b/SysManager/SysManager/Views/StatusFooter.xaml.cs
@@ -1,0 +1,42 @@
+// SysManager · StatusFooter
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Windows;
+using System.Windows.Controls;
+
+namespace SysManager.Views;
+
+/// <summary>
+/// The scan-progress bar plus status line that every scan-capable tab ends with. Centralizes the idiom so
+/// the progress colour, the accessibility wiring and the "Done" affordance can never drift between views.
+/// </summary>
+/// <remarks>
+/// Bindings inside are unqualified: <see cref="ViewModels.ViewModelBase"/> owns
+/// <c>IsProgressIndeterminate</c>, <c>IsBusy</c> and <c>StatusMessage</c>, so the control inherits the view's
+/// DataContext and needs no plumbing. Place it where the copied <c>DockPanel</c> was, keeping that element's
+/// <c>Grid.Row</c> and <c>Margin</c> on the call site — the two layout strategies disagree about the footer's
+/// gutter, and the row index differs per view.
+/// <para><see cref="ProgressName"/> has no default on purpose. Every view names its own bar — "Cleanup
+/// progress", "Uninstall progress" — and a default would let a call site silently ship an unnamed progress
+/// bar to a screen reader, which is the regression this control was most at risk of introducing.</para>
+/// </remarks>
+public partial class StatusFooter : UserControl
+{
+    public StatusFooter() => InitializeComponent();
+
+    /// <summary>
+    /// What a screen reader calls this tab's progress bar, e.g. "Cleanup progress". Required: an unnamed
+    /// progress bar is worse than the duplication this control replaces.
+    /// </summary>
+    public static readonly DependencyProperty ProgressNameProperty =
+        DependencyProperty.Register(nameof(ProgressName), typeof(string), typeof(StatusFooter),
+            new PropertyMetadata(string.Empty));
+
+    /// <inheritdoc cref="ProgressNameProperty"/>
+    public string ProgressName
+    {
+        get => (string)GetValue(ProgressNameProperty);
+        set => SetValue(ProgressNameProperty, value);
+    }
+}

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -377,12 +377,7 @@
                 </Border>
 
                 <!-- Status bar -->
-                <DockPanel Margin="0,16,0,0">
-                    <ProgressBar AutomationProperties.Name="System health check progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                                 IsIndeterminate="{Binding IsProgressIndeterminate}"
-                                 Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-                </DockPanel>
+                <v:StatusFooter Margin="0,16,0,0" ProgressName="System health check progress"/>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/SysManager/SysManager/Views/SystemReportView.xaml
+++ b/SysManager/SysManager/Views/SystemReportView.xaml
@@ -78,11 +78,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="3" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Report generation progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="3" Margin="0,8,0,0" ProgressName="Report generation progress"/>
     </Grid>
 </UserControl>

--- a/SysManager/SysManager/Views/WindowsFeaturesView.xaml
+++ b/SysManager/SysManager/Views/WindowsFeaturesView.xaml
@@ -249,11 +249,6 @@
         </Border>
 
         <!-- Status bar -->
-        <DockPanel Grid.Row="5" Margin="0,8,0,0">
-            <ProgressBar AutomationProperties.Name="Windows feature progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
-                         IsIndeterminate="{Binding IsProgressIndeterminate}"
-                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}"/>
-        </DockPanel>
+        <v:StatusFooter Grid.Row="5" Margin="0,8,0,0" ProgressName="Windows feature progress"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
Addresses #1630 part (a). Behaviour identical. `refactor:` — no release.

### The premise was wrong, and it changed the work

The issue says the block is character-for-character identical across 37 views and needs no dependency properties at all. Measured first:

**37 footers, 12 distinct shapes.** Only **21** are the plain block.

| shape | count | what differs |
|---|---|---|
| plain | 21 | nothing — these are the ones converted |
| + `VerticalAlignment` and `TextWrapping` | 4 | |
| + `Value="{Binding Progress}"` | 3 | determinate |
| literal `IsIndeterminate="True"` | 2 | not bound at all |
| one-offs | 7 | docked Cancel/Refresh button, ETA line, trimmed path with tooltip, ModeDescription |

And every one of the 37 carries its **own** accessible name — "Cleanup progress", "Uninstall progress", "Startup item scan progress". A control with no dependency property would have collapsed 21 distinct names into one shared "Progress": an accessibility regression dressed up as deduplication. So `ProgressName` is the one DP, and it has **no default**, because a default is what would let a call site silently ship an unnamed bar to a screen reader.

Two more corrections: the text style is `StatusLine` (49 uses) / `SubtleStatusLine` (2), not `Caption`; and 6 views bind `Value="{Binding Progress}"`. Those 6 are **exactly** the 6 view-models that ever assign `Progress`, so the shared control omitting `Value` is provably behaviour-neutral for the 21 rather than merely probably.

The 16 with extra content are deliberately untouched. Giving the control enough slots for a docked button, an ETA and a tooltip would make it more complicated than the duplication it removes.

### Two existing guards went red, and lowering their floors was the wrong fix

Sharing the markup moved 21 progress bars and 21 status lines out of the views, so:

- `NoTwoProgressBarsOnAPage_AreAnnouncedTheSame` could no longer catch a view whose **own** bar is announced the same way as its footer's.
- `EveryStatusLine_IsALiveRegion_AndTheFastReadoutsAreNot` could no longer see the lines at all.

Both now count a `<v:StatusFooter ProgressName="…"/>` as the bar and the line it renders, which restores the coverage rather than hiding its loss. Checked while there: **no collision today** — AudioMixer, BatteryHealth and DiskAnalyzer keep their own bars and all names are distinct. The live region survives because it is set on the `StatusLine` **style** in App.xaml, not per `TextBlock`, so one definition still announces all 21.

### New guard

`EveryStatusFooter_NamesItsProgressBar_AndNobodyReInlinesIt` — a call site without a name, and someone copying the block back from a neighbour, which is exactly how there came to be 21 copies. The re-inlining check runs against whitespace-collapsed markup, so re-indenting a copy does not evade it.

```
baseline: GREEN
mutation 1 ProgressName dropped          -> RED  "…do not name their progress bar … PrivacyView.xaml"
mutation 2 block re-inlined, re-indented -> RED  "…inline the status-footer markup … ServicesView.xaml"
2 of 2 mutations failed for the expected reason
```

The first attempt had the assertions in the wrong order: replacing a call site with an inlined copy lowers the count, so the vacuity floor fired first and reported "the element match is out of date" — sending a reader after a broken regex instead of the block they had just pasted back. The floor now sits immediately before the single assertion it protects.

### Verification

- 21 footers converted, each keeping its own accessible name verbatim
- App and unit projects — **0 errors, 0 warnings**
- Unit suite **5480 passed**, 0 failed
- `dotnet format --verify-no-changes` clean on all four projects, exit status captured properly this time
- Leak scan of the staged diff against all 43 patterns — 0 hits
- ARCHITECTURE updated: four shared controls now, not three

### Not in scope

Part (b), the typography rungs. The issue itself says it changes visible sizes on five tabs and needs mockup-first review, so it is not bundled here.

### Deferred to the secondary workstation

That the 21 footers still look identical to before. The markup is the same elements with the same bindings and the same style, and the gutter values moved across unchanged, so I expect no visual difference at all — but 21 tabs is worth a glance.