### PR TITLE
feat: report the component store before offering to clean it

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -852,6 +852,14 @@ tab cannot ship a refresh or cancel button the keyboard cannot reach.
   runner, so a `SystemModification` `OperationLockService` lock prevents running
   them (or other system-repair operations) concurrently — starting one while the
   other runs is refused with a status message.
+- The two component-store operations join that set under one `IsStoreRunning` flag and
+  the same lock. They are **two commands over one flag on purpose**: `AnalyzeComponentStore`
+  is read-only and always available, while `CleanComponentStore` additionally requires
+  `CanCleanStore`, which only a completed analysis that Windows itself recommended can set —
+  and which a completed cleanup clears again, because the analysis it was based on is then
+  stale. `/ResetBase` is never passed (it discards the ability to uninstall installed
+  updates), and `NoComponentStoreCall_PassesResetBase_AndBothCommandsAreBound` enforces both
+  that and the presence of the bindings.
 
 ## Safety guardrails (Deep Cleanup)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.94.0] - 2026-09-11
+
+**Quick Cleanup can now reclaim the several gigabytes Windows keeps in its component store — and it tells
+you the number before it touches anything.** WinSxS is where Windows stores the older versions of its own
+components, and on a machine that has been updated for a few years it routinely holds five to ten
+gigabytes. It is also where the free editions of the mainstream cleaners find their biggest headline
+figure, and they generally remove it on a single click without saying what it costs. "Check component
+store" runs a read-only analysis and reports what Windows itself considers reclaimable; only then does
+"Clean up component store" become clickable, and only behind a confirmation that states plainly what you
+give up: after a cleanup, updates already installed can no longer be uninstalled.
+
+### Added
+
+- **Check component store** — read-only `DISM /AnalyzeComponentStore`, reporting the size Windows reports
+  and whether Windows recommends a cleanup. "No cleanup needed" is a real answer and is shown as one,
+  rather than leaving a button that would spend half an hour reclaiming nothing.
+- **Clean up component store** — `DISM /StartComponentCleanup`, disabled until an analysis has recommended
+  it, confirmed before it starts, and recorded in the activity log. `/ResetBase` is never used: it
+  reclaims a little more and permanently discards update uninstallation, which is not a trade a cleanup
+  button may make for you. A test makes it impossible to add by accident.
+
+### Changed
+
+- The Repair Windows description now covers all four operations, including what cleaning up the component
+  store costs.
+
 ## [1.93.0] - 2026-09-11
 
 **Deep Cleanup can now find the biggest file on a PC that has blue-screened.** When Windows crashes it

--- a/README.md
+++ b/README.md
@@ -443,6 +443,14 @@ a confirmation before it runs:
 - Empty the Recycle Bin
 - Run `SFC /scannow` and `DISM /RestoreHealth` in the background — keep
   using the app while they grind
+- **Component store (WinSxS), reported before it is touched.** WinSxS routinely holds
+  several gigabytes of superseded Windows components, and it is where the free editions of
+  the mainstream cleaners find their biggest number. "Check component store" runs the
+  read-only `DISM /AnalyzeComponentStore` and tells you what Windows itself says is
+  reclaimable; only then does "Clean up component store" become clickable, and only behind
+  a confirmation that states the cost — after a cleanup, updates already installed can no
+  longer be uninstalled. `/ResetBase` is never used, and a test makes it impossible to add
+  by accident
 
 ### Deep Cleanup
 - **Scan-first**: every category is discovered with size + file count

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.93.x   | :white_check_mark: |
-| < 1.93   | :x:                |
+| 1.94.x   | :white_check_mark: |
+| < 1.94   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -10752,6 +10752,51 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// No component-store call may pass <c>/ResetBase</c>, and both component-store commands must be bound
+    /// to a control.
+    /// </summary>
+    /// <remarks>
+    /// <c>/StartComponentCleanup /ResetBase</c> reclaims more, and also permanently discards the ability to
+    /// uninstall every update currently installed. That is not a trade a cleanup button may make on the
+    /// user's behalf, and it differs from the safe form by one appended word — so it is banned mechanically
+    /// rather than left to whoever next edits the argument string. #1577 names it as the irreversible
+    /// variant for exactly this reason.
+    /// <para>The binding half is this codebase's dominant recurring defect: a command implemented and
+    /// unit-tested while nothing in the XAML invokes it. Both halves are checked here because they fail the
+    /// same way — the feature looks present, and no compiler or view-model test can see that it is not.
+    /// <c>CleanComponentStore</c> is the one that matters: it is gated on <c>CanCleanStore</c>, so a missing
+    /// binding would leave the analysis reporting a size the user can never act on.</para>
+    /// </remarks>
+    [Fact]
+    public void NoComponentStoreCall_PassesResetBase_AndBothCommandsAreBound()
+    {
+        var vmPath = Path.Combine(FindAppProjectDir(), "ViewModels", "CleanupViewModel.cs");
+        Assert.True(File.Exists(vmPath), $"CleanupViewModel.cs was not found at {vmPath}");
+        var vm = WithoutComments(File.ReadAllText(vmPath));
+
+        // Floor first: if the operations were removed or moved, everything below is about nothing.
+        Assert.True(vm.Contains("/Online /Cleanup-Image /StartComponentCleanup", StringComparison.Ordinal)
+                    && vm.Contains("/Online /Cleanup-Image /AnalyzeComponentStore", StringComparison.Ordinal),
+            "CleanupViewModel no longer contains both component-store DISM arguments. If they moved, move "
+            + "this guard with them — it is checking nothing where it is.");
+
+        Assert.False(vm.Contains("ResetBase", StringComparison.OrdinalIgnoreCase),
+            "a component-store call passes /ResetBase. It reclaims more and permanently discards the "
+            + "ability to uninstall every installed update, which a cleanup button must not decide for the "
+            + "user. Use /StartComponentCleanup on its own.");
+
+        var markup = WithoutXamlComments(
+            File.ReadAllText(Path.Combine(FindAppProjectDir(), "Views", "CleanupView.xaml")));
+        foreach (var command in new[] { "AnalyzeComponentStoreCommand", "CleanComponentStoreCommand" })
+        {
+            Assert.True(markup.Contains($"{{Binding {command}}}", StringComparison.Ordinal),
+                $"{command} is implemented but no control in CleanupView invokes it, so the feature ships "
+                + "unreachable. Nothing else catches this: the compiler cannot see a XAML binding that is "
+                + "absent, and a view-model test executes the command directly.");
+        }
+    }
+
+    /// <summary>
     /// The cleanup walk must ABANDON a directory whose enumerator throws, not retry it. A throwing
     /// <c>MoveNext</c> does not advance, so retrying it is an infinite loop.
     /// </summary>

--- a/SysManager/SysManager.Tests/ComponentStoreCleanupTests.cs
+++ b/SysManager/SysManager.Tests/ComponentStoreCleanupTests.cs
@@ -1,0 +1,342 @@
+// SysManager · ComponentStoreCleanupTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using NSubstitute;
+using SysManager.Helpers;
+using SysManager.Services;
+using SysManager.ViewModels;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// The two component-store operations (#1577): what the analysis decides, and the gates standing between
+/// the user and the cleanup.
+/// </summary>
+/// <remarks>
+/// WinSxS is the one Deep Cleanup target that must not be touched as files — deleting component-store files
+/// directly corrupts servicing — so this goes through DISM, which makes the interesting logic the parsing
+/// and the gating rather than any traversal.
+/// <para>The single most important assertion in the file is that the analysis is what enables the cleanup.
+/// The mainstream cleaners run component cleanup as one opaque click; the value here is that the read-only
+/// report comes first and states the cost, and a cleanup button that were clickable without it would erase
+/// exactly that difference.</para>
+/// </remarks>
+[Collection("ProcessWideStatics")]
+public sealed class ComponentStoreCleanupTests
+{
+    /// <summary>What `/AnalyzeComponentStore` prints on a machine where a cleanup is worth doing.</summary>
+    private static string[] RecommendedOutput() =>
+    [
+        "Deployment Image Servicing and Management tool",
+        "Version: 10.0.26100.1",
+        "Component Store (WinSxS) Information:",
+        "Windows Explorer Reported Size of Component Store : 8.19 GB",
+        "Actual Size of Component Store : 7.90 GB",
+        "    Shared with Windows : 5.99 GB",
+        "    Backups and Disabled Features : 1.35 GB",
+        "    Cache and Temporary Data : 556.00 MB",
+        "Date of Last Cleanup : 2026-08-01 03:12:44",
+        "Number of Reclaimable Packages : 12",
+        "Component Store Cleanup Recommended : Yes",
+        "The operation completed successfully.",
+    ];
+
+    private static string[] NotRecommendedOutput() =>
+    [
+        "Component Store (WinSxS) Information:",
+        "Actual Size of Component Store : 6.11 GB",
+        "Number of Reclaimable Packages : 0",
+        "Component Store Cleanup Recommended : No",
+        "The operation completed successfully.",
+    ];
+
+    private static CleanupViewModel NewVm(IPowerShellRunner? runner = null)
+        => new(runner ?? Substitute.For<IPowerShellRunner>(), Substitute.For<ICleanupPreScanService>());
+
+    // ── What the analysis decides ────────────────────────────────────────────
+
+    [Fact]
+    public void Analysis_WhenWindowsRecommendsCleanup_SaysSoAndUnlocksIt()
+    {
+        var (verdict, color, recommended) =
+            CleanupViewModel.ParseComponentStoreResult(RecommendedOutput(), 0, analyzing: true);
+
+        Assert.True(recommended);
+        Assert.Equal(StatusColors.Warning, color);
+        Assert.Contains("recommends", verdict, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The size is quoted from Windows' own "Actual Size of Component Store", not computed — showing a
+    /// saving this app cannot promise would be worse than showing none.
+    /// </summary>
+    [Fact]
+    public void Analysis_QuotesTheSizeWindowsReported()
+    {
+        var (verdict, _, _) =
+            CleanupViewModel.ParseComponentStoreResult(RecommendedOutput(), 0, analyzing: true);
+
+        Assert.Contains("7.90 GB", verdict, StringComparison.Ordinal);
+        // Not the Explorer-reported size, which is a different (larger) number on the same output.
+        Assert.DoesNotContain("8.19 GB", verdict, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// "No" is a real and common answer. A store already cleaned must not present a button that would
+    /// spend half an hour reclaiming nothing.
+    /// </summary>
+    [Fact]
+    public void Analysis_WhenNoCleanupIsNeeded_SaysSoAndLeavesItLocked()
+    {
+        var (verdict, color, recommended) =
+            CleanupViewModel.ParseComponentStoreResult(NotRecommendedOutput(), 0, analyzing: true);
+
+        Assert.False(recommended);
+        Assert.Equal(StatusColors.Good, color);
+        Assert.Contains("No cleanup needed", verdict, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("6.11 GB", verdict, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Output DISM never printed must not unlock the cleanup. A localised machine prints its own wording,
+    /// and defaulting to "recommended" there would offer a destructive operation on no evidence at all.
+    /// </summary>
+    [Fact]
+    public void Analysis_WhenTheOutputSaysNeither_LeavesTheCleanupLocked()
+    {
+        var (_, _, recommended) = CleanupViewModel.ParseComponentStoreResult(
+            ["Komponentenspeicher (WinSxS)-Informationen:", "Der Vorgang wurde erfolgreich beendet."],
+            0, analyzing: true);
+
+        Assert.False(recommended);
+    }
+
+    [Fact]
+    public void Analysis_WithNoSizeInTheOutput_OmitsItRatherThanInventingOne()
+    {
+        var (verdict, _, recommended) = CleanupViewModel.ParseComponentStoreResult(
+            ["Component Store Cleanup Recommended : Yes"], 0, analyzing: true);
+
+        Assert.True(recommended);
+        Assert.DoesNotContain("holds", verdict, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Analysis_WithANonZeroExitAndNoVerdictLine_ReportsTheExitCode()
+    {
+        var (verdict, color, recommended) =
+            CleanupViewModel.ParseComponentStoreResult(["Error: 87"], 87, analyzing: true);
+
+        Assert.False(recommended);
+        Assert.Equal(StatusColors.Warning, color);
+        Assert.Contains("87", verdict, StringComparison.Ordinal);
+    }
+
+    // ── What the cleanup reports ─────────────────────────────────────────────
+
+    /// <summary>
+    /// A completed CLEANUP never leaves the button enabled: the analysis it was based on is now stale, and
+    /// offering another run on the strength of it would quote a size that no longer exists.
+    /// </summary>
+    [Fact]
+    public void Cleanup_HoweverItEnds_NeverReportsThatAnotherCleanupIsRecommended()
+    {
+        foreach (var (lines, exit) in new (string[], int)[]
+        {
+            (["The operation completed successfully."], 0),
+            (["Error: 0x800f081f"], 2),
+            ([], 0),
+        })
+        {
+            var (_, _, recommended) = CleanupViewModel.ParseComponentStoreResult(lines, exit, analyzing: false);
+            Assert.False(recommended);
+        }
+    }
+
+    [Fact]
+    public void Cleanup_WhenItSucceeds_SaysTheSpaceIsFree()
+    {
+        var (verdict, color, _) = CleanupViewModel.ParseComponentStoreResult(
+            ["The operation completed successfully."], 0, analyzing: false);
+
+        Assert.Equal(StatusColors.Good, color);
+        Assert.Contains("free", verdict, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Cleanup_WithANonZeroExit_ReportsTheExitCode()
+    {
+        var (verdict, color, _) = CleanupViewModel.ParseComponentStoreResult(
+            ["Error: 0x800f081f"], 2, analyzing: false);
+
+        Assert.Equal(StatusColors.Warning, color);
+        Assert.Contains("2", verdict, StringComparison.Ordinal);
+    }
+
+    // ── The gates between the user and the cleanup ───────────────────────────
+
+    [Fact]
+    public void TheCleanupCommand_IsNotClickableBeforeAnAnalysisRecommendsIt()
+    {
+        var vm = NewVm();
+
+        Assert.False(vm.CleanComponentStoreCommand.CanExecute(null));
+        Assert.True(vm.AnalyzeComponentStoreCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void TheCleanupCommand_BecomesClickableOnceAnAnalysisRecommendsIt()
+    {
+        var vm = NewVm();
+        vm.CanCleanStore = true;
+
+        Assert.True(vm.CleanComponentStoreCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void NeitherOperation_IsClickableWhileOneIsRunning()
+    {
+        var vm = NewVm();
+        vm.CanCleanStore = true;
+        vm.IsStoreRunning = true;
+
+        Assert.False(vm.AnalyzeComponentStoreCommand.CanExecute(null));
+        Assert.False(vm.CleanComponentStoreCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task Analyze_WhenNotElevated_DoesNotReachTheRunner()
+    {
+        using var notElevated = AdminHelper.ForceElevation(false);
+        var runner = Substitute.For<IPowerShellRunner>();
+        var vm = NewVm(runner);
+        Assert.False(vm.IsElevated, "the scope must reach the view-model's constructor");
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);   // decline the restart
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.AnalyzeComponentStoreCommand.ExecuteAsync(null);
+
+            Assert.Contains("admin", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+            await runner.DidNotReceive().RunProcessAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>(), Arg.Any<System.Text.Encoding?>());
+            Assert.False(vm.IsStoreRunning);
+        }
+        finally { DialogService.Instance = prevDialog; }
+    }
+
+    /// <summary>
+    /// The mirror image: elevated, the analysis must actually reach DISM — and with the READ-ONLY argument.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_WhenElevated_RunsTheReadOnlyAnalysis()
+    {
+        using var elevated = AdminHelper.ForceElevation(true);
+        var runner = Substitute.For<IPowerShellRunner>();
+        var vm = NewVm(runner);
+        Assert.True(vm.IsElevated);
+
+        await vm.AnalyzeComponentStoreCommand.ExecuteAsync(null);
+
+        await runner.Received(1).RunProcessAsync(
+            "DISM.exe", "/Online /Cleanup-Image /AnalyzeComponentStore",
+            Arg.Any<CancellationToken>(), Arg.Any<System.Text.Encoding?>());
+    }
+
+    /// <summary>
+    /// Declining the confirmation must not run the cleanup. This is the last gate before something
+    /// irreversible, so it is asserted on the runner and not only on the status message.
+    /// </summary>
+    [Fact]
+    public async Task Clean_WhenTheUserDeclinesTheConfirmation_RunsNothing()
+    {
+        using var elevated = AdminHelper.ForceElevation(true);
+        var runner = Substitute.For<IPowerShellRunner>();
+        var vm = NewVm(runner);
+        vm.CanCleanStore = true;
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.CleanComponentStoreCommand.ExecuteAsync(null);
+
+            dialog.Received(1).Confirm(Arg.Any<string>(), Arg.Any<string>());
+            await runner.DidNotReceive().RunProcessAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>(), Arg.Any<System.Text.Encoding?>());
+        }
+        finally { DialogService.Instance = prevDialog; }
+    }
+
+    /// <summary>
+    /// Confirming runs `/StartComponentCleanup` — and the assertion is on the exact argument string,
+    /// because the one variant that must never appear (`/ResetBase`) differs from it by a suffix.
+    /// </summary>
+    [Fact]
+    public async Task Clean_WhenTheUserConfirms_RunsStartComponentCleanupAndNothingElse()
+    {
+        using var elevated = AdminHelper.ForceElevation(true);
+        var runner = Substitute.For<IPowerShellRunner>();
+        var vm = NewVm(runner);
+        vm.CanCleanStore = true;
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        dialog.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.CleanComponentStoreCommand.ExecuteAsync(null);
+
+            await runner.Received(1).RunProcessAsync(
+                "DISM.exe", "/Online /Cleanup-Image /StartComponentCleanup",
+                Arg.Any<CancellationToken>(), Arg.Any<System.Text.Encoding?>());
+        }
+        finally { DialogService.Instance = prevDialog; }
+    }
+
+    /// <summary>
+    /// The confirmation has to say what is given up, not merely ask. "Are you sure?" on an operation whose
+    /// cost is "you can no longer uninstall your updates" is not consent.
+    /// </summary>
+    [Fact]
+    public async Task Clean_TheConfirmation_StatesWhatTheUserGivesUp()
+    {
+        using var elevated = AdminHelper.ForceElevation(true);
+        var vm = NewVm();
+        vm.CanCleanStore = true;
+
+        var prevDialog = DialogService.Instance;
+        var dialog = Substitute.For<IDialogService>();
+        string? shown = null;
+        dialog.Confirm(Arg.Do<string>(m => shown = m), Arg.Any<string>()).Returns(false);
+        DialogService.Instance = dialog;
+        try
+        {
+            await vm.CleanComponentStoreCommand.ExecuteAsync(null);
+
+            Assert.NotNull(shown);
+            Assert.Contains("uninstall", shown!, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("10 to 30 minutes", shown!, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { DialogService.Instance = prevDialog; }
+    }
+
+    [Fact]
+    public void AStoreOperation_CountsAsAnyRunning_SoCancelIsEnabled()
+    {
+        var vm = NewVm();
+        Assert.False(vm.IsAnyRunning);
+
+        vm.IsStoreRunning = true;
+
+        Assert.True(vm.IsAnyRunning);
+        Assert.True(vm.CancelCommand.CanExecute(null));
+    }
+}

--- a/SysManager/SysManager.Tests/UiAutomationContractTests.cs
+++ b/SysManager/SysManager.Tests/UiAutomationContractTests.cs
@@ -19,6 +19,8 @@ public partial class UiAutomationContractTests
             ["btn-cleanup-empty-recycle-bin"] = "Empty Recycle Bin",
             ["btn-cleanup-sfc"] = "SFC /scannow — run SFC system file check",
             ["btn-cleanup-dism"] = "Run DISM RestoreHealth",
+            ["btn-cleanup-analyze-store"] = "Check component store — report what Windows considers reclaimable",
+            ["btn-cleanup-clean-store"] = "Clean up component store — remove the superseded components Windows keeps",
             ["btn-cleanup-cancel"] = "Cancel the running operation",
             ["btn-system-health-scan"] = "Scan system health",
             ["btn-system-health-smart"] = "Run SMART check — disk health",

--- a/SysManager/SysManager.UITests/OtherTabsUiTests.cs
+++ b/SysManager/SysManager.UITests/OtherTabsUiTests.cs
@@ -45,6 +45,33 @@ public class OtherTabsUiTests
     }
 
     [Fact]
+    public void Cleanup_AnalyzeComponentStoreButton_Exists()
+    {
+        _fx.GoToTab("nav-cleanup");
+        Assert.NotNull(_fx.FindButtonById("btn-cleanup-analyze-store"));
+    }
+
+    /// <summary>
+    /// Present, and DISABLED until an analysis has reported that a cleanup is worth doing.
+    /// </summary>
+    /// <remarks>
+    /// The safety property of the whole feature, and the only place it is observable end to end. Component
+    /// cleanup permanently removes the ability to uninstall installed updates, so it must not be reachable
+    /// before the read-only analysis has said what there is to gain — and on a freshly launched app no
+    /// analysis has run. Asserted without clicking anything: no DISM is started by this test.
+    /// </remarks>
+    [Fact]
+    public void Cleanup_CleanComponentStoreButton_StartsDisabledUntilAnalysed()
+    {
+        _fx.GoToTab("nav-cleanup");
+        var button = _fx.FindButtonById("btn-cleanup-clean-store");
+        Assert.NotNull(button);
+        Assert.False(button!.IsEnabled,
+            "the component-store cleanup is clickable with no analysis behind it, so the user can start an "
+            + "irreversible operation without being told what it reclaims or what it costs.");
+    }
+
+    [Fact]
     public void Cleanup_CancelButton_Exists()
     {
         _fx.GoToTab("nav-cleanup");

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.93.0</Version>
-    <FileVersion>1.93.0.0</FileVersion>
-    <AssemblyVersion>1.93.0.0</AssemblyVersion>
+    <Version>1.94.0</Version>
+    <FileVersion>1.94.0.0</FileVersion>
+    <AssemblyVersion>1.94.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/CleanupViewModel.cs
+++ b/SysManager/SysManager/ViewModels/CleanupViewModel.cs
@@ -29,10 +29,13 @@ public sealed partial class CleanupViewModel : ViewModelBase
     private readonly EtaCalculator _sfcEta = new();
     private readonly EtaCalculator _dismEta = new();
 
+    private readonly EtaCalculator _storeEta = new();
+
     private CancellationTokenSource? _tempCts;
     private CancellationTokenSource? _binCts;
     private CancellationTokenSource? _sfcCts;
     private CancellationTokenSource? _dismCts;
+    private CancellationTokenSource? _storeCts;
 
     // Temp Cleanup, SFC, and DISM all stream through the single shared _runner and its
     // LineReceived/ProgressChanged events into the one Console, so only one may run at a
@@ -53,6 +56,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
     [ObservableProperty] private bool _isBinRunning;
     [ObservableProperty] private bool _isSfcRunning;
     [ObservableProperty] private bool _isDismRunning;
+    [ObservableProperty] private bool _isStoreRunning;
 
     [ObservableProperty] private string _sfcStatus = "Idle";
     [ObservableProperty] private string _sfcVerdict = "";
@@ -61,15 +65,34 @@ public sealed partial class CleanupViewModel : ViewModelBase
     [ObservableProperty] private string _dismVerdict = "";
     [ObservableProperty] private string _dismVerdictColorHex = StatusColors.Neutral;
 
+    [ObservableProperty] private string _storeStatus = "Idle";
+    [ObservableProperty] private string _storeVerdict = "";
+    [ObservableProperty] private string _storeVerdictColorHex = StatusColors.Neutral;
+
+    /// <summary>
+    /// True once an analysis has reported that Windows itself considers a cleanup worthwhile — which is
+    /// what enables the button that actually performs one.
+    /// </summary>
+    /// <remarks>
+    /// The whole point of splitting this into two steps. Every rival runs component cleanup as one opaque
+    /// click; here the read-only <c>/AnalyzeComponentStore</c> reports first, and the destructive
+    /// <c>/StartComponentCleanup</c> is not even clickable until it has. So the user is told what they
+    /// stand to reclaim, and what they give up, before anything is removed.
+    /// </remarks>
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(CleanComponentStoreCommand))]
+    private bool _canCleanStore;
+
     [ObservableProperty] private string _sfcEtaText = string.Empty;
     [ObservableProperty] private string _dismEtaText = string.Empty;
+    [ObservableProperty] private string _storeEtaText = string.Empty;
 
     // Pre-scan info so the tab doesn't look empty on first load
     [ObservableProperty] private string _tempSizeLabel = "Scanning…";
     [ObservableProperty] private string _recycleBinLabel = "Scanning…";
 
     /// <summary>True whenever any background task is running — for a small badge.</summary>
-    public bool IsAnyRunning => IsTempRunning || IsBinRunning || IsSfcRunning || IsDismRunning;
+    public bool IsAnyRunning => IsTempRunning || IsBinRunning || IsSfcRunning || IsDismRunning || IsStoreRunning;
 
     public CleanupViewModel(IPowerShellRunner runner, ICleanupPreScanService preScan)
     {
@@ -122,6 +145,8 @@ public sealed partial class CleanupViewModel : ViewModelBase
             _sfcCts?.Dispose();
             _dismCts?.Cancel();
             _dismCts?.Dispose();
+            _storeCts?.Cancel();
+            _storeCts?.Dispose();
         }
         base.Dispose(disposing);
     }
@@ -171,6 +196,14 @@ public sealed partial class CleanupViewModel : ViewModelBase
     partial void OnIsBinRunningChanged(bool value) => OnAnyRunningChanged();
     partial void OnIsSfcRunningChanged(bool value) => OnAnyRunningChanged();
     partial void OnIsDismRunningChanged(bool value) => OnAnyRunningChanged();
+    partial void OnIsStoreRunningChanged(bool value)
+    {
+        OnAnyRunningChanged();
+        // Analyse and clean are separate commands over one running flag, so both re-evaluate:
+        // neither may be clickable a second time while the other is mid-flight.
+        AnalyzeComponentStoreCommand.NotifyCanExecuteChanged();
+        CleanComponentStoreCommand.NotifyCanExecuteChanged();
+    }
 
     private void OnAnyRunningChanged()
     {
@@ -183,8 +216,9 @@ public sealed partial class CleanupViewModel : ViewModelBase
         IsBusy = IsAnyRunning;
         // Temp and Recycle-Bin cleanup report no percentage, but SFC/DISM do (via the runner's
         // ProgressChanged → Progress). Marquee only when nothing is reporting a real number,
-        // otherwise the determinate value would be ignored.
-        IsProgressIndeterminate = IsAnyRunning && !(IsSfcRunning || IsDismRunning);
+        // otherwise the determinate value would be ignored. The component-store operations are
+        // DISM too and report the same decimal percentage, so they count as determinate here.
+        IsProgressIndeterminate = IsAnyRunning && !(IsSfcRunning || IsDismRunning || IsStoreRunning);
     }
 
     [RelayCommand]
@@ -508,6 +542,192 @@ public sealed partial class CleanupViewModel : ViewModelBase
             : ($"DISM finished with exit code {exitCode}. Check the console output for details.", StatusColors.Warning);
     }
 
+    // ---------- component store (WinSxS) ----------
+
+    /// <summary>
+    /// Asks DISM what the component store holds and whether it thinks a cleanup is worth doing. Read-only.
+    /// </summary>
+    /// <remarks>
+    /// WinSxS routinely holds several gigabytes of superseded components, and it is the one place the free
+    /// editions of the mainstream cleaners beat this app on the headline number. They also run the cleanup
+    /// as a single opaque click. This reports first — Windows' own numbers, with the cost stated — and
+    /// leaves the removal to a second, separate press.
+    /// <para>Never given <c>/ResetBase</c>: that variant also discards the ability to uninstall installed
+    /// updates, which is not something a cleanup button may decide on the user's behalf. Enforced by
+    /// <c>NoComponentStoreCall_PassesResetBase</c> rather than left to review.</para>
+    /// </remarks>
+    [RelayCommand(CanExecute = nameof(CanRunStoreOp))]
+    private Task AnalyzeComponentStoreAsync()
+        => RunComponentStoreAsync("/Online /Cleanup-Image /AnalyzeComponentStore", analyzing: true);
+
+    /// <summary>Performs the cleanup the analysis reported, after an explicit confirmation.</summary>
+    [RelayCommand(CanExecute = nameof(CanCleanComponentStore))]
+    private async Task CleanComponentStoreAsync()
+    {
+        if (IsStoreRunning) return;
+
+        // Confirmed because it is not reversible in the way the rest of the tab is: superseded component
+        // versions are what get removed, and those are exactly what an update uninstall would roll back to.
+        if (!DialogService.Instance.Confirm(
+                "Windows will remove the superseded components it is keeping in the component store.\n\n"
+                + "What you give up: updates already installed can no longer be uninstalled afterwards. "
+                + "Nothing you have installed stops working, and no personal files are touched.\n\n"
+                + "This can take 10 to 30 minutes. Cancelling stops the process mid-way, which leaves "
+                + "Windows to finish the servicing transaction on its own — better to let it run.",
+                "Clean up the component store?"))
+        {
+            StatusMessage = "Component store cleanup cancelled.";
+            return;
+        }
+
+        await RunComponentStoreAsync("/Online /Cleanup-Image /StartComponentCleanup", analyzing: false);
+    }
+
+    /// <summary>Analyse and clean differ only in the DISM argument and the wording, so they share this.</summary>
+    private async Task RunComponentStoreAsync(string arguments, bool analyzing)
+    {
+        if (IsStoreRunning) return;
+        if (!AdminHelper.IsElevated())
+        {
+            if (!DialogService.Instance.Confirm(
+                "Working with the component store requires admin privileges. Restart the application with elevated privileges?",
+                "Admin Required"))
+            {
+                StatusMessage = "Component store check cancelled — admin privileges required.";
+                return;
+            }
+            if (AdminHelper.RelaunchAsAdmin()) App.RequestShutdown();
+            return;
+        }
+
+        // Same two guards as SFC/DISM, for the same two reasons: the SystemModification lock keeps the
+        // system-repair operations mutually exclusive, and _runnerBusy keeps anything else off the single
+        // shared runner whose LineReceived feeds the one Console.
+        using var opLock = OperationLockService.Instance.TryAcquire(
+            OperationCategory.SystemModification, analyzing ? "Component store analysis" : "Component store cleanup");
+        if (opLock is null)
+        {
+            StatusMessage = $"Cannot start — {OperationLockService.Instance.GetActiveOperationName(OperationCategory.SystemModification)} is already running.";
+            return;
+        }
+        if (!TryBeginConsoleOp())
+        {
+            StatusMessage = "Cannot start — a repair is already using the console. Wait for it to finish.";
+            return;
+        }
+
+        IsStoreRunning = true;
+        IsProgressIndeterminate = true;
+        StoreStatus = analyzing ? "Analysing — usually under a minute" : "Cleaning up — can take 10–30 minutes";
+        StoreVerdict = "";
+        StoreVerdictColorHex = StatusColors.Neutral;
+        StoreEtaText = string.Empty;
+        _storeEta.Reset();
+        StatusMessage = analyzing
+            ? "Analysing the component store. You can keep using the app."
+            : "Cleaning up the component store in the background. You can keep using the app.";
+        _storeCts?.Dispose();
+        _storeCts = new CancellationTokenSource();
+        var captured = new System.Collections.Generic.List<string>();
+        void Collect(PowerShellLine l)
+        {
+            if (l.Kind == OutputKind.Output) captured.Add(l.Text);
+            if (l.Text.Contains('%'))
+            {
+                var m = DismPercentRegex().Match(l.Text);
+                if (m.Success && double.TryParse(m.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var pct) && pct is >= 0 and <= 100)
+                {
+                    Progress = (int)pct;
+                    StoreEtaText = _storeEta.Update((int)pct);
+                    IsProgressIndeterminate = false;
+                }
+            }
+        }
+        _runner.LineReceived += Collect;
+        try
+        {
+            var exit = await _runner.RunProcessAsync("DISM.exe", arguments, _storeCts.Token, PowerShellRunner.OemEncoding);
+            var result = ParseComponentStoreResult(captured, exit, analyzing);
+            StoreVerdict = result.Verdict;
+            StoreVerdictColorHex = result.ColorHex;
+            StoreStatus = exit == 0 ? "Completed" : $"Finished (exit {exit})";
+            StatusMessage = result.Verdict;
+            // Only an analysis may enable the cleanup, and only when Windows said it is worth doing. A
+            // completed cleanup clears it: the analysis it was based on is now stale, and offering to
+            // clean again on the strength of it would report a size that no longer exists.
+            CanCleanStore = analyzing && result.CleanupRecommended;
+            if (!analyzing)
+            {
+                ActivityLogService.Instance.Log("Component store cleanup", result.Verdict);
+            }
+        }
+        catch (OperationCanceledException) { StoreStatus = "Cancelled."; StoreVerdict = analyzing ? "Analysis was cancelled." : "Cleanup was cancelled — Windows will finish the servicing transaction itself."; StoreVerdictColorHex = StatusColors.Neutral; StatusMessage = StoreStatus; }
+        catch (InvalidOperationException ex) { StoreStatus = $"Error: {ex.Message}"; StoreVerdict = ex.Message; StoreVerdictColorHex = StatusColors.Bad; StatusMessage = StoreStatus; }
+        catch (System.ComponentModel.Win32Exception ex) { StoreStatus = $"Error: {ex.Message}"; StoreVerdict = ex.Message; StoreVerdictColorHex = StatusColors.Bad; StatusMessage = StoreStatus; }
+        finally { _runner.LineReceived -= Collect; EndConsoleOp(); IsStoreRunning = false; IsProgressIndeterminate = false; StoreEtaText = string.Empty; }
+    }
+
+    /// <summary>Neither component-store operation may start while one is already running.</summary>
+    private bool CanRunStoreOp => !IsStoreRunning;
+
+    /// <summary>The cleanup additionally needs an analysis that recommended it.</summary>
+    private bool CanCleanComponentStore => !IsStoreRunning && CanCleanStore;
+
+    /// <summary>
+    /// Turns <c>/AnalyzeComponentStore</c> or <c>/StartComponentCleanup</c> output into a verdict, a colour,
+    /// and — for an analysis — whether the cleanup button should become available.
+    /// </summary>
+    /// <remarks>
+    /// Matches on the English phrases DISM prints, the same approach and the same limitation as
+    /// <see cref="ParseSfcResult"/> and <see cref="ParseDismResult"/>, with an exit-code fallback for
+    /// everything else. <c>Component Store Cleanup Recommended : No</c> is a real and common answer, and
+    /// saying so is more useful than an empty result — a store already cleaned should not present a button
+    /// that would spend half an hour reclaiming nothing.
+    /// <para>The reclaimable size is quoted from <c>Actual Size of Component Store</c> rather than computed.
+    /// Windows' own number is the honest one to show, and the alternative — subtracting "Shared with
+    /// Windows" — would state a saving this app cannot actually promise.</para>
+    /// </remarks>
+    internal static (string Verdict, string ColorHex, bool CleanupRecommended) ParseComponentStoreResult(
+        IReadOnlyList<string> lines, int exitCode, bool analyzing)
+    {
+        var all = string.Join(" ", lines);
+
+        if (!analyzing)
+        {
+            if (all.Contains("The operation completed successfully", StringComparison.OrdinalIgnoreCase))
+                return ("Component store cleaned up. The space Windows reported as reclaimable is now free.", StatusColors.Good, false);
+
+            return exitCode == 0
+                ? ("Component store cleanup finished.", StatusColors.Good, false)
+                : ($"Component store cleanup finished with exit code {exitCode}. Check the console output for details.", StatusColors.Warning, false);
+        }
+
+        var recommended = all.Contains("Component Store Cleanup Recommended : Yes", StringComparison.OrdinalIgnoreCase);
+        var notRecommended = all.Contains("Component Store Cleanup Recommended : No", StringComparison.OrdinalIgnoreCase);
+        var size = StoreSizeRegex().Match(all);
+        var sizeText = size.Success ? size.Groups[1].Value.Trim() : null;
+
+        if (recommended)
+        {
+            return (sizeText is null
+                    ? "Windows recommends cleaning up the component store."
+                    : $"Windows recommends cleaning up the component store, which currently holds {sizeText}.",
+                StatusColors.Warning, true);
+        }
+
+        if (notRecommended)
+        {
+            return (sizeText is null
+                    ? "No cleanup needed — Windows says the component store is already as small as it will get."
+                    : $"No cleanup needed — the component store holds {sizeText}, and Windows says none of it is worth reclaiming.",
+                StatusColors.Good, false);
+        }
+
+        return exitCode == 0
+            ? ("Analysis completed. Check the console output for what Windows reported.", StatusColors.Neutral, false)
+            : ($"Analysis finished with exit code {exitCode}. Check the console output for details.", StatusColors.Warning, false);
+    }
+
     [RelayCommand(CanExecute = nameof(IsAnyRunning))]
     private void Cancel()
     {
@@ -515,6 +735,7 @@ public sealed partial class CleanupViewModel : ViewModelBase
         _binCts?.Cancel();
         _sfcCts?.Cancel();
         _dismCts?.Cancel();
+        _storeCts?.Cancel();
     }
 
     // SFC reports progress as a whole-number percentage, e.g. "50 %".
@@ -524,4 +745,10 @@ public sealed partial class CleanupViewModel : ViewModelBase
     // DISM reports progress as a decimal percentage, e.g. "50.0%".
     [GeneratedRegex(@"([\d.]+)%")]
     private static partial Regex DismPercentRegex();
+
+    // "Actual Size of Component Store : 7.90 GB" — the size Windows itself reports, quoted rather than
+    // recomputed. Bounded to a number-and-unit so a localised or reworded line yields no match and the
+    // verdict simply omits the size, instead of quoting whatever followed the colon.
+    [GeneratedRegex(@"Actual Size of Component Store\s*:\s*([\d.,]+\s*[KMGT]?B)", RegexOptions.IgnoreCase)]
+    private static partial Regex StoreSizeRegex();
 }

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -65,7 +65,7 @@
 
                 <!-- Repair section — Windows system-file repairs, distinct from cleanup -->
                 <TextBlock Text="Repair Windows" Style="{StaticResource SectionTitle}" Margin="0,14,0,4"/>
-                <TextBlock Text="SFC /scannow checks Windows system files for corruption and repairs them. DISM /RestoreHealth repairs the Windows component store using Windows Update as a source. Both run in the background — you can keep using the app."
+                <TextBlock Text="SFC /scannow checks Windows system files for corruption and repairs them. DISM /RestoreHealth repairs the Windows component store using Windows Update as a source. Checking the component store reports how much of it Windows considers reclaimable, and cleaning it up removes the older component versions Windows keeps — after that, installed updates can no longer be uninstalled. All of these run in the background — you can keep using the app."
                            Style="{StaticResource Subtle}" Margin="0,0,0,10" TextWrapping="Wrap"/>
                 <WrapPanel Orientation="Horizontal">
                     <Button Content="SFC /scannow" Command="{Binding RunSfcCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
@@ -76,6 +76,16 @@
                             AutomationProperties.AutomationId="btn-cleanup-dism"
                             AutomationProperties.Name="Run DISM RestoreHealth"
                             IsEnabled="{Binding IsDismRunning, Converter={StaticResource BoolInvert}}"/>
+                    <!-- Two buttons, not one, and the second starts disabled: the analysis is read-only and
+                         its result is what enables the cleanup, so nothing is removed before the user has
+                         been told what it costs. Same SecondaryButton style and 0,0,8,8 spacing as SFC/DISM
+                         beside them. -->
+                    <Button Content="Check component store" Command="{Binding AnalyzeComponentStoreCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.AutomationId="btn-cleanup-analyze-store"
+                            AutomationProperties.Name="Check component store — report what Windows considers reclaimable"/>
+                    <Button Content="Clean up component store" Command="{Binding CleanComponentStoreCommand}" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8"
+                            AutomationProperties.AutomationId="btn-cleanup-clean-store"
+                            AutomationProperties.Name="Clean up component store — remove the superseded components Windows keeps"/>
                     <Button Content="Cancel" Command="{Binding CancelCommand}" Style="{StaticResource GhostButton}" Margin="0,0,8,8"
                             AutomationProperties.AutomationId="btn-cleanup-cancel"
                             AutomationProperties.Name="Cancel the running operation"/>
@@ -132,6 +142,29 @@
                         <TextBlock Text="{Binding DismVerdict}" TextWrapping="Wrap" VerticalAlignment="Center"
                                    AutomationProperties.LiveSetting="Polite"
                                    Foreground="{Binding DismVerdictColorHex, Converter={StaticResource HexBrush}}"/>
+                    </DockPanel>
+                </Border>
+                <StackPanel Orientation="Horizontal" Margin="0,6,0,0"
+                            Visibility="{Binding IsStoreRunning, Converter={StaticResource FlexVis}}">
+                    <Ellipse Width="10" Height="10" VerticalAlignment="Center" Margin="0,0,8,0" Fill="{DynamicResource Info}"/>
+                    <TextBlock Text="Component store — " Foreground="{DynamicResource Info}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding StoreStatus}" Foreground="{DynamicResource TextSecondary}" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding StoreEtaText}" Foreground="{DynamicResource TextMuted}" FontSize="11" Margin="8,0,0,0" VerticalAlignment="Center"
+                               Visibility="{Binding StoreEtaText, Converter={StaticResource FlexVis}}"/>
+                </StackPanel>
+                <!-- Component store verdict (shown after completion) -->
+                <Border Margin="0,8,0,0" Padding="12,10" CornerRadius="{StaticResource RadiusMd}"
+                        Background="{DynamicResource Surface1}"
+                        Visibility="{Binding StoreVerdict, Converter={StaticResource FlexVis}}">
+                    <!-- DockPanel for the same reason as the SFC verdict above, and it matters more here:
+                         this verdict names a size and what cleaning it up costs, so it is a long sentence. -->
+                    <DockPanel>
+                        <TextBlock Text="Component store:" DockPanel.Dock="Left" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextSecondary}"
+                                   VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <TextBlock Text="{Binding StoreVerdict}" TextWrapping="Wrap" VerticalAlignment="Center"
+                                   AutomationProperties.LiveSetting="Polite"
+                                   Foreground="{Binding StoreVerdictColorHex, Converter={StaticResource HexBrush}}"/>
                     </DockPanel>
                 </Border>
             </StackPanel>


### PR DESCRIPTION
Closes #1577 — the last of its three space hogs. The other two (blue-screen memory dumps, Explorer thumbnail cache) shipped in #2248 / v1.93.0.

## What this adds

WinSxS holds the older versions of Windows' own components, and on a machine that has been updated for a few years it routinely runs to five or ten gigabytes. It is where the free editions of CCleaner, Glary Utilities and Microsoft PC Manager find their biggest headline figure. Nothing in this app looked at it at all.

**Two commands, deliberately not one.**

| | |
|---|---|
| **Check component store** | Read-only `DISM /Online /Cleanup-Image /AnalyzeComponentStore`. Reports the size Windows itself reports and whether Windows recommends a cleanup. |
| **Clean up component store** | `/StartComponentCleanup`. Disabled until an analysis has recommended it, confirmed before it starts, logged to the activity log afterwards. |

The split is the whole point. The mainstream cleaners run component cleanup as one opaque click; here the read-only report comes first and states the cost, so the destructive step is not even clickable until the user has been told what they stand to reclaim and what they give up. `CanCleanStore` is set only by an analysis Windows recommended, and a completed cleanup clears it again — the analysis behind it is then stale, and offering another run would quote a size that no longer exists.

"Component Store Cleanup Recommended : **No**" is a real and common answer, and it is shown as one rather than leaving a button that would spend half an hour reclaiming nothing.

## Never `/ResetBase`

`/StartComponentCleanup /ResetBase` reclaims a little more and **permanently discards the ability to uninstall every currently installed update**. That is not a trade a cleanup button may make on the user's behalf. It differs from the safe form by one appended word, so `NoComponentStoreCall_PassesResetBase_AndBothCommandsAreBound` bans it mechanically rather than leaving it to whoever next edits the argument string.

## The size is quoted, not computed

DISM prints two sizes. The verdict quotes `Actual Size of Component Store`, not the larger `Windows Explorer Reported Size`, and not `Actual` minus `Shared with Windows` — that subtraction would state a saving this app cannot promise. If a localised or reworded line yields no match, the verdict simply omits the size instead of quoting whatever followed the colon. `Analysis_QuotesTheSizeWindowsReported` asserts both halves: the right number present, the wrong one absent.

## Nothing invented

Structure copied from the SFC and DISM RestoreHealth controls beside it: same `SystemModification` `OperationLockService` lock, same `TryBeginConsoleOp` shared-runner guard, same `PowerShellRunner.OemEncoding`, same `DismPercentRegex` for progress, same ETA and verdict shape, same `SecondaryButton` at `Margin="0,0,8,8"` in the same `WrapPanel`, same `DockPanel` verdict `Border` with `LiveSetting="Polite"`. One `IsStoreRunning` flag joins `IsAnyRunning`, so the existing Cancel button covers it too.

Cancellation kills the process, as it does for RestoreHealth — so the confirmation says plainly that it is better left to finish, and the cancelled verdict says Windows will complete the servicing transaction itself.

## Tests

18 over the parser and the gates, plus the guard, plus one UI test.

The UI test is the one worth calling out: it asserts the cleanup button is **disabled** on a freshly launched app. That is the safety property of the whole feature and the only place it is observable end to end — and it is asserted without clicking anything, so no DISM is started.

Seven mutations, each proven red, each reverted byte-for-byte:

| mutation | what went red |
|---|---|
| `/ResetBase` appended to the cleanup | the guard, **and** the exact-argument test |
| the cleanup button bound to something else | the guard's binding assertion |
| cleanup clickable with no analysis | `TheCleanupCommand_IsNotClickableBeforeAnAnalysisRecommendsIt` |
| analysis always reports "recommended" | 3 analysis tests |
| the confirmation gate removed | `Clean_WhenTheUserDeclinesTheConfirmation_RunsNothing` |
| size read from the Explorer-reported line | `Analysis_QuotesTheSizeWindowsReported` + 1 |

Every test in the class drives a substituted `IPowerShellRunner`, so no mutation here could start a real DISM.

## Three existing guards caught real mistakes

Worth recording, because all three are invisible to the compiler:

1. **WCAG 2.5.3** — my accessible names read "Check **the** component store …" while the buttons show "Check component store". Voice control could not have activated them by their visible label. Names now lead with the visible text.
2. **The UI-test contract map** — two new `btn-` AutomationIds must appear in `DescriptiveAccessibleNames` *and* be referenced by a `FindButtonById` call, or a button ships with an id no test drives.
3. **`ProcessWideStatics`** — the new class sets `DialogService.Instance` and forces elevation, so without `[Collection("ProcessWideStatics")]` it races the classes that do the same and can pass or fail for a foreign reason.

## Verification

- All four projects: **0 errors, 0 warnings**.
- Unit suite: **5512 passed, 0 failed** (5493 → 5512).
- `dotnet format --verify-no-changes`: clean on all three C# projects, exit code captured without a pipe masking it.
- Full local pre-commit scan against all 43 current patterns: **0 matches in the added lines**.
- Docs in this same PR: README (Quick Cleanup, including that `/ResetBase` is never used), ARCHITECTURE (the two-commands-one-flag contract and why the analysis gates the cleanup), CHANGELOG, SECURITY.md's supported line, and the Repair Windows description in the tab itself.
