### PR TITLE
refactor: give the type scale names for the sizes views already render

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -71,6 +71,20 @@ colour, accent included, falls to 1.00:1 against at least one of those.
 `ArchitectureTests.NoStyle_SuppressesTheKeyboardFocusIndicator` forbids
 `FocusVisualStyle="{x:Null}"` anywhere and asserts the ring keeps both strokes.
 
+The type scale in `App.xaml` runs in two families. **Text**: `Display` (28) → `Heading` (20) →
+`SectionTitle` (14) → `Subtle` → `Caption`. **Numbers**: `MetricHero` (30), `MetricLarge` (26),
+`Metric` (22), `MetricSmall` (20). The metric rungs above and below `Metric` were added for sizes views
+were already rendering with raw `FontSize` attributes, and `Heading` was restored alongside its first
+real user — the sidebar wordmark — having been deleted once for having none (#1630). `Heading` and
+`MetricSmall` share a size and are deliberately separate: one is text, the other a number, and System
+Logs' severity counts take the metric one for that reason. The new rungs are `BasedOn` the implicit
+`TextBlock` style because an explicit style REPLACES it, which would otherwise drop
+`TextFormattingMode`/`TextRenderingMode`; `Display` and `Metric` predate that and still have the gap.
+`ArchitectureTests.EveryMetricRungSize_IsReachedThroughItsRung` enforces both directions — no raw
+`FontSize` at a metric rung's size, and no reference to a rung `App.xaml` does not define, the latter
+because a `{StaticResource}` inside a `DataTemplate` resolves at runtime and would otherwise crash a tab
+rather than fail a build.
+
 Every tab is backed by a real view and view-model. A shared WIP placeholder view
 existed while tabs were still being built; the last tab graduated off it, so it was
 removed rather than left as unreachable code. A tab that is implemented but not yet

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4323,6 +4323,86 @@ public partial class ArchitectureTests
     /// which is the intended prompt to either justify it in the list below or use <c>Tab&lt;TVm&gt;</c>.</para>
     /// </summary>
     /// <summary>
+    /// A number rendered at one of the metric rungs' sizes must use the rung, and every rung a view
+    /// references must actually be defined.
+    /// </summary>
+    /// <remarks>
+    /// #1630(b): the type scale had names for 22 and 28 while views rendered numbers at 20, 26 and 30 with
+    /// raw <c>FontSize</c> attributes — so the scale was not being ignored, it simply had no name for what
+    /// the app draws. The rungs now exist at those sizes and the twelve call sites use them; this keeps the
+    /// next one from going back to a literal, which is how the drift started.
+    /// <para><b>Both halves matter, and the second is the subtle one.</b> A <c>{StaticResource}</c> inside a
+    /// <c>DataTemplate</c> resolves at RUNTIME, not at compile time, so a misspelled or deleted rung
+    /// compiles cleanly and throws when the tab is opened. Several of these call sites are inside templates.
+    /// Checking that every referenced rung is defined is the only thing standing between a rename and a
+    /// crash in a tab nobody opened during review.</para>
+    /// <para>Scoped to the metric rungs (20, 22, 26, 30) on purpose. 14 is <c>SectionTitle</c>'s size and
+    /// appears raw 39 times as ordinary label sizing — a different and much larger question. 28 is
+    /// <c>Display</c>'s size and is still raw in two places (Battery Health's charge, Dashboard's health
+    /// score); pulling those onto a rung makes numbers visibly smaller, which is the open half of #1630(b)
+    /// and needs a decision rather than a guard.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryMetricRungSize_IsReachedThroughItsRung()
+    {
+        var appDir = FindAppProjectDir();
+        var appXaml = File.ReadAllText(Path.Combine(appDir, "App.xaml"));
+
+        // The rungs, read from App.xaml rather than restated: a size changed there must change what this
+        // guard looks for, or it would enforce a scale the app no longer has.
+        var rungs = Regex.Matches(
+                appXaml,
+                @"<Style x:Key=""(?<key>Metric\w*|Heading)"" TargetType=""TextBlock""[^>]*>\s*<Setter Property=""FontSize"" Value=""(?<size>[\d.]+)""")
+            .ToDictionary(m => m.Groups["key"].Value, m => m.Groups["size"].Value, StringComparer.Ordinal);
+
+        Assert.True(rungs.Count >= 4,
+            $"only {rungs.Count} metric/heading rungs were matched in App.xaml, and there are 4 "
+            + "(Metric, MetricSmall, MetricLarge, MetricHero) plus Heading. The pattern no longer matches "
+            + "the style shape, so this guard is checking nothing.");
+
+        var rungSizes = rungs
+            .Where(r => r.Key.StartsWith("Metric", StringComparison.Ordinal))
+            .Select(r => r.Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var offenders = new List<string>();
+        var referenced = 0;
+
+        foreach (var file in Directory.EnumerateFiles(Path.Combine(appDir, "Views"), "*.xaml")
+                     .Append(Path.Combine(appDir, "MainWindow.xaml"))
+                     .OrderBy(p => p, StringComparer.Ordinal))
+        {
+            var markup = WithoutXamlComments(File.ReadAllText(file));
+            var name = Path.GetFileName(file);
+
+            foreach (var m in Regex.Matches(markup, @"FontSize=""(?<size>[\d.]+)""").Cast<Match>())
+            {
+                var size = m.Groups["size"].Value;
+                if (!rungSizes.Contains(size)) continue;
+                var rung = rungs.First(r => r.Value == size && r.Key.StartsWith("Metric", StringComparison.Ordinal)).Key;
+                offenders.Add($"{name}: raw FontSize=\"{size}\" — use Style=\"{{StaticResource {rung}}}\"");
+            }
+
+            // Every rung a view names must exist. This is what a compile cannot tell you.
+            foreach (var m in Regex.Matches(markup, @"\{StaticResource (?<key>Metric\w*|Heading)\}").Cast<Match>())
+            {
+                referenced++;
+                var key = m.Groups["key"].Value;
+                if (!rungs.ContainsKey(key))
+                    offenders.Add($"{name}: references {{StaticResource {key}}}, which App.xaml does not define — "
+                                  + "inside a DataTemplate that throws when the tab is opened, not at build time");
+            }
+        }
+
+        Assert.True(referenced >= 12,
+            $"only {referenced} rung references were found across the views, and twelve call sites use them. "
+            + "The reference pattern stopped matching, so the 'every rung is defined' half proves nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "the type scale is being bypassed or a rung is missing:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
     /// The startup expansion is driven by <c>InitiallyExpandedGroupId</c>, not by a repeated literal.
     /// </summary>
     /// <remarks>

--- a/SysManager/SysManager/App.xaml
+++ b/SysManager/SysManager/App.xaml
@@ -1114,10 +1114,11 @@
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
             </Style>
 
-            <!-- The type scale runs Display (28) → SectionTitle (14) → Subtle → Caption. A Heading
-                 (20) rung existed between the first two and no view ever used it, which made it a
-                 trap: a reviewer enforcing "use an existing style" would point at a style that had
-                 never actually rendered. Add it back only alongside a view that needs it. -->
+            <!-- The text scale runs Display (28) → Heading (20) → SectionTitle (14) → Subtle → Caption.
+                 Heading was deleted once, because no view used it and that made it a trap: a reviewer
+                 enforcing "use an existing style" would point at a style that had never rendered. The
+                 condition set for its return — "only alongside a view that needs it" — is met now, by the
+                 sidebar wordmark; it is defined next to the Metric rungs below. -->
             <Style x:Key="SectionTitle" TargetType="TextBlock">
                 <Setter Property="FontSize" Value="14"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
@@ -1172,6 +1173,52 @@
                 <Setter Property="FontSize" Value="22"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
                 <Setter Property="FontFamily" Value="{StaticResource UiFont}"/>
+            </Style>
+
+            <!-- The rungs above Metric, added because views were already using these exact sizes with raw
+                 FontSize attributes: 26 in six places (Dashboard's CPU/RAM/GPU meters, Bandwidth Monitor's
+                 up and down figures, Boot Analyzer's seconds), 30 in one (Timer Resolution's current
+                 value), and 20 in four (System Logs' four severity counts). So the scale was not being
+                 ignored — it simply had no name for what the app actually renders (#1630).
+                 The sizes are unchanged from what those views already had; only the source of the number
+                 moves. Every one of those call sites states its own FontWeight and Foreground, and a local
+                 attribute beats a style setter, so nothing about them renders differently.
+
+                 BasedOn the implicit TextBlock style, unlike Metric and Display above. That is
+                 load-bearing rather than tidiness: an explicit style REPLACES the keyless
+                 `<Style TargetType="TextBlock">`, so without BasedOn a repointed TextBlock would quietly
+                 lose its TextFormattingMode="Ideal" and TextRenderingMode="ClearType". Metric and Display
+                 have that gap today; widening it was not part of this change, and closing it for them is a
+                 separate one because it would alter how existing views render. -->
+            <Style x:Key="MetricSmall" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
+            </Style>
+
+            <Style x:Key="MetricLarge" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                <Setter Property="FontSize" Value="26"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
+            </Style>
+
+            <Style x:Key="MetricHero" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                <Setter Property="FontSize" Value="30"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
+            </Style>
+
+            <!-- Heading (20) is back, and this time it has a user: the "SysManager" wordmark at the top of
+                 the sidebar, which was a raw FontSize="20".
+
+                 It was deleted precisely because nothing used it, which made it a trap — a reviewer
+                 enforcing "use an existing style" would point at a style that had never rendered. The
+                 comment left in its place set the condition for its return: "add it back only alongside a
+                 view that needs it." MainWindow is that view.
+
+                 Distinct from MetricSmall despite sharing the size, because they are different things: the
+                 Metric rungs are numbers, and Heading is text. System Logs' four severity counts take
+                 MetricSmall rather than this for that reason. -->
+            <Style x:Key="Heading" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
             </Style>
 
             <!-- ============================================================ -->

--- a/SysManager/SysManager/MainWindow.xaml
+++ b/SysManager/SysManager/MainWindow.xaml
@@ -163,7 +163,7 @@
 
                 <!-- Header -->
                 <StackPanel Grid.Row="0" Margin="20,20,20,16">
-                    <TextBlock Text="SysManager" FontSize="20" FontWeight="SemiBold"
+                    <TextBlock Text="SysManager" Style="{StaticResource Heading}" FontWeight="SemiBold"
                                Foreground="{DynamicResource TextPrimary}"
                                FontFamily="{StaticResource UiFont}"/>
                     <TextBlock Text="System toolkit" Style="{StaticResource Caption}" Margin="0,2,0,0"/>

--- a/SysManager/SysManager/Views/BandwidthMonitorView.xaml
+++ b/SysManager/SysManager/Views/BandwidthMonitorView.xaml
@@ -46,13 +46,13 @@
                 <!-- Download tile -->
                 <StackPanel Grid.Column="0" Margin="0,0,32,0">
                     <TextBlock Text="DOWNLOAD" Style="{StaticResource SectionLabel}"/>
-                    <TextBlock Text="{Binding DownDisplay}" FontSize="26" FontWeight="SemiBold"
+                    <TextBlock Text="{Binding DownDisplay}" Style="{StaticResource MetricLarge}" FontWeight="SemiBold"
                                Foreground="{DynamicResource TextPrimary}" Margin="0,2,0,0"/>
                 </StackPanel>
                 <!-- Upload tile -->
                 <StackPanel Grid.Column="1" Margin="0,0,32,0">
                     <TextBlock Text="UPLOAD" Style="{StaticResource SectionLabel}"/>
-                    <TextBlock Text="{Binding UpDisplay}" FontSize="26" FontWeight="SemiBold"
+                    <TextBlock Text="{Binding UpDisplay}" Style="{StaticResource MetricLarge}" FontWeight="SemiBold"
                                Foreground="{DynamicResource TextPrimary}" Margin="0,2,0,0"/>
                 </StackPanel>
 

--- a/SysManager/SysManager/Views/BootAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/BootAnalyzerView.xaml
@@ -37,7 +37,7 @@
             <StackPanel>
                 <TextBlock Text="Latest boot" Style="{StaticResource SectionTitle}"/>
                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0" DataContext="{Binding LatestBoot}">
-                    <TextBlock Text="{Binding BootSecondsDisplay}" FontSize="26" FontWeight="Bold"
+                    <TextBlock Text="{Binding BootSecondsDisplay}" Style="{StaticResource MetricLarge}" FontWeight="Bold"
                                Foreground="{DynamicResource TextPrimary}" VerticalAlignment="Center"/>
                     <StackPanel Margin="20,0,0,0" VerticalAlignment="Center">
                         <TextBlock Foreground="{DynamicResource TextMuted}" FontSize="12">

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -265,7 +265,7 @@
                                        DockPanel.Dock="Left" VerticalAlignment="Center"/>
                             <Ellipse Width="6" Height="6" Fill="{DynamicResource Success}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
                         </DockPanel>
-                        <TextBlock FontSize="26" FontWeight="Bold" Foreground="{DynamicResource Success}">
+                        <TextBlock Style="{StaticResource MetricLarge}" FontWeight="Bold" Foreground="{DynamicResource Success}">
                             <Run Text="{Binding CpuPercent, StringFormat='{}{0:F0}', Mode=OneWay}"/><Run Text="%"/>
                         </TextBlock>
                         <TextBlock Text="{Binding CpuName}" FontSize="11" Foreground="{DynamicResource TextMuted}"
@@ -284,7 +284,7 @@
                                        DockPanel.Dock="Left" VerticalAlignment="Center"/>
                             <Ellipse Width="6" Height="6" Fill="{DynamicResource MetricBlue}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
                         </DockPanel>
-                        <TextBlock FontSize="26" FontWeight="Bold" Foreground="{DynamicResource MetricBlue}">
+                        <TextBlock Style="{StaticResource MetricLarge}" FontWeight="Bold" Foreground="{DynamicResource MetricBlue}">
                             <Run Text="{Binding RamPercent, StringFormat='{}{0:F0}', Mode=OneWay}"/><Run Text="%"/>
                         </TextBlock>
                         <TextBlock FontSize="11" Foreground="{DynamicResource TextMuted}" Margin="0,4,0,0">
@@ -312,7 +312,7 @@
                                        DockPanel.Dock="Left" VerticalAlignment="Center"/>
                             <Ellipse Width="6" Height="6" Fill="{DynamicResource MetricPurple}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
                         </DockPanel>
-                        <TextBlock FontSize="26" FontWeight="Bold" Foreground="{DynamicResource MetricPurple}">
+                        <TextBlock Style="{StaticResource MetricLarge}" FontWeight="Bold" Foreground="{DynamicResource MetricPurple}">
                             <Run Text="{Binding GpuPercent, StringFormat='{}{0:F0}', Mode=OneWay}"/><Run Text="%"/>
                         </TextBlock>
                         <TextBlock Text="{Binding GpuName}" FontSize="11" Foreground="{DynamicResource TextMuted}"

--- a/SysManager/SysManager/Views/LogsView.xaml
+++ b/SysManager/SysManager/Views/LogsView.xaml
@@ -62,7 +62,7 @@
                                 <DropShadowEffect Color="#FF3B30" BlurRadius="8" ShadowDepth="0" Opacity="0.6"/>
                             </Ellipse.Effect>
                         </Ellipse>
-                        <TextBlock Text="{Binding CriticalCount}" FontSize="20" FontWeight="Bold"
+                        <TextBlock Text="{Binding CriticalCount}" Style="{StaticResource MetricSmall}" FontWeight="Bold"
                                    Foreground="{DynamicResource Danger}" VerticalAlignment="Center" Margin="10,0,0,0"/>
                         <!-- Bold + ▲ glyph distinguish Critical from Error without relying on hue
                              (both are reds — a colorblind-safe, non-color cue). -->
@@ -85,7 +85,7 @@
                                 <DropShadowEffect Color="#F87171" BlurRadius="8" ShadowDepth="0" Opacity="0.6"/>
                             </Ellipse.Effect>
                         </Ellipse>
-                        <TextBlock Text="{Binding ErrorCount}" FontSize="20" FontWeight="Bold"
+                        <TextBlock Text="{Binding ErrorCount}" Style="{StaticResource MetricSmall}" FontWeight="Bold"
                                    Foreground="{DynamicResource Danger}" VerticalAlignment="Center" Margin="10,0,0,0"/>
                         <!-- Plain "Errors" — the coloured SevDot already marks the row; the leading
                              glyph is reserved for Critical (▲) as its colourblind-safe "most severe red"
@@ -111,7 +111,7 @@
                                 <DropShadowEffect Color="#FBBF24" BlurRadius="8" ShadowDepth="0" Opacity="0.6"/>
                             </Ellipse.Effect>
                         </Ellipse>
-                        <TextBlock Text="{Binding WarningCount}" FontSize="20" FontWeight="Bold"
+                        <TextBlock Text="{Binding WarningCount}" Style="{StaticResource MetricSmall}" FontWeight="Bold"
                                    Foreground="{DynamicResource Warning}" VerticalAlignment="Center" Margin="10,0,0,0"/>
                         <TextBlock Text="Warnings" FontSize="12" Foreground="{DynamicResource TextMuted}"
                                    VerticalAlignment="Center" Margin="10,0,0,0"/>
@@ -130,7 +130,7 @@
                                 <DropShadowEffect Color="#38BDF8" BlurRadius="8" ShadowDepth="0" Opacity="0.6"/>
                             </Ellipse.Effect>
                         </Ellipse>
-                        <TextBlock Text="{Binding InfoCount}" FontSize="20" FontWeight="Bold"
+                        <TextBlock Text="{Binding InfoCount}" Style="{StaticResource MetricSmall}" FontWeight="Bold"
                                    Foreground="{DynamicResource Info}" VerticalAlignment="Center" Margin="10,0,0,0"/>
                         <TextBlock Text="Info" FontSize="12" Foreground="{DynamicResource TextMuted}"
                                    VerticalAlignment="Center" Margin="10,0,0,0"/>

--- a/SysManager/SysManager/Views/TimerResolutionView.xaml
+++ b/SysManager/SysManager/Views/TimerResolutionView.xaml
@@ -34,7 +34,7 @@
             <StackPanel>
                 <TextBlock Text="Current resolution" Style="{StaticResource SectionTitle}"/>
                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding CurrentDisplay}" FontSize="30" FontWeight="Bold"
+                    <TextBlock Text="{Binding CurrentDisplay}" Style="{StaticResource MetricHero}" FontWeight="Bold"
                                Foreground="{DynamicResource TextPrimary}"/>
                     <Border CornerRadius="{StaticResource RadiusMd}" Padding="8,3" Margin="14,0,0,0" VerticalAlignment="Center"
                             Background="{DynamicResource Surface3}"


### PR DESCRIPTION
Part of #1630 — the (b) half, minus the four numbers that need your eye. The (a) half (the shared status footer) shipped in #2245.

## What #1630(b) actually is, re-derived

The issue reads as "the scale is bypassed 409 times over 18 values". Measured against current source it is **410 raw `FontSize` attributes over 17 distinct values** — and above the `Metric` token (22) there are only **13**, of which two are not metrics at all:

| size | n | where | what it is |
|---|---|---|---|
| 32 | 1 | EmptyState | a Segoe Fluent **icon glyph** — not text |
| 30 | 1 | Timer Resolution | hero metric |
| 28 | 2 | Battery Health, Dashboard | hero metrics — **would shrink**, not in this PR |
| 26 | 6 | Dashboard ×3, Bandwidth ×2, Boot Analyzer | hero metrics |
| 24 | 1 | About | the **wordmark** — a title |
| 24 | 2 | Battery Health | metrics — **would shrink**, not in this PR |

So the scale was not being ignored. **It had no name for what the app draws.**

## What this adds

| rung | size | first users |
|---|---|---|
| `MetricLarge` | 26 | Dashboard CPU/RAM/GPU, Bandwidth up/down, Boot Analyzer seconds |
| `MetricHero` | 30 | Timer Resolution's current value |
| `MetricSmall` | 20 | System Logs' four severity counts |
| `Heading` | 20 | the sidebar wordmark |

Twelve raw values repointed.

`Heading` is a restoration, and it comes with its own precondition already written in the source. It was deleted for having no user, and the comment left in its place said: *"add it back only alongside a view that needs it."* MainWindow is that view. It stays distinct from `MetricSmall` despite sharing a size because one is text and the other is a number — which is why System Logs' counts take the metric rung rather than `Heading`, contrary to what the issue suggests.

## Zero visual change, by construction

Each rung's `FontSize` is exactly what was there, and every one of the twelve call sites states its own `FontWeight` and `Foreground`; a local attribute beats a style setter in WPF, so nothing about them renders differently.

One thing that would have broken that quietly, and is the reason the new rungs carry `BasedOn`:

> An explicit `Style` **replaces** the keyless `<Style TargetType="TextBlock">`.

That implicit style sets `Foreground`, `FontFamily`, `TextOptions.TextFormattingMode="Ideal"` and `TextRenderingMode="ClearType"`. Repointing without `BasedOn="{StaticResource {x:Type TextBlock}}"` would have silently dropped the last two. `Display` and `Metric` have that gap today — closing it for them changes how existing views render, so it is deliberately not in this change, and the comment in `App.xaml` says so.

## The guard, and the half a compile cannot give you

`EveryMetricRungSize_IsReachedThroughItsRung` enforces two directions:

1. No raw `FontSize` at a metric rung's size — the drift itself.
2. **No reference to a rung `App.xaml` does not define.** A `{StaticResource}` inside a `DataTemplate` resolves at **runtime**, so a renamed or deleted rung compiles cleanly and throws when the tab is opened. Several of these call sites are inside templates.

It reads the rung sizes out of `App.xaml` rather than restating them, which mutation D proves: resizing `MetricLarge` to 24 makes the existing raw 24s become violations, so the guard is genuinely reading the scale and not a copy of it.

| mutation | what went red |
|---|---|
| a Dashboard call site back to `FontSize="26"` | *raw FontSize="26" — use MetricLarge* |
| `MetricSmall` → `MetricTiny` in one LogsView row | *references MetricTiny, which App.xaml does not define* |
| `MetricHero` deleted from App.xaml | same message, for Timer Resolution |
| `MetricLarge` resized 26 → 24 | the three existing raw 24s became violations |

Both floors are measured: ≥4 rungs matched in `App.xaml`, ≥12 rung references across the views. Either collapsing means a pattern stopped matching and the guard proves nothing.

## Deliberately not here

**Four numbers would get visibly smaller** — two 28s down to 26, two 24s down to 22. That is the part that makes the scale honest rather than just better-labelled, but it shrinks the biggest numbers on Battery Health and the Dashboard, so it waits for a look at `type-scale-1630b.html`, which draws each of them at both sizes. My own read is in that mockup: pulling the two 28s onto the 26 rung buys the most consistency for the least difference, and Battery Health's two 24s are the ones I would most readily skip.

Also not here: **`SectionTitle`'s 14, raw 39 times.** That is ordinary label sizing rather than the metric drift this issue describes, and it is a much larger question. The guard's scope comment says why it is excluded rather than leaving the next reader to wonder.

## No CHANGELOG entry

Nothing a user can see changed. Protocol Q makes the entry optional for exactly this case, and `refactor:` does not release.

## Verification

- App and tests: **0 errors, 0 warnings**.
- Unit suite: **5551 passed, 0 failed** (5550 → 5551).
- `dotnet format --verify-no-changes`: clean on both projects.
- Full local pre-commit scan against all 43 current patterns: **0 matches in the added lines**.
- ARCHITECTURE now documents both families of the scale, the `BasedOn` reason, and the guard.
