### PR TITLE
feat: find the biggest file on a PC that has blue-screened

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -859,7 +859,15 @@ tab cannot ship a refresh or cancel button the keyboard cannot reach.
 - Scan first, clean second. Every category is opt-in and shows its size.
 - Never touches browsers, passwords, registry, active drivers, Program
   Files, or actual game files in `steamapps\common`.
-- Windows.old is tagged **Irreversible** and never selected by default.
+- Windows.old is tagged **Irreversible** and never selected by default, as are the
+  blue-screen memory dumps: they are the only record of why a machine crashed.
+- A bucket may restrict itself to files matching a wildcard (`FilePatterns`), and the
+  restriction is carried on the `CleanupCategory` rather than looked up at clean time —
+  the cleaner is handed categories and walks their `Paths`, so a filter it could not see
+  would show an honest size and delete the whole folder. Two buckets need it: the dumps
+  (`*.dmp`, among `.etl` traces) and the Explorer thumbnail cache, whose folder also holds
+  the jump lists that are the user's recent-files history. A filtered bucket also leaves
+  its emptied folders in place, because it owns files and not the folder.
 - Large files finder has no delete action, even with admin rights.
 
 ## Logging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.93.0] - 2026-09-11
+
+**Deep Cleanup can now find the biggest file on a PC that has blue-screened.** When Windows crashes it
+writes out `MEMORY.DMP`, sized to how much RAM the machine has — routinely several gigabytes, and often
+the single largest reclaimable file on the drive. Deep Cleanup had no bucket for it, nor for the
+`Minidump` and `LiveKernelReports` folders beside it. It now does, and it is deliberately never ticked
+for you: those dumps are the only record of why the machine crashed, so removing them ends any
+investigation into it. The second addition is the thumbnail cache — the previews Windows keeps so folders
+open quickly, whose clearing is the standard fix for thumbnails that come up blank or show the wrong
+picture.
+
+### Added
+
+- **Blue-screen memory dumps** as a bucket of its own: `MEMORY.DMP`, `Windows\Minidump` and
+  `Windows\LiveKernelReports`. Offered with its size and file count like every other bucket, never
+  pre-selected, and it needs administrator to delete — which the tab now says.
+- **Explorer thumbnail & icon cache**, scoped to exactly `thumbcache_*.db` and `iconcache_*.db`. That
+  folder is Explorer's own working directory and also holds the jump lists that are your recent-files
+  history, so nothing else in it is counted, and nothing else in it is deleted.
+
+### Changed
+
+- A cleanup bucket can now name a single file rather than a folder, and can restrict itself to files
+  matching a pattern. Both the scan and the delete read the same restriction, so the size shown is by
+  construction the size removed.
+- The Deep Cleanup elevation notice names six categories instead of five, the dumps being the sixth.
+
 ## [1.92.0] - 2026-09-11
 
 **Deep Cleanup now tells you when administrator rights are the thing standing in the way.** Five of its

--- a/README.md
+++ b/README.md
@@ -447,15 +447,23 @@ a confirmation before it runs:
 ### Deep Cleanup
 - **Scan-first**: every category is discovered with size + file count
   before a single byte is deleted. You pick what goes.
-- **Says when administrator rights are what's stopping it.** Five of the buckets live in
+- **Says when administrator rights are what's stopping it.** Six of the buckets live in
   the Windows folder — the Windows Update download cache, Delivery Optimization, the
-  Installer patch cache, `Windows\Temp` and Prefetch — and without administrator they are
-  still scanned and counted but cannot be deleted. They used to show as "skipped" with no
-  reason given; the tab now says so at the top, and offers to restart elevated
+  Installer patch cache, `Windows\Temp`, Prefetch and the blue-screen memory dumps — and
+  without administrator they are still scanned and counted but cannot be deleted. They used
+  to show as "skipped" with no reason given; the tab now says so at the top, and offers to
+  restart elevated
 - **System buckets**: NVIDIA / AMD / Intel installer leftovers, Windows
   Update cache, Delivery Optimization cache, Windows Installer patch
   cache, TEMP, Prefetch, crash dumps, old CBS logs, DirectX shader cache,
   Recycle Bin on every drive.
+- **The two biggest wins on a machine that has crashed**, both new and both scoped to
+  exactly the files they name: the **blue-screen memory dumps** (`MEMORY.DMP` is sized to
+  your RAM, so it is routinely gigabytes — never ticked for you, because deleting it ends
+  any investigation into the crash) and the **Explorer thumbnail & icon cache**, which
+  Windows rebuilds and whose clearing is the standard fix for blank or wrong thumbnails.
+  Its folder also holds your recent-files jump lists, so only `thumbcache_*.db` and
+  `iconcache_*.db` are counted, and only those are deleted.
 - **Gamer buckets** — launcher *caches only*, never game files or logins:
   Steam (appcache, htmlcache, depotcache, shader cache), Epic Games
   Launcher, Battle.net, Riot / League of Legends, GOG Galaxy, EA Desktop.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.92.x   | :white_check_mark: |
-| < 1.92   | :x:                |
+| 1.93.x   | :white_check_mark: |
+| < 1.93   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -8984,10 +8984,15 @@ public partial class ArchitectureTests
             }
         }
 
-        // Vacuity floor, re-measured: seven call sites across three files (five in the two sweepers, two in
+        // Vacuity floor, re-measured: six call sites across three files (four in the two sweepers, two in
         // CleanupPreScanService). A collapse means the pattern or the declaration filter stopped matching,
         // and this guard would then pass without reading a single call.
-        Assert.True(callsChecked >= 7,
+        //
+        // It was seven until #1577. DeepCleanupService's scan and clean each walked files directly; both now
+        // go through EnumerateTargets, which owns the single walk and applies the per-bucket file filter, so
+        // two call sites became one. The floor moved because the population did, not because the pattern
+        // stopped matching — the distinction the message below asks the next reader to make.
+        Assert.True(callsChecked >= 6,
             $"only {callsChecked} walker calls were matched across {callers.Count} file(s) — the pattern no "
             + "longer matches the call shape, so this guard proves nothing. Re-derive it before trusting a "
             + "pass.");
@@ -10693,6 +10698,101 @@ public partial class ArchitectureTests
             + "built — without it the scan's file counts, byte totals and age cutoff can only be asserted "
             + "as \"non-negative\":\n  "
             + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// A bucket that counts only some of the files under its path must delete only those files. Scan and
+    /// Clean are separate walks, so the filter has to reach both or the bucket lies about what it removes.
+    /// </summary>
+    /// <remarks>
+    /// Two buckets are filtered (#1577). The blue-screen dumps take <c>*.dmp</c> from
+    /// folders that also hold <c>.etl</c> traces, and the Explorer thumbnail cache takes
+    /// <c>thumbcache_*.db</c> / <c>iconcache_*.db</c> from Explorer's own working folder — which also holds
+    /// the jump lists that are the user's recent-files history. A filter applied in Scan alone gives the
+    /// worst possible outcome: an honest size on screen, and a delete that takes the whole folder.
+    /// <para>Flat greps over the comment-stripped file, matching
+    /// <see cref="DeepCleanupsScan_TakesItsRootsFromTheSeam"/> — a guard that slices a method body between
+    /// markers passes vacuously the moment a marker moves. The count of direct <c>EnumerateFiles</c> uses
+    /// is what pins it: the raw walk is unfiltered, so the only legitimate uses are its own declaration and
+    /// the one call inside the filtering helper. A third means someone reached past the filter.</para>
+    /// <para>The floor comes first. If no definition sets <c>FilePatterns</c> any more, nothing below is
+    /// about live code and the guard would pass while checking nothing.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryFilteredCleanupBucket_IsFilteredInBothScanAndClean()
+    {
+        var path = Path.Combine(FindAppProjectDir(), "Services", "DeepCleanupService.cs");
+        Assert.True(File.Exists(path), $"DeepCleanupService.cs was not found at {path}");
+        var source = WithoutComments(File.ReadAllText(path));
+
+        var declared = source.Split("FilePatterns:").Length - 1;
+        Assert.True(declared >= 2,
+            $"only {declared} cleanup definitions set FilePatterns, and there were 2 — the blue-screen "
+            + "dumps and the Explorer thumbnail cache. If a filtered bucket was removed, remove the part "
+            + "of this guard that is about it rather than leaving it asserting over nothing.");
+
+        Assert.True(source.Contains("FilePatterns = d.FilePatterns", StringComparison.Ordinal),
+            "the scan no longer copies FilePatterns onto the CleanupCategory it builds. Clean is handed "
+            + "categories and walks their Paths — it cannot see the definitions — so a filter that stops "
+            + "at the definition is a bucket that reports one set of files and deletes another.");
+
+        Assert.True(source.Contains("cat.FilePatterns", StringComparison.Ordinal),
+            "Clean no longer reads FilePatterns off the category. Every unmatched file under a filtered "
+            + "bucket's path is then deleted, including Explorer's recent-files jump lists, which that "
+            + "bucket's own scan never counted.");
+
+        // Directory.EnumerateFiles is the framework call inside the walker itself; the walk this is about
+        // is DeepCleanupService's own, which is unfiltered by design.
+        var directWalks = Regex.Matches(source, @"(?<!Directory\.)\bEnumerateFiles\(").Count;
+        Assert.True(directWalks == 2,
+            $"DeepCleanupService uses its raw EnumerateFiles walk {directWalks} times, and there are only "
+            + "two legitimate uses: the declaration, and the single call inside EnumerateTargets that "
+            + "applies the pattern filter. Anything else walks a bucket's files without filtering them — "
+            + "which for the Explorer bucket means deleting the user's jump lists.");
+    }
+
+    /// <summary>
+    /// The cleanup walk must ABANDON a directory whose enumerator throws, not retry it. A throwing
+    /// <c>MoveNext</c> does not advance, so retrying it is an infinite loop.
+    /// </summary>
+    /// <remarks>
+    /// This was live code, and only a proof mutation reached it: 900 seconds of nothing on a run that takes
+    /// 0.24. Measured with a standalone probe afterwards — <c>Directory.EnumerateFiles</c> over a path that
+    /// is a FILE returns without throwing, <c>GetEnumerator</c> returns without throwing, and
+    /// <c>MoveNext</c> then threw <c>IOException</c> on all ten attempts without advancing once. The
+    /// <c>catch { continue; }</c> that used to sit here therefore re-threw forever, pinning a core in a loop
+    /// cancellation cannot reach — the token is only checked on the outer loop.
+    /// <para>It stayed unreachable for as long as both callers filtered their paths through
+    /// <c>Directory.Exists</c>. #1577 is what made a path that names a FILE legitimate (<c>MEMORY.DMP</c>),
+    /// so the distance between this walker and a hang is now one edit, and nothing else would catch it: a
+    /// spin fails no assertion, it just never finishes.</para>
+    /// <para>The two <c>catch (…) { continue; }</c> arms guarding the <c>EnumerateFiles</c> CALL are
+    /// deliberately untouched and must stay <c>continue</c> — they sit on the outer loop, where continuing
+    /// means "take the next directory off the stack", which is real progress. So this matches the shape
+    /// around <c>MoveNext</c> rather than banning the string.</para>
+    /// </remarks>
+    [Fact]
+    public void TheCleanupWalk_AbandonsADirectoryWhoseEnumeratorThrows()
+    {
+        var path = Path.Combine(FindAppProjectDir(), "Services", "DeepCleanupService.cs");
+        Assert.True(File.Exists(path), $"DeepCleanupService.cs was not found at {path}");
+        var source = WithoutComments(File.ReadAllText(path));
+
+        var match = Regex.Match(
+            source,
+            @"try \{ if \(!enumerator\.MoveNext\(\)\) break; item = enumerator\.Current; \}\s*"
+            + @"catch \([^)]*\) \{ (?<first>\w+); \}\s*catch \([^)]*\) \{ (?<second>\w+); \}");
+
+        Assert.True(match.Success,
+            "the MoveNext try/catch this guard is about was not found in DeepCleanupService. If the walk was "
+            + "rewritten, re-derive the check against the new shape — a pass here currently means nothing.");
+
+        var arms = new[] { match.Groups["first"].Value, match.Groups["second"].Value };
+        Assert.True(arms.All(a => a == "break"),
+            $"the walk retries a directory whose enumerator threw (arms: {string.Join(", ", arms)}). MoveNext "
+            + "does not advance when it throws — measured, it threw the same IOException ten times out of ten "
+            + "over a path that is a file — so `continue` here spins forever inside while(true), and the "
+            + "cancellation token is only checked on the outer loop. Use break: the directory is finished.");
     }
 
     /// <summary>

--- a/SysManager/SysManager.Tests/DeepCleanupFilteredBucketTests.cs
+++ b/SysManager/SysManager.Tests/DeepCleanupFilteredBucketTests.cs
@@ -1,0 +1,262 @@
+// SysManager · DeepCleanupFilteredBucketTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.IO;
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// The two buckets that must count and delete only SOME of the files under their path — blue-screen
+/// memory dumps and the Explorer thumbnail cache (#1577).
+/// </summary>
+/// <remarks>
+/// Every other bucket owns its whole folder, so "everything under this path" was a correct rule for all
+/// nineteen of them. These two do not: <c>%LOCALAPPDATA%\Microsoft\Windows\Explorer</c> is Explorer's own
+/// working folder and only the <c>thumbcache_*.db</c> / <c>iconcache_*.db</c> files in it are rebuildable
+/// caches, while the dumps bucket names one exact file (<c>MEMORY.DMP</c>) alongside two folders. So the
+/// filter is not a convenience — without it this feature deletes files it never claimed to.
+/// <para><b>Scan and Clean are asserted separately and both must filter.</b> They are two code paths over
+/// the same definitions: Scan aggregates and Clean deletes, and Clean re-reads the filter off the
+/// <see cref="CleanupCategory"/> rather than from the definition it came from. A filter applied in Scan
+/// only would produce the worst possible outcome — an honest size on screen, and a delete that took the
+/// whole folder.</para>
+/// </remarks>
+public sealed class DeepCleanupFilteredBucketTests
+{
+    private static TempCleanupRoots Roots() => new();
+
+    private static string WriteFile(string path, int bytes) => TempCleanupRoots.WriteFile(path, bytes);
+
+    private static CleanupCategory Named(IReadOnlyList<CleanupCategory> categories, string name)
+    {
+        var found = categories.FirstOrDefault(c => c.Name == name);
+        Assert.NotNull(found);   // renamed or removed — fix this test rather than letting it assert nothing
+        return found!;
+    }
+
+    private static string ExplorerCache(TempCleanupRoots roots)
+        => Path.Combine(roots.LocalAppData, "Microsoft", "Windows", "Explorer");
+
+    // ── Blue-screen memory dumps ─────────────────────────────────────────────
+
+    /// <summary>
+    /// <c>MEMORY.DMP</c> is a FILE, not a folder — every other bucket names directories, and the scan
+    /// only looked at paths <c>Directory.Exists</c> agreed with, so naming it would have been silently
+    /// dropped.
+    /// </summary>
+    [Fact]
+    public async Task Scan_CountsTheMemoryDumpFileItself()
+    {
+        using var roots = Roots();
+        WriteFile(Path.Combine(roots.WindowsDirectory, "MEMORY.DMP"), 40);
+
+        var categories = await new DeepCleanupService(roots).ScanAsync();
+
+        var category = Named(categories, "Blue-screen memory dumps");
+        Assert.Equal(1, category.FileCount);
+        Assert.Equal(40, category.TotalSizeBytes);
+    }
+
+    /// <summary>The two dump folders are walked, and <c>LiveKernelReports</c> keeps its dumps in subfolders.</summary>
+    [Fact]
+    public async Task Scan_CountsMinidumpsAndLiveKernelReportsBelowTheirFolders()
+    {
+        using var roots = Roots();
+        WriteFile(Path.Combine(roots.WindowsDirectory, "Minidump", "010125-1234.dmp"), 10);
+        WriteFile(Path.Combine(roots.WindowsDirectory, "LiveKernelReports", "WATCHDOG", "a.dmp"), 20);
+
+        var categories = await new DeepCleanupService(roots).ScanAsync();
+
+        var category = Named(categories, "Blue-screen memory dumps");
+        Assert.Equal(2, category.FileCount);
+        Assert.Equal(30, category.TotalSizeBytes);
+    }
+
+    /// <summary>
+    /// Deleting a dump ends any investigation into why the machine crashed, so this bucket follows the
+    /// <c>Windows.old</c> precedent: offered, described, never ticked for you.
+    /// </summary>
+    [Fact]
+    public async Task Scan_NeverPreSelectsTheDumpsBucket_EvenWhenItHasContent()
+    {
+        using var roots = Roots();
+        WriteFile(Path.Combine(roots.WindowsDirectory, "MEMORY.DMP"), 4096);
+
+        var categories = await new DeepCleanupService(roots).ScanAsync();
+
+        var category = Named(categories, "Blue-screen memory dumps");
+        Assert.True(category.IsDestructiveHint);
+        Assert.False(category.IsSelected);
+        Assert.Equal(4096, category.TotalSizeBytes);
+    }
+
+    /// <summary>
+    /// <c>LiveKernelReports</c> also holds <c>.etl</c> traces and XML metadata. The bucket is named for
+    /// dumps and its size is what the user reads before ticking it, so anything else must not be counted.
+    /// </summary>
+    [Fact]
+    public async Task Scan_IgnoresNonDumpFilesInTheDumpFolders()
+    {
+        using var roots = Roots();
+        WriteFile(Path.Combine(roots.WindowsDirectory, "LiveKernelReports", "a.dmp"), 10);
+        WriteFile(Path.Combine(roots.WindowsDirectory, "LiveKernelReports", "trace.etl"), 500);
+        WriteFile(Path.Combine(roots.WindowsDirectory, "Minidump", "notes.txt"), 700);
+
+        var categories = await new DeepCleanupService(roots).ScanAsync();
+
+        var category = Named(categories, "Blue-screen memory dumps");
+        Assert.Equal(1, category.FileCount);
+        Assert.Equal(10, category.TotalSizeBytes);
+    }
+
+    // ── Explorer thumbnail & icon cache ──────────────────────────────────────
+
+    [Fact]
+    public async Task Scan_CountsThumbnailAndIconCacheFiles()
+    {
+        using var roots = Roots();
+        var explorer = ExplorerCache(roots);
+        WriteFile(Path.Combine(explorer, "thumbcache_256.db"), 10);
+        WriteFile(Path.Combine(explorer, "thumbcache_idx.db"), 20);
+        WriteFile(Path.Combine(explorer, "iconcache_16.db"), 30);
+
+        var categories = await new DeepCleanupService(roots).ScanAsync();
+
+        var category = Named(categories, "Explorer thumbnail & icon cache");
+        Assert.Equal(3, category.FileCount);
+        Assert.Equal(60, category.TotalSizeBytes);
+    }
+
+    /// <summary>
+    /// The Explorer folder is not a cache folder — it is where Explorer keeps its own state, including
+    /// the jump lists that hold the user's recent-files history. Counting the whole folder would put that
+    /// history inside a bucket described as rebuildable, and then delete it.
+    /// </summary>
+    [Fact]
+    public async Task Scan_IgnoresEverythingElseInTheExplorerFolder()
+    {
+        using var roots = Roots();
+        var explorer = ExplorerCache(roots);
+        WriteFile(Path.Combine(explorer, "thumbcache_256.db"), 10);
+        WriteFile(Path.Combine(explorer, "AutomaticDestinations", "recent.automaticDestinations-ms"), 900);
+        WriteFile(Path.Combine(explorer, "notifications.db"), 500);
+
+        var categories = await new DeepCleanupService(roots).ScanAsync();
+
+        var category = Named(categories, "Explorer thumbnail & icon cache");
+        Assert.Equal(1, category.FileCount);
+        Assert.Equal(10, category.TotalSizeBytes);
+    }
+
+    /// <summary>Windows rebuilds these on demand, so unlike the dumps this one may arrive ticked.</summary>
+    [Fact]
+    public async Task Scan_PreSelectsTheThumbnailCache()
+    {
+        using var roots = Roots();
+        WriteFile(Path.Combine(ExplorerCache(roots), "thumbcache_1024.db"), 10);
+
+        var categories = await new DeepCleanupService(roots).ScanAsync();
+
+        var category = Named(categories, "Explorer thumbnail & icon cache");
+        Assert.False(category.IsDestructiveHint);
+        Assert.True(category.IsSelected);
+    }
+
+    // ── Clean applies the same filter ────────────────────────────────────────
+
+    /// <summary>
+    /// The one that matters. Clean walks <see cref="CleanupCategory.Paths"/> itself; if the filter lives
+    /// only in the scan definitions, the user sees "1 file · 10 bytes" and loses their jump lists.
+    /// </summary>
+    [Fact]
+    public async Task Clean_DeletesOnlyTheFilesThatMatchTheFilter()
+    {
+        using var roots = Roots();
+        var explorer = ExplorerCache(roots);
+        var cache = WriteFile(Path.Combine(explorer, "thumbcache_256.db"), 10);
+        var jumpList = WriteFile(Path.Combine(explorer, "AutomaticDestinations", "recent.automaticDestinations-ms"), 900);
+        var other = WriteFile(Path.Combine(explorer, "notifications.db"), 500);
+
+        var service = new DeepCleanupService(roots);
+        var categories = await service.ScanAsync();
+        var category = Named(categories, "Explorer thumbnail & icon cache");
+        category.IsSelected = true;
+
+        var result = await service.CleanAsync([category]);
+
+        Assert.False(File.Exists(cache));
+        Assert.True(File.Exists(jumpList), "Clean deleted Explorer's recent-files history, which this bucket never counted.");
+        Assert.True(File.Exists(other));
+        Assert.Equal(1, result.FilesDeleted);
+        Assert.Equal(10, result.BytesFreed);
+    }
+
+    /// <summary>
+    /// A filtered bucket owns files, not folders. Deleting the emptied folder would remove a directory
+    /// Explorer expects to exist and that the bucket's own scan never counted.
+    /// </summary>
+    [Fact]
+    public async Task Clean_LeavesTheFoldersOfAFilteredBucketInPlace()
+    {
+        using var roots = Roots();
+        var explorer = ExplorerCache(roots);
+        WriteFile(Path.Combine(explorer, "thumbcache_256.db"), 10);
+        var staging = Path.Combine(explorer, "ThumbCacheToDelete");
+        Directory.CreateDirectory(staging);
+
+        var service = new DeepCleanupService(roots);
+        var categories = await service.ScanAsync();
+        var category = Named(categories, "Explorer thumbnail & icon cache");
+        category.IsSelected = true;
+
+        await service.CleanAsync([category]);
+
+        Assert.True(Directory.Exists(staging), "Clean removed a folder Explorer owns.");
+        Assert.True(Directory.Exists(explorer));
+    }
+
+    /// <summary>Clean has to handle a path that is a file, for the same reason Scan does.</summary>
+    [Fact]
+    public async Task Clean_DeletesTheMemoryDumpFileItself()
+    {
+        using var roots = Roots();
+        var dump = WriteFile(Path.Combine(roots.WindowsDirectory, "MEMORY.DMP"), 40);
+        var minidump = WriteFile(Path.Combine(roots.WindowsDirectory, "Minidump", "010125-1234.dmp"), 10);
+
+        var service = new DeepCleanupService(roots);
+        var categories = await service.ScanAsync();
+        var category = Named(categories, "Blue-screen memory dumps");
+        category.IsSelected = true;
+
+        var result = await service.CleanAsync([category]);
+
+        Assert.False(File.Exists(dump));
+        Assert.False(File.Exists(minidump));
+        Assert.Equal(2, result.FilesDeleted);
+        Assert.Equal(50, result.BytesFreed);
+    }
+
+    /// <summary>
+    /// An unfiltered bucket must keep deleting its emptied subfolders — the filter is opt-in per bucket,
+    /// and this is the behaviour every other one of them relies on.
+    /// </summary>
+    [Fact]
+    public async Task Clean_StillRemovesEmptiedFoldersForAnUnfilteredBucket()
+    {
+        using var roots = Roots();
+        var amd = Path.Combine(roots.SystemDrive, "AMD");
+        WriteFile(Path.Combine(amd, "nested", "a.bin"), 10);
+
+        var service = new DeepCleanupService(roots);
+        var categories = await service.ScanAsync();
+        var category = Named(categories, "AMD installer leftovers");
+        category.IsSelected = true;
+
+        await service.CleanAsync([category]);
+
+        Assert.False(Directory.Exists(Path.Combine(amd, "nested")));
+    }
+}

--- a/SysManager/SysManager/Models/CleanupCategory.cs
+++ b/SysManager/SysManager/Models/CleanupCategory.cs
@@ -23,6 +23,20 @@ public sealed partial class CleanupCategory : ObservableObject
     public int FileCount { get; init; }
     public int SkippedCount { get; init; }
     public TimeSpan? OlderThan { get; init; }
+
+    /// <summary>
+    /// When set, only files matching one of these wildcards belong to this category — and so only they
+    /// are deleted, and its folders are left in place.
+    /// </summary>
+    /// <remarks>
+    /// Carried here rather than looked up at clean time, for the same reason as <see cref="OlderThan"/>:
+    /// the cleaner is handed categories and walks their <see cref="Paths"/>, so a filter it cannot see is
+    /// a category that reports one set of files and deletes another. Two of the buckets need it — the
+    /// blue-screen dumps (<c>*.dmp</c>, among <c>.etl</c> traces) and the Explorer thumbnail cache, whose
+    /// folder also holds the jump lists that are the user's recent-files history (#1577).
+    /// </remarks>
+    public IReadOnlyList<string>? FilePatterns { get; init; }
+
     public bool IsDestructiveHint { get; init; }
 
     /// <summary>

--- a/SysManager/SysManager/Services/DeepCleanupService.cs
+++ b/SysManager/SysManager/Services/DeepCleanupService.cs
@@ -3,6 +3,7 @@
 // License: MIT
 
 using System.IO;
+using System.IO.Enumeration;
 using Serilog;
 using SysManager.Helpers;
 using SysManager.Models;
@@ -54,10 +55,21 @@ public sealed class DeepCleanupService
 
     // ---------- scan definitions (built once, then iterated with progress) ----------
 
+    /// <summary>One scannable bucket: what to call it, what to tell the user about it, and where it lives.</summary>
+    /// <param name="Paths">
+    /// Directories to walk. An entry may also name a single FILE — <c>MEMORY.DMP</c> is one file sitting
+    /// directly in the Windows folder, and naming its parent instead would walk all of <c>%WinDir%</c>.
+    /// </param>
+    /// <param name="FilePatterns">
+    /// When set, only files matching one of these wildcards are counted and deleted, and the bucket's
+    /// emptied folders are left in place. Every bucket but two owns its whole folder, so the default is
+    /// null and means "everything under the path" — see <see cref="Scan"/> for why both halves matter.
+    /// </param>
     private sealed record Def(
         string Name,
         string Description,
         string[] Paths,
+        string[]? FilePatterns = null,
         TimeSpan? OlderThan = null,
         bool IsDestructiveHint = false,
         bool IsRecycleBin = false);
@@ -124,6 +136,26 @@ public sealed class DeepCleanupService
                     Path.Combine(programData, "Microsoft", "Windows", "WER", "ReportQueue"),
                     Path.Combine(programData, "Microsoft", "Windows", "WER", "ReportArchive"),
                 ]),
+
+            new("Blue-screen memory dumps",
+                "What Windows writes out when it blue-screens. MEMORY.DMP is sized to how much RAM you have, "
+                + "so on a machine that has crashed it is often the single biggest file on the drive. These are "
+                + "also the only record of why it crashed — delete them and any investigation into that ends, "
+                + "which is why this one is never ticked for you. Deleting them needs administrator.",
+                [
+                    Path.Combine(windowsDir, "MEMORY.DMP"),
+                    Path.Combine(windowsDir, "Minidump"),
+                    Path.Combine(windowsDir, "LiveKernelReports"),
+                ],
+                FilePatterns: ["*.dmp"],
+                IsDestructiveHint: true),
+
+            new("Explorer thumbnail & icon cache",
+                "The picture previews and icons Windows keeps so folders open quickly. It rebuilds them as you "
+                + "browse, and clearing them is the standard fix for thumbnails that show the wrong picture or "
+                + "come up blank.",
+                [Path.Combine(localAppData, "Microsoft", "Windows", "Explorer")],
+                FilePatterns: ["thumbcache_*.db", "iconcache_*.db"]),
 
             new("Old Windows servicing logs (> 30 days)",
                 "CBS logs older than 30 days. Windows keeps rolling ones itself.",
@@ -215,7 +247,7 @@ public sealed class DeepCleanupService
             var d = defs[i];
             progress?.Report(new ScanProgress(i + 1, total, d.Name));
 
-            var existing = d.Paths.Where(p => !string.IsNullOrEmpty(p) && Directory.Exists(p))
+            var existing = d.Paths.Where(p => !string.IsNullOrEmpty(p) && (Directory.Exists(p) || File.Exists(p)))
                                   .Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
 
             long size = 0; var files = 0; var skipped = 0;
@@ -224,7 +256,7 @@ public sealed class DeepCleanupService
             foreach (var p in existing)
             {
                 if (ct.IsCancellationRequested) break;
-                foreach (var file in EnumerateFiles(p, ct, SystemPaths.BundleExtractionRoot, SystemPaths.OwnExtractionDirectory))
+                foreach (var file in EnumerateTargets(p, d.FilePatterns, ct))
                 {
                     if (ct.IsCancellationRequested) break;
                     try
@@ -256,6 +288,10 @@ public sealed class DeepCleanupService
                 FileCount = files,
                 SkippedCount = skipped,
                 OlderThan = d.OlderThan,
+                // Carried on the category, not looked up from the definitions at clean time: Clean is
+                // handed categories by the caller and walks their Paths, so a filter it could not see
+                // would give the user an honest size on screen and a delete that took the whole folder.
+                FilePatterns = d.FilePatterns,
                 IsDestructiveHint = d.IsDestructiveHint,
                 IsRecycleBin = d.IsRecycleBin,
                 IsSelected = size > 0 && !d.IsDestructiveHint
@@ -374,14 +410,15 @@ public sealed class DeepCleanupService
             }
 
             var cutoff = cat.OlderThan.HasValue ? DateTime.UtcNow - cat.OlderThan.Value : (DateTime?)null;
+            var patterns = cat.FilePatterns?.ToArray();
             foreach (var path in cat.Paths)
             {
                 if (ct.IsCancellationRequested) break;
-                if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path)) continue;
+                if (string.IsNullOrWhiteSpace(path) || (!Directory.Exists(path) && !File.Exists(path))) continue;
 
                 try
                 {
-                    foreach (var file in EnumerateFiles(path, ct, SystemPaths.BundleExtractionRoot, SystemPaths.OwnExtractionDirectory))
+                    foreach (var file in EnumerateTargets(path, patterns, ct))
                     {
                         if (ct.IsCancellationRequested) break;
                         try
@@ -403,6 +440,10 @@ public sealed class DeepCleanupService
                             Log.Debug(ex, "Deep cleanup: failed to delete file {File}", file);
                         }
                     }
+                    // A filtered bucket owns files, not folders: the Explorer cache lives inside Explorer's
+                    // own working folder, and removing a directory there — which the bucket's scan never
+                    // counted — is outside what the user agreed to.
+                    if (patterns is not null) continue;
                     foreach (var dir in EnumerateDirectoriesDepthFirst(path, ct, SystemPaths.BundleExtractionRoot, SystemPaths.OwnExtractionDirectory))
                     {
                         try { Directory.Delete(dir, recursive: false); }
@@ -432,6 +473,58 @@ public sealed class DeepCleanupService
 
     private static long SafeLength(string path)
     { try { return new FileInfo(path).Length; } catch (IOException) { return 0; } catch (UnauthorizedAccessException) { return 0; } }
+
+    /// <summary>
+    /// Yields the files one <see cref="Def.Paths"/> entry stands for: the file itself when the entry names
+    /// a file, otherwise everything under it — in both cases narrowed to <paramref name="patterns"/> when
+    /// the definition set any.
+    /// </summary>
+    /// <remarks>
+    /// Two behaviours the bucket definitions need and the raw walk does not give. A path may be a FILE,
+    /// because <c>MEMORY.DMP</c> sits directly in <c>%WinDir%</c> and pointing the bucket at that folder
+    /// would walk all of Windows. And a walk may need narrowing, because
+    /// <c>%LOCALAPPDATA%\Microsoft\Windows\Explorer</c> holds the rebuildable thumbnail caches next to the
+    /// jump lists that are the user's recent-files history.
+    /// <para>Called by BOTH <see cref="Scan"/> and <see cref="Clean"/>, so the set of files a bucket
+    /// reports is by construction the set it deletes. That is the whole point of the helper: those were
+    /// two separate walks, and a filter added to one of them is a bucket that lies.</para>
+    /// </remarks>
+    private static IEnumerable<string> EnumerateTargets(string path, string[]? patterns, CancellationToken ct)
+    {
+        if (File.Exists(path) && !Directory.Exists(path))
+        {
+            // Guarded like a traversal root: a symlink here would make the caller delete its target,
+            // outside the bucket's tree. IsReparsePoint fails safe on an access error.
+            if (!IsReparsePoint(path) && Matches(path, patterns)) yield return path;
+            yield break;
+        }
+
+        foreach (var file in EnumerateFiles(path, ct, SystemPaths.BundleExtractionRoot, SystemPaths.OwnExtractionDirectory))
+        {
+            if (Matches(file, patterns)) yield return file;
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="path"/>'s file name matches one of <paramref name="patterns"/>, or when
+    /// the bucket set none — an unfiltered bucket owns everything under its paths.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="FileSystemName.MatchesSimpleExpression(ReadOnlySpan{char}, ReadOnlySpan{char}, bool)"/>
+    /// rather than a hand-rolled comparison, so <c>thumbcache_*.db</c> means here exactly what it means to
+    /// <c>Directory.EnumerateFiles</c>. Case-insensitive: NTFS is, and Windows writes <c>MEMORY.DMP</c>
+    /// upper-case while the pattern reads lower.
+    /// </remarks>
+    private static bool Matches(string path, string[]? patterns)
+    {
+        if (patterns is null || patterns.Length == 0) return true;
+        var name = Path.GetFileName(path.AsSpan());
+        foreach (var pattern in patterns)
+        {
+            if (FileSystemName.MatchesSimpleExpression(pattern, name, ignoreCase: true)) return true;
+        }
+        return false;
+    }
 
     /// <summary>
     /// Walks <paramref name="root"/> depth-first and yields every file under it, skipping reparse points
@@ -466,15 +559,22 @@ public sealed class DeepCleanupService
             try { files = Directory.EnumerateFiles(cur); } catch (IOException) { continue; } catch (UnauthorizedAccessException) { continue; }
             try { dirs = Directory.EnumerateDirectories(cur); } catch (IOException) { dirs = []; } catch (UnauthorizedAccessException) { dirs = []; }
 
-            // Wrap iteration to handle exceptions thrown during MoveNext()
-            // (e.g., file becomes inaccessible mid-enumeration).
+            // Wrap iteration because the enumerator can throw from MoveNext() rather than from the call
+            // above — a directory that stops being one mid-walk, or an entry that becomes unreadable.
+            //
+            // The throw ENDS this directory; it does not skip one entry. A throwing MoveNext leaves the
+            // enumerator terminal, so `continue` here re-threw the same exception forever and pinned a core
+            // in a loop cancellation cannot even reach (the ct check is on the outer loop). Measured, not
+            // reasoned: EnumerateFiles over a path that is a FILE returns fine, GetEnumerator returns fine,
+            // and MoveNext then threw IOException on all ten attempts without advancing once. `break` moves
+            // on to the next directory on the stack, which is the most this walk can honestly do.
             using var enumerator = files.GetEnumerator();
             while (true)
             {
                 string? item;
                 try { if (!enumerator.MoveNext()) break; item = enumerator.Current; }
-                catch (IOException) { continue; }
-                catch (UnauthorizedAccessException) { continue; }
+                catch (IOException) { break; }
+                catch (UnauthorizedAccessException) { break; }
                 yield return item;
             }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.92.0</Version>
-    <FileVersion>1.92.0.0</FileVersion>
-    <AssemblyVersion>1.92.0.0</AssemblyVersion>
+    <Version>1.93.0</Version>
+    <FileVersion>1.93.0.0</FileVersion>
+    <AssemblyVersion>1.93.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DeepCleanupViewModel.cs
@@ -35,10 +35,10 @@ public sealed partial class DeepCleanupViewModel : ViewModelBase
 
     /// <summary>Whether this session is elevated. Read by the shared <c>AdminBanner</c> from the DataContext.</summary>
     /// <remarks>
-    /// Five of the nineteen buckets live under <c>%WinDir%</c> — the Windows Update download cache, the
-    /// Delivery Optimization cache, the Installer patch cache, <c>Windows\Temp</c> and Prefetch — so an
-    /// unelevated run cannot delete them. It did not fail visibly either: the files landed in
-    /// <see cref="Models.CleanupCategory.SkippedCount"/> and the row read "N files · M skipped" without ever
+    /// Six of the buckets live under <c>%WinDir%</c> — the Windows Update download cache, the Delivery
+    /// Optimization cache, the Installer patch cache, <c>Windows\Temp</c>, Prefetch and the blue-screen
+    /// memory dumps — so an unelevated run cannot delete them. It did not fail visibly either: the files
+    /// landed in <see cref="Models.CleanupCategory.SkippedCount"/> and the row read "N files · M skipped" without ever
     /// saying that administrator rights were the reason, which is the one thing the user could have acted on.
     /// </remarks>
     [ObservableProperty] private bool _isElevated;

--- a/SysManager/SysManager/Views/DeepCleanupView.xaml
+++ b/SysManager/SysManager/Views/DeepCleanupView.xaml
@@ -20,12 +20,13 @@
                 <!-- Elevation. Directly under the header, which is where the golden admin-control contract
                      puts it on every other privileged tab, and Margin="0,12,0,0" because this is a
                      scrolling page whose StackPanel already carries the 28 gutter.
-                     Five of the nineteen buckets live under %WinDir% — the Windows Update download cache,
-                     Delivery Optimization, the Installer patch cache, Windows\Temp and Prefetch — and
-                     without admin they were silently counted as "skipped" with no stated reason. -->
+                     Six of the buckets live under %WinDir% — the Windows Update download cache, Delivery
+                     Optimization, the Installer patch cache, Windows\Temp, Prefetch and the blue-screen
+                     memory dumps — and without admin they were silently counted as "skipped" with no
+                     stated reason. -->
                 <v:AdminBanner Margin="0,12,0,0"
-                               NotElevatedMessage="Some of the biggest items — the Windows Update download cache, Delivery Optimization, the Installer patch cache, Windows\Temp and Prefetch — can only be deleted as administrator. They are still scanned and counted, and shown as skipped."
-                               ElevatedMessage="Running as administrator — the Windows Update, Delivery Optimization, Installer patch cache, Windows\Temp and Prefetch items can be deleted too."/>
+                               NotElevatedMessage="Some of the biggest items — the Windows Update download cache, Delivery Optimization, the Installer patch cache, Windows\Temp, Prefetch and the blue-screen memory dumps — can only be deleted as administrator. They are still scanned and counted, and shown as skipped."
+                               ElevatedMessage="Running as administrator — the Windows Update, Delivery Optimization, Installer patch cache, Windows\Temp, Prefetch and blue-screen memory dump items can be deleted too."/>
 
                 <!-- Safety note -->
                 <Border Style="{StaticResource Card}" Margin="0,16,0,0"


### PR DESCRIPTION
Closes #1577 (partially — the WinSxS component store half is deliberately not here; see below).

## What this adds

Two buckets, and the one schema change both of them needed.

**Blue-screen memory dumps** — `MEMORY.DMP`, `Windows\Minidump`, `Windows\LiveKernelReports`. `MEMORY.DMP` is sized to installed RAM, so on a machine that has crashed it is routinely the single largest reclaimable file on the drive, and nothing in the app looked at it. It follows the `Windows.old` precedent: offered with its size and file count, `IsDestructiveHint`, never pre-selected. Those dumps are the only record of why the machine crashed, and the description says so.

**Explorer thumbnail & icon cache** — `thumbcache_*.db` and `iconcache_*.db`. Windows rebuilds them, and clearing them is the standard fix for thumbnails that come up blank or show the wrong picture.

## Why the schema had to change

Neither bucket fits "every file under these directories".

`MEMORY.DMP` is a **file**, sitting directly in `%WinDir%`. The scan only considered paths `Directory.Exists` agreed with, so naming it would have been silently dropped — and naming its parent instead would walk all of Windows. A `Def` path may now name a file.

The Explorer folder is **Explorer's own working directory**. Alongside the rebuildable caches it holds `AutomaticDestinations` — the jump lists that are the user's recent-files history. So a bucket may now restrict itself to files matching a wildcard, via `FileSystemName.MatchesSimpleExpression` so a pattern means here what it means to `Directory.EnumerateFiles`.

The restriction is carried on the `CleanupCategory`, mirroring `OlderThan`, **not** looked up from the definitions at clean time. `Clean` is handed categories by the caller and walks their `Paths`; a filter it could not see would produce the worst available outcome — an honest size on screen and a delete that took the whole folder. Both sides now go through one helper, `EnumerateTargets`, so the set a bucket reports is by construction the set it deletes. A filtered bucket also leaves its emptied folders in place: it owns files, not the folder.

## The infinite loop this feature made reachable

The proof mutation that replaced the filtered call with the raw walk did not fail — it ran for **900 seconds** on a class that takes 0.24. That is a real defect in the walker, not a test artifact.

`EnumerateFiles` caught a throwing `MoveNext` and `continue`d, a shape written for "an entry becomes unreadable mid-enumeration". Measured with a standalone probe rather than reasoned about:

| path | `EnumerateFiles(...)` | `GetEnumerator()` | `MoveNext()` |
|---|---|---|---|
| missing directory | throws `DirectoryNotFoundException` | — | — |
| directory the user may not list | throws `UnauthorizedAccessException` | — | — |
| **a file** | returns | returns | throws `IOException` **10 times out of 10, never advancing** |

The first two throw from the call, where the existing `catch { continue; }` sits on the outer loop and continuing means "take the next directory off the stack" — real progress, and why an unelevated scan of Prefetch reports "skipped" rather than hanging. The third reaches the inner `while (true)`, where `continue` re-threw forever and pinned a core in a loop the cancellation token is never checked inside.

It stayed unreachable for exactly as long as both callers filtered their paths through `Directory.Exists`. This PR is what makes a file path legitimate, so it now abandons the directory instead. Minimal diff: two `continue`s became `break`s, and the comment says what was measured.

## Tests

11 behaviour tests over a temp tree the test owns (`TempCleanupRoots`, the `ICleanupRoots` seam from #2176), asserting Scan and Clean filter **independently** — they are two code paths and a filter in one of them is a bucket that lies. Plus two guards.

Red-before, green-after: 10 of the 11 failed with "no category named …" against the unfixed code; the 11th passed and is there to pin the behaviour every *unfiltered* bucket relies on (emptied folders still get removed).

Every guard assertion was proven red by mutation, each reverted byte-for-byte:

| mutation | what went red |
|---|---|
| `Matches` returns true for everything | 2 scan tests + the Clean jump-list test |
| Scan stops copying the filter onto the category | guard + 2 bucket tests |
| Clean stops reading the filter off the category | guard + 2 bucket tests |
| Scan walks files directly, past the filter | guard (`raw EnumerateFiles walk 3 times`) |
| the dir-delete gate inverted | both the filtered **and** the unfiltered folder test |
| the retry restored (`break` → `continue`) | `TheCleanupWalk_AbandonsADirectoryWhoseEnumeratorThrows` |

The walker guard is a source guard on purpose: a spin fails no assertion, it just never returns, so nothing else would catch its return.

`EveryTempTreeWalkerCall_PassesBothExtractionExclusions`' vacuity floor moves 7 → 6. Two direct walks became one; the population shrank, the pattern did not stop matching, and the comment records which.

## Verification

- All four projects: **0 errors, 0 warnings**.
- Unit suite: **5493 passed, 0 failed** (5480 → 5493: 11 behaviour tests + 2 guards).
- `dotnet format --verify-no-changes`: clean on both projects (exit 0, captured without a pipe masking it).
- Full local pre-commit scan against all 43 current patterns: 3 pre-existing matches, every one of them a legitimate product string that predates this branch. Nothing from this diff.
- Docs in this same PR: README (the six `%WinDir%` buckets, and both new buckets with what is *not* deleted), ARCHITECTURE (the `FilePatterns` contract under the Deep Cleanup guardrails), CHANGELOG, and the elevation banner copy — five → six, the dumps being the sixth.

## Deliberately not here

#1577 also asks for the **WinSxS component store**, and its own text is right that it must not be a file bucket — deleting WinSxS files directly corrupts servicing. That half is a `DISM /Online /Cleanup-Image /AnalyzeComponentStore` report followed by an opt-in `/StartComponentCleanup`, which belongs next to the existing SFC/DISM controls in Quick Cleanup rather than in this bucket list. Separate change, separate risk profile: a 10–30 minute operation that cannot be cancelled cleanly mid-servicing.
