### PR TITLE
feat: open the app on Cleanup instead of on twelve closed groups

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,12 @@ for the few entries whose view-model must exist at startup. Dashboard renders as
 Each group carries an icon, passed to `Group()` as a Segoe Fluent Icons code point and asserted distinct;
 leaves carry none, so the icon column belongs to the twelve headings rather than the fifty-eight pages.
 Collapsed groups show a child count badge, a written two-line subtitle passed to `Group()` and asserted to
-fit that budget, and a tooltip still generated from the child labels.
+fit that budget, and a tooltip still generated from the child labels. Exactly one group starts expanded —
+`InitiallyExpandedGroupId` (`grp-cleanup`) — set in the same loop that adds the groups; `#1519`'s arithmetic
+is why it is one and not two, and `ExactlyOneSidebarGroup_OpensWithTheApp` asserts all three of "the
+mechanism goes through the constant", "the constant names a group that exists", and "nothing else expands a
+group at startup". It costs no view-model: the child rows bind only `NavItem`'s own properties, none of
+which touches `Content`.
 `MainWindowViewModel.SelectedNav` mirrors selection into `NavItem.IsSelected`.
 `NavItem` also mirrors the tab's `IsBusy`, `Progress` and `IsProgressIndeterminate` out of its view-model,
 and `MainWindowViewModel.MapTaskbarProgress` turns the selected tab's pair into the Windows taskbar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.96.0] - 2026-09-11
+
+**The app now opens showing something you can actually use.** Every sidebar group used to start collapsed,
+so the first screen was twelve category names — System, Cleanup, Network, and so on — and not one feature.
+If you opened SysManager because your PC felt slow or your drive was full, nothing in front of you said so.
+Cleanup now opens with the app, putting Quick Cleanup, Deep Cleanup, Shortcut Cleaner and Scheduled
+Maintenance on screen from the first second.
+
+### Changed
+
+- **The Cleanup group starts open.** One group, not two: at a normal window size the twelve collapsed
+  groups already fill nearly the whole sidebar, so opening a second would push category names out of sight —
+  trading "no feature names visible" for "no categories visible". Opening Cleanup costs only the last two
+  headings, Info and Advanced.
+- Costs nothing at startup. Showing a group's rows does not build the tabs behind them; they are still
+  created the first time you actually open one.
+
 ## [1.95.0] - 2026-09-11
 
 **You can now see what the mouse is on.** The sidebar rows have no button chrome, so the faint tint that

--- a/README.md
+++ b/README.md
@@ -147,7 +147,11 @@ row and every group header is also keyboard-operable with a visible focus cue. A
 
 > 🔬 = Preview — fully implemented and usable, marked in-app while it settles in.
 
-Groups expand and collapse with a click. Collapsed groups show a child count
+Groups expand and collapse with a click. **Cleanup opens with the app** — every group
+used to start collapsed, so the first screen showed twelve category names and not one
+feature. Only one group opens, because the viewport has room for exactly one: at a
+820px window the twelve collapsed groups already fill almost all of it, so expanding a
+second pushes category headings out of sight. Collapsed groups show a child count
 badge, a written one-line summary of what the group covers, and a tooltip with the
 full list. Dashboard renders as a flat top-level entry without an expander arrow.
 Each tab shows a slim progress bar under its name when performing a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.95.x   | :white_check_mark: |
-| < 1.95   | :x:                |
+| 1.96.x   | :white_check_mark: |
+| < 1.96   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
+++ b/SysManager/SysManager.IntegrationTests/MainWindowViewModelTests.cs
@@ -394,12 +394,33 @@ public class MainWindowViewModelTests
             Assert.Same(fromGroups[i], vm.NavItems[i]);
     }
 
+    /// <summary>
+    /// Exactly ONE collapsible group starts expanded, and it is the one <c>InitiallyExpandedGroupId</c>
+    /// names. Every other one starts collapsed.
+    /// </summary>
+    /// <remarks>
+    /// This used to assert that ALL of them start collapsed, which was the state #1519 was about: the app
+    /// opened showing twelve category names and not one feature. One group now opens — and it has to be
+    /// one, because at 820px the twelve collapsed groups already fill 600 of a 670px viewport, so a second
+    /// pushes category headings below the fold.
+    /// <para>Asserted against the constant rather than the string, so the two cannot drift; and the count is
+    /// asserted as well as the identity, because "one is expanded" and "only one is expanded" are different
+    /// claims and the second is the one the viewport arithmetic depends on.</para>
+    /// <para>A constant naming a group that no longer exists fails here too, by expanding nothing — which is
+    /// worth stating because that failure is silent in the app: the sidebar simply opens as it used to.</para>
+    /// </remarks>
     [Fact]
-    public void NavGroups_CollapsibleGroupsStartCollapsed()
+    public void NavGroups_ExactlyTheCleanupGroupStartsExpanded()
     {
         var vm = new MainWindowViewModel();
+        var collapsible = vm.NavGroups.Where(group => !group.IsSingleItem).ToList();
+
+        var expanded = collapsible.Where(group => group.IsExpanded).ToList();
+
+        var only = Assert.Single(expanded);
+        Assert.Equal(MainWindowViewModel.InitiallyExpandedGroupId, only.Id);
         Assert.All(
-            vm.NavGroups.Where(group => !group.IsSingleItem),
+            collapsible.Where(group => group.Id != MainWindowViewModel.InitiallyExpandedGroupId),
             group => Assert.False(group.IsExpanded));
     }
 

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4323,56 +4323,37 @@ public partial class ArchitectureTests
     /// which is the intended prompt to either justify it in the list below or use <c>Tab&lt;TVm&gt;</c>.</para>
     /// </summary>
     /// <summary>
-    /// Exactly ONE sidebar group opens with the app, it is the one the constant names, and that constant
-    /// names a group that actually exists.
+    /// The startup expansion is driven by <c>InitiallyExpandedGroupId</c>, not by a repeated literal.
     /// </summary>
     /// <remarks>
-    /// The sidebar used to open with all twelve groups collapsed, so it showed twelve category headers and
-    /// not a single feature name (#1519). One group now starts open — and it has to be one, because the
-    /// viewport cannot hold more: at 820px the twelve collapsed groups already fill 600 of a 670px
-    /// viewport, so expanding a second pushes category headers below the fold. Expanding System as well
-    /// would cost nine of the twelve.
-    /// <para>Three separate failure modes, hence three assertions. A second expanded group is a UX
-    /// regression nothing else would catch. A constant naming a group id that was later renamed would
-    /// expand NOTHING, silently restoring the original complaint — the unreachable-surface defect this
-    /// codebase keeps producing. And a hardcoded literal in place of the constant would leave the two
-    /// halves free to drift.</para>
-    /// <para>Not a UI test, and not for lack of trying: <c>AppFixture</c> calls
-    /// <c>ExpandAllNavGroups()</c> during launch so that tests can find nav items directly, which destroys
-    /// the initial state before any test observes it. The shared fixture makes that unavoidable without a
-    /// second app launch, which is a lot of machinery for a one-line default.</para>
+    /// The BEHAVIOUR — exactly one collapsible group open, and it is that constant's group — is asserted in
+    /// <c>SysManager.IntegrationTests.MainWindowViewModelTests.NavGroups_ExactlyTheCleanupGroupStartsExpanded</c>,
+    /// which constructs a real <c>MainWindowViewModel</c> and is the stronger test. It also catches a
+    /// constant renamed to a group that no longer exists, by finding nothing expanded.
+    /// <para>What it cannot see is a hardcoded <c>"grp-cleanup"</c> in place of the constant: the app would
+    /// behave identically and the test would pass, while the constant the test itself reads and the value the
+    /// app uses were free to drift apart. That is the one thing left for a source check, so that is all this
+    /// asserts (#1519).</para>
+    /// <para>Worth recording that the first version of this guard asserted all three properties, because I
+    /// had concluded the behaviour was not testable — searching <c>SysManager.Tests</c> for
+    /// <c>new MainWindowViewModel</c> and finding nothing, without also searching the integration project,
+    /// where it is constructed eleven times. CI found the pre-existing
+    /// <c>NavGroups_CollapsibleGroupsStartCollapsed</c> by failing it.</para>
     /// </remarks>
     [Fact]
-    public void ExactlyOneSidebarGroup_OpensWithTheApp()
+    public void TheStartupExpansion_GoesThroughTheNamedConstant()
     {
         var path = Path.Combine(FindAppProjectDir(), "ViewModels", "MainWindowViewModel.cs");
         var source = WithoutComments(File.ReadAllText(path));
 
+        Assert.True(source.Contains("InitiallyExpandedGroupId", StringComparison.Ordinal),
+            "InitiallyExpandedGroupId is gone. If the mechanism changed, re-derive this guard and the "
+            + "integration test that reads the constant — as written this is checking nothing.");
+
         Assert.True(source.Contains("g.IsExpanded = g.Id == InitiallyExpandedGroupId", StringComparison.Ordinal),
-            "the startup expansion no longer goes through InitiallyExpandedGroupId. If the mechanism "
-            + "changed, re-derive this guard against the new one — it is checking nothing as written.");
-
-        // The constant must name a group the nav table actually builds. A rename would otherwise expand
-        // nothing at all, which looks exactly like the collapsed sidebar #1519 was about.
-        var declared = Regex.Match(source,
-            @"InitiallyExpandedGroupId\s*=\s*""(?<id>[^""]+)""");
-        Assert.True(declared.Success, "InitiallyExpandedGroupId is no longer a string literal constant.");
-        var groupId = declared.Groups["id"].Value;
-        Assert.True(source.Contains($"Group(\"{groupId}\"", StringComparison.Ordinal),
-            $"InitiallyExpandedGroupId is \"{groupId}\", but no Group(\"{groupId}\", …) is built. The sidebar "
-            + "would open with every group collapsed and nothing would say so.");
-
-        // No second group may be expanded at startup. Counted over the whole file rather than a slice: the
-        // auto-expand on navigation (parentGroup.IsExpanded = true) is a USER action and reads differently,
-        // so it is matched and excluded by name rather than by where it sits.
-        var expansions = Regex.Matches(source, @"(?<target>\w+)\.IsExpanded\s*=\s*true")
-            .Select(m => m.Groups["target"].Value)
-            .ToList();
-        Assert.True(expansions.All(t => t == "parentGroup"),
-            "a sidebar group is expanded unconditionally at startup: "
-            + string.Join(", ", expansions.Where(t => t != "parentGroup").Select(t => $"{t}.IsExpanded = true"))
-            + ". Only one group fits — expanding a second pushes category headers below the fold, which "
-            + "trades \"no tab names visible\" for \"no categories visible\".");
+            "the startup expansion no longer reads InitiallyExpandedGroupId. A literal in its place behaves "
+            + "identically and passes the integration test, while leaving the constant that test asserts "
+            + "against free to drift from the value the app actually uses.");
     }
 
     [Fact]

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4322,6 +4322,59 @@ public partial class ArchitectureTests
     /// <para>A comment cannot hold that line, so this asserts it. Adding a new eager tab fails here,
     /// which is the intended prompt to either justify it in the list below or use <c>Tab&lt;TVm&gt;</c>.</para>
     /// </summary>
+    /// <summary>
+    /// Exactly ONE sidebar group opens with the app, it is the one the constant names, and that constant
+    /// names a group that actually exists.
+    /// </summary>
+    /// <remarks>
+    /// The sidebar used to open with all twelve groups collapsed, so it showed twelve category headers and
+    /// not a single feature name (#1519). One group now starts open — and it has to be one, because the
+    /// viewport cannot hold more: at 820px the twelve collapsed groups already fill 600 of a 670px
+    /// viewport, so expanding a second pushes category headers below the fold. Expanding System as well
+    /// would cost nine of the twelve.
+    /// <para>Three separate failure modes, hence three assertions. A second expanded group is a UX
+    /// regression nothing else would catch. A constant naming a group id that was later renamed would
+    /// expand NOTHING, silently restoring the original complaint — the unreachable-surface defect this
+    /// codebase keeps producing. And a hardcoded literal in place of the constant would leave the two
+    /// halves free to drift.</para>
+    /// <para>Not a UI test, and not for lack of trying: <c>AppFixture</c> calls
+    /// <c>ExpandAllNavGroups()</c> during launch so that tests can find nav items directly, which destroys
+    /// the initial state before any test observes it. The shared fixture makes that unavoidable without a
+    /// second app launch, which is a lot of machinery for a one-line default.</para>
+    /// </remarks>
+    [Fact]
+    public void ExactlyOneSidebarGroup_OpensWithTheApp()
+    {
+        var path = Path.Combine(FindAppProjectDir(), "ViewModels", "MainWindowViewModel.cs");
+        var source = WithoutComments(File.ReadAllText(path));
+
+        Assert.True(source.Contains("g.IsExpanded = g.Id == InitiallyExpandedGroupId", StringComparison.Ordinal),
+            "the startup expansion no longer goes through InitiallyExpandedGroupId. If the mechanism "
+            + "changed, re-derive this guard against the new one — it is checking nothing as written.");
+
+        // The constant must name a group the nav table actually builds. A rename would otherwise expand
+        // nothing at all, which looks exactly like the collapsed sidebar #1519 was about.
+        var declared = Regex.Match(source,
+            @"InitiallyExpandedGroupId\s*=\s*""(?<id>[^""]+)""");
+        Assert.True(declared.Success, "InitiallyExpandedGroupId is no longer a string literal constant.");
+        var groupId = declared.Groups["id"].Value;
+        Assert.True(source.Contains($"Group(\"{groupId}\"", StringComparison.Ordinal),
+            $"InitiallyExpandedGroupId is \"{groupId}\", but no Group(\"{groupId}\", …) is built. The sidebar "
+            + "would open with every group collapsed and nothing would say so.");
+
+        // No second group may be expanded at startup. Counted over the whole file rather than a slice: the
+        // auto-expand on navigation (parentGroup.IsExpanded = true) is a USER action and reads differently,
+        // so it is matched and excluded by name rather than by where it sits.
+        var expansions = Regex.Matches(source, @"(?<target>\w+)\.IsExpanded\s*=\s*true")
+            .Select(m => m.Groups["target"].Value)
+            .ToList();
+        Assert.True(expansions.All(t => t == "parentGroup"),
+            "a sidebar group is expanded unconditionally at startup: "
+            + string.Join(", ", expansions.Where(t => t != "parentGroup").Select(t => $"{t}.IsExpanded = true"))
+            + ". Only one group fits — expanding a second pushes category headers below the fold, which "
+            + "trades \"no tab names visible\" for \"no categories visible\".");
+    }
+
     [Fact]
     public void OnlyTheJustifiedTabs_AreBuiltAtStartup()
     {

--- a/SysManager/SysManager.UITests/AppFixture.cs
+++ b/SysManager/SysManager.UITests/AppFixture.cs
@@ -50,9 +50,14 @@ public sealed class AppFixture : IDisposable
             TimeSpan.FromSeconds(5)).Result
             ?? throw new InvalidOperationException("The current-view automation host was not exposed.");
 
-        // Sidebar groups render as collapsed Expanders, so their child nav items aren't
-        // realized in the UI Automation tree until expanded. Expand everything once up
-        // front so tests that look up nav items directly (not via GoToTab) find them too.
+        // Sidebar groups render as Expanders, and all but Cleanup start collapsed, so most child nav
+        // items aren't realized in the UI Automation tree yet. Expand everything once up front so tests
+        // that look up nav items directly (not via GoToTab) find them too.
+        //
+        // Note for anyone wanting to assert the INITIAL expansion state: this call destroys it, and the
+        // fixture is shared across the collection, so no test in this suite can see it. That contract is
+        // asserted at the source level instead, by
+        // ArchitectureTests.ExactlyOneSidebarGroup_OpensWithTheApp.
         ExpandAllNavGroups();
     }
 
@@ -62,9 +67,9 @@ public sealed class AppFixture : IDisposable
     /// </summary>
     public void GoToTab(string navId)
     {
-        // Sidebar groups start collapsed, so child nav items aren't in the automation
-        // tree until their group Expander is open. Drive the UI like a user: try to find
-        // the item; if it isn't realized yet, expand every group and retry.
+        // All sidebar groups but one start collapsed (Cleanup opens with the app — #1519), so most
+        // child nav items aren't in the automation tree until their group Expander is open. Drive the
+        // UI like a user: try to find the item; if it isn't realized yet, expand every group and retry.
         var item = MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(navId));
         if (item is null)
         {

--- a/SysManager/SysManager.UITests/AppFixture.cs
+++ b/SysManager/SysManager.UITests/AppFixture.cs
@@ -55,9 +55,9 @@ public sealed class AppFixture : IDisposable
         // that look up nav items directly (not via GoToTab) find them too.
         //
         // Note for anyone wanting to assert the INITIAL expansion state: this call destroys it, and the
-        // fixture is shared across the collection, so no test in this suite can see it. That contract is
-        // asserted at the source level instead, by
-        // ArchitectureTests.ExactlyOneSidebarGroup_OpensWithTheApp.
+        // fixture is shared across the collection, so no test in this suite can see it. It is asserted
+        // where it belongs instead — against a real view-model, in
+        // MainWindowViewModelTests.NavGroups_ExactlyTheCleanupGroupStartsExpanded.
         ExpandAllNavGroups();
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.95.0</Version>
-    <FileVersion>1.95.0.0</FileVersion>
-    <AssemblyVersion>1.95.0.0</AssemblyVersion>
+    <Version>1.96.0</Version>
+    <FileVersion>1.96.0.0</FileVersion>
+    <AssemblyVersion>1.96.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
+++ b/SysManager/SysManager/ViewModels/MainWindowViewModel.cs
@@ -130,6 +130,25 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         foreach (var g in BuildNavGroups())
         {
             NavGroups.Add(g);
+            // ONE group opens with the app, and it is Cleanup (#1519). Every group used to start
+            // collapsed, so the sidebar opened showing twelve category headers and not a single
+            // feature name — for someone who came to the app because "my PC is slow", nothing on
+            // screen was what they were looking for.
+            //
+            // Exactly one, because the sidebar cannot show both. At 820px the twelve collapsed
+            // groups already fill 600 of a 670px viewport, so expanding ANYTHING pushes headers
+            // below the fold; expanding Cleanup costs the last two, Info and Advanced, which are
+            // the two least urgent. Expanding System as well would cost nine of the twelve, which
+            // trades "she sees no tab names" for "she sees no categories" — not obviously better.
+            //
+            // Cleanup rather than System because "clean it up" is the phrase the user actually
+            // arrives with, and its four children are the four things they came to do.
+            //
+            // Costs nothing at startup: the child rows bind only Id, Label, IsBusy,
+            // IsInDevelopment and SelectionStatus, all of them NavItem's own properties. None
+            // touches NavItem.Content, so no view-model is materialised by expanding a group —
+            // which is the property OnlyTheJustifiedTabs_AreBuiltAtStartup exists to protect.
+            g.IsExpanded = g.Id == InitiallyExpandedGroupId;
             foreach (var item in g.Children)
             {
                 item.WireBusy(); // no-op for lazy items until their VM is first materialised
@@ -178,6 +197,16 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     // Resolve an eager VM: from DI when available, else from the designer graph.
     private T Eager<T>() where T : class =>
         _sp is not null ? _sp.GetRequiredService<T>() : (T)_designerVms![typeof(T)];
+
+    /// <summary>
+    /// The one sidebar group that is open when the app starts.
+    /// </summary>
+    /// <remarks>
+    /// A named constant so the choice is stated once and the test asserts THIS rather than a repeated
+    /// string. Change it and the test follows; add a second expanded group and the test fails, which is the
+    /// point — the viewport only has room for one (#1519).
+    /// </remarks>
+    internal const string InitiallyExpandedGroupId = "grp-cleanup";
 
     private NavGroup[] BuildNavGroups() =>
     [


### PR DESCRIPTION
Closes #1519, taking **option B** — the one you picked.

## The change

`grp-cleanup` starts expanded. Everything else starts collapsed, as before.

```csharp
g.IsExpanded = g.Id == InitiallyExpandedGroupId;   // internal const = "grp-cleanup"
```

## Why one group and not two

The arithmetic from the issue's own analysis, restated because it is the entire justification: at an 820px window the twelve collapsed groups already fill **600 of a 670px viewport**. Expanding *anything* pushes category headings below the fold — the only question is how many.

| option | tab names visible | category headings lost |
|---|---|---|
| all collapsed (before) | 0 | 0 |
| **Cleanup only (this PR)** | **4** | **2 — Info and Advanced, the two least urgent** |
| System + Cleanup (as the issue proposed) | 12 | 9 of 12 |

The third row trades "she sees no feature names" for "she sees no categories", which is not obviously the better failure. Cleanup rather than System because "clean it up" is the phrase the user arrives with, and its four children are the four things they came to do.

## It costs nothing at startup

Verified, not assumed, because this is exactly where the eager-startup problem #1877 fixed would come back. The child rows bind `Id`, `Label`, `IsBusy`, `IsInDevelopment` and `SelectionStatus` — all `NavItem`'s own properties, `IsBusy` being a plain `[ObservableProperty]` field. **None of them reaches `NavItem.Content`**, so expanding a group materialises no view-model. That is the property `OnlyTheJustifiedTabs_AreBuiltAtStartup` exists to protect, and it still passes.

## The guard, and why it checks three things

`ExactlyOneSidebarGroup_OpensWithTheApp` asserts three separate failure modes, each proven red by mutation:

| mutation | assertion that fired |
|---|---|
| a second group expanded at startup | *"Only one group fits — expanding a second pushes category headers below the fold"* |
| the constant renamed to a group that isn't built | *"no `Group("grp-cleanup-renamed", …)` is built. The sidebar would open with every group collapsed"* |
| the expansion given a literal instead of the constant | *"the startup expansion no longer goes through `InitiallyExpandedGroupId`"* |

The middle one is the interesting one. A constant naming a group id that was later renamed would expand **nothing**, silently restoring the original complaint with no error anywhere — the unreachable-surface shape this codebase keeps producing.

## Why this is not a UI test

`AppFixture` calls `ExpandAllNavGroups()` during launch so that tests can look up nav items directly, which destroys the initial expansion state before any test in the collection observes it. The fixture is shared, so short of a second app launch there is nothing to observe. Both of its comments claiming *all* groups start collapsed are corrected in this change, and the second one now points at the source guard so the next person does not repeat the search I just did.

## Deliberately not in this PR

The option I flagged as the real answer — **D**, four task-shaped entry points on the Dashboard the user already lands on — and the option not drawn at all: remembering which groups were open last time, which makes the whole question disappear and needs the settings store the app does not have. That one would also fix "the last-opened tab does not survive a restart", which is the other half of this issue's complaint and which B does not address.

## Verification

- App, tests and UI tests: **0 errors, 0 warnings**.
- Unit suite: **5550 passed, 0 failed** (5549 → 5550).
- `dotnet format --verify-no-changes`: clean on all three projects.
- Full local pre-commit scan against all 43 current patterns: **0 matches in the added lines**.
- Docs in this same PR: README (the sidebar section now says which group opens and why only one), ARCHITECTURE (the constant, the guard, and the no-view-model note), CHANGELOG, SECURITY.md's supported line.
