### PR TITLE
feat: say when administrator rights are what Deep Cleanup is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.92.0] - 2026-09-11
+
+**Deep Cleanup now tells you when administrator rights are the thing standing in the way.** Five of its
+categories live in the Windows folder — the Windows Update download cache, Delivery Optimization, the
+Installer patch cache, `Windows\Temp` and Prefetch — and without administrator they were counted, listed,
+and then quietly reported as "skipped" with no reason given. Those are among the largest items on the
+list, so the tab could look like it had done its job while leaving the biggest wins untouched. It now
+says so at the top of the page, in the same place every other tab does, with a button to restart elevated.
+
+### Added
+
+- **Elevation notice on Deep Cleanup**, naming the five categories that need administrator and what
+  becomes deletable once you restart elevated.
+
+### Fixed
+
+- Items skipped for lack of permission no longer look like items that were simply not there.
+
 ## [1.91.0] - 2026-09-11
 
 **Every tab whose output is a list can now save it to a file.** Five more got an **Export CSV** button —

--- a/README.md
+++ b/README.md
@@ -447,6 +447,11 @@ a confirmation before it runs:
 ### Deep Cleanup
 - **Scan-first**: every category is discovered with size + file count
   before a single byte is deleted. You pick what goes.
+- **Says when administrator rights are what's stopping it.** Five of the buckets live in
+  the Windows folder — the Windows Update download cache, Delivery Optimization, the
+  Installer patch cache, `Windows\Temp` and Prefetch — and without administrator they are
+  still scanned and counted but cannot be deleted. They used to show as "skipped" with no
+  reason given; the tab now says so at the top, and offers to restart elevated
 - **System buckets**: NVIDIA / AMD / Intel installer leftovers, Windows
   Update cache, Delivery Optimization cache, Windows Installer patch
   cache, TEMP, Prefetch, crash dumps, old CBS logs, DirectX shader cache,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.91.x   | :white_check_mark: |
-| < 1.91   | :x:                |
+| 1.92.x   | :white_check_mark: |
+| < 1.92   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.91.0</Version>
-    <FileVersion>1.91.0.0</FileVersion>
-    <AssemblyVersion>1.91.0.0</AssemblyVersion>
+    <Version>1.92.0</Version>
+    <FileVersion>1.92.0.0</FileVersion>
+    <AssemblyVersion>1.92.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -33,6 +33,16 @@ public sealed partial class DeepCleanupViewModel : ViewModelBase
     public BulkObservableCollection<LargeFileEntry> LargeFiles { get; } = new();
     public ObservableCollection<ScanLocation> ScanLocations { get; } = new();
 
+    /// <summary>Whether this session is elevated. Read by the shared <c>AdminBanner</c> from the DataContext.</summary>
+    /// <remarks>
+    /// Five of the nineteen buckets live under <c>%WinDir%</c> — the Windows Update download cache, the
+    /// Delivery Optimization cache, the Installer patch cache, <c>Windows\Temp</c> and Prefetch — so an
+    /// unelevated run cannot delete them. It did not fail visibly either: the files landed in
+    /// <see cref="Models.CleanupCategory.SkippedCount"/> and the row read "N files · M skipped" without ever
+    /// saying that administrator rights were the reason, which is the one thing the user could have acted on.
+    /// </remarks>
+    [ObservableProperty] private bool _isElevated;
+
     [ObservableProperty] private bool _isScanning;
     [ObservableProperty] private bool _isCleaning;
     [ObservableProperty] private bool _isLargeScanning;
@@ -75,7 +85,18 @@ public sealed partial class DeepCleanupViewModel : ViewModelBase
         _cleanup = cleanup;
         _largeFiles = largeFiles;
         _drives = drives;
+        // Read synchronously, before InitAsync: the banner is above the fold and its two states must not
+        // flicker from "needs administrator" to "running as administrator" after the page has painted.
+        IsElevated = AdminHelper.IsElevated();
         InitializeAsync(InitAsync);
+    }
+
+    /// <summary>Restarts SysManager elevated, so the five <c>%WinDir%</c> buckets stop being skipped.</summary>
+    [RelayCommand]
+    private void RelaunchAsAdmin()
+    {
+        if (AdminHelper.RelaunchAsAdmin())
+            App.RequestShutdown();
     }
 
     private async Task InitAsync()

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -17,6 +17,16 @@
                     </StackPanel>
                 </DockPanel>
 
+                <!-- Elevation. Directly under the header, which is where the golden admin-control contract
+                     puts it on every other privileged tab, and Margin="0,12,0,0" because this is a
+                     scrolling page whose StackPanel already carries the 28 gutter.
+                     Five of the nineteen buckets live under %WinDir% — the Windows Update download cache,
+                     Delivery Optimization, the Installer patch cache, Windows\Temp and Prefetch — and
+                     without admin they were silently counted as "skipped" with no stated reason. -->
+                <v:AdminBanner Margin="0,12,0,0"
+                               NotElevatedMessage="Some of the biggest items — the Windows Update download cache, Delivery Optimization, the Installer patch cache, Windows\Temp and Prefetch — can only be deleted as administrator. They are still scanned and counted, and shown as skipped."
+                               ElevatedMessage="Running as administrator — the Windows Update, Delivery Optimization, Installer patch cache, Windows\Temp and Prefetch items can be deleted too."/>
+
                 <!-- Safety note -->
                 <Border Style="{StaticResource Card}" Margin="0,16,0,0"
                         Background="{DynamicResource AccentSoft}" BorderBrush="{DynamicResource Accent}" BorderThickness="1">


### PR DESCRIPTION
Prerequisite for #1577. `feat:` -> v1.92.0.

### The gap

Deep Cleanup had **no elevation affordance at all**. Grepping the view and the view model for `admin|IsElevated|administrator` returned exactly one hit, and it was prose about the large-files finder being read-only.

Five of its nineteen buckets live under `%WinDir%`:

- Windows Update download cache
- Delivery Optimization cache
- Windows Installer patch cache
- `Windows\Temp`
- Prefetch

Unelevated, those files were scanned, sized, listed — and then reported through `CleanupCategory.SkippedCount` as `"N files · M skipped"`, with nothing anywhere saying that administrator rights were the reason. Those are among the **largest** items on the list, so the tab could look like it had done its job while leaving the biggest wins untouched. The one thing the user could act on was the one thing it did not say.

### The fix is the contract, not a new idea

The golden admin-control contract already specifies this: a privileged page explains WHY admin is needed and WHAT unlocks, at the top of the page. So: the shared `AdminBanner` in the documented position, plus the two members it binds ambiently (`IsElevated`, `RelaunchAsAdminCommand`).

Two details worth stating:

- `Margin="0,12,0,0"`, not a 28 gutter — Deep Cleanup is one of the three **scrolling pages**, whose `StackPanel` already carries the gutter. Using the per-section value would have double-indented it.
- `IsElevated` is read **synchronously in the constructor, before `InitializeAsync`**, so the banner does not flicker from "needs administrator" to "running as administrator" after the page has painted.

### No new guard, and I checked rather than assumed

`TheElevationBanner_LivesInOneControl_AndItsHostsExposeWhatItBinds` already covers exactly this failure — the banner binds ambiently, so a host missing either member renders a banner stuck in one state or a dead button, with no compiler error and nothing visible on a machine that never launches the app. Rather than trust that, I removed each half:

```
baseline: GREEN
mutation 1 IsElevated removed        -> the project no longer compiles (caught by the COMPILER)
mutation 2 RelaunchAsAdmin removed   -> RED  "DeepCleanupView — its view model exposes no
                                             RelaunchAsAdminCommand, so the button does nothing"
2 of 2 halves are caught
```

View model restored byte-for-byte. Recorded honestly that one half is a compile break rather than a guard hit — that is still caught, just by a different mechanism.

### Verification

- App and unit projects — **0 errors, 0 warnings**
- Unit suite **5480 passed**, 0 failed
- `dotnet format --verify-no-changes` clean on both projects
- Leak scan of the staged diff against all 43 patterns — 0 hits
- Docs in this PR: README Deep Cleanup section, CHANGELOG `[1.92.0]` with both an Added and a Fixed entry, SECURITY -> 1.92.x, csproj -> 1.92.0

### Why this is a prerequisite

#1577 wants two new buckets — blue-screen memory dumps and the Explorer thumbnail cache — that need admin to delete, and its risk note names this gap as what blocks them: without a banner they would "silently land in the existing SkippedCount path". Now they would not.

### Deferred to the secondary workstation

The banner is above the fold on a scrolling page, so it competes for space with the existing accent-coloured safety note directly beneath it. Two stacked notices at the top of one page is the kind of thing that reads fine in markup and heavy on screen — worth a look.