### PR TITLE
fix: a cancelled PowerShell query was reported as a successful empty result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,12 @@ whichever moment it lands in.
 - A cancelled PowerShell query is no longer reported to the app as a successful run that returned nothing.
   It only reported cancellation when the engine was interrupted mid-script; a cancel that arrived before the
   script started, or one that failed to interrupt a script already running, was silently discarded.
-- The two cancellation paths now say which one happened, so a failure of this kind can be diagnosed from its
+- **Cancelling now works the same way with administrator rights as without.** The two are not the same
+  underneath — running elevated hands the work to a separate Windows PowerShell process — and the cancelled
+  result came back in a different form from there that the app did not recognise. So on an elevated session
+  a cancelled query surfaced as a raw engine error rather than as a cancellation. This is the half that
+  could only ever be seen on a machine running as administrator.
+- The cancellation paths now say which one happened, so a failure of this kind can be diagnosed from its
   message instead of from a stopwatch. That is what this bug needed five CI failures to work out.
 
 ## [1.96.0] - 2026-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.96.1] - 2026-09-11
+
+**Pressing Cancel could leave a tab looking like it had finished successfully with nothing to show.** When a
+PowerShell query was cancelled in a narrow window — while its engine was still starting up — the query never
+ran, but nothing told the tab that. It received an empty list of results, which for a question like "which
+DNS servers am I using?" or "what did Defender find?" looks exactly like a real answer of "none". The tab
+would then show an empty state instead of saying it had been cancelled. Cancelling now always reports itself,
+whichever moment it lands in.
+
+### Fixed
+
+- A cancelled PowerShell query is no longer reported to the app as a successful run that returned nothing.
+  It only reported cancellation when the engine was interrupted mid-script; a cancel that arrived before the
+  script started, or one that failed to interrupt a script already running, was silently discarded.
+- The two cancellation paths now say which one happened, so a failure of this kind can be diagnosed from its
+  message instead of from a stopwatch. That is what this bug needed five CI failures to work out.
+
 ## [1.96.0] - 2026-09-11
 
 **The app now opens showing something you can actually use.** Every sidebar group used to start collapsed,

--- a/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
@@ -468,17 +468,194 @@ public class PowerShellRunnerTests
         Assert.True(gotError);
     }
 
+    /// <summary>
+    /// Cancelling a running script must stop it, and must surface that as
+    /// <see cref="OperationCanceledException"/> so a caller's cancel branch fires.
+    /// </summary>
+    /// <remarks>
+    /// This test has failed on CI five times with the elapsed time sitting on the script's own duration —
+    /// 31.12, 30.565, 30.664, 33.82, 32.03 seconds against a 30-second sleep, and nothing in between. So the
+    /// failure is all-or-nothing: either <c>ps.Stop()</c> takes effect within a few hundred milliseconds or
+    /// the pipeline runs to its natural end (#2206). The obvious cause — the cancellation callback landing on
+    /// a not-yet-invoked <c>PowerShell</c> instance — was refuted with a harness that mutated the runner three
+    /// ways and cancelled in ~0.35 s every time, so no speculative fix was shipped.
+    ///
+    /// <para><b>What this instrumentation is for.</b> The failure message used to be one number, which cannot
+    /// tell the two live hypotheses apart. The runner's contract makes them distinguishable:
+    /// <c>ps.Stop()</c> makes <c>EndInvoke</c> throw <c>PipelineStoppedException</c>, which
+    /// <c>RunOnLeasedRunspaceAsync</c> translates to <c>OperationCanceledException</c>. So if Stop never
+    /// takes effect the script completes, <c>EndInvoke</c> returns normally and <b>no exception is thrown at
+    /// all</b>.</para>
+    ///
+    /// <list type="bullet">
+    /// <item>slow + <c>OperationCanceledException</c> → Stop worked and the 5-second bound is simply tight.</item>
+    /// <item>slow + <b>no exception</b> → Stop had no effect; the pipeline ran to completion. A user pressing
+    /// Cancel would wait out the whole operation.</item>
+    /// <item>token never fired → the <c>CancellationTokenSource</c> itself was starved, which on a loaded
+    /// runner is a test-environment fact rather than a product defect.</item>
+    /// </list>
+    ///
+    /// <para>The token's own firing time is captured through a SECOND registration on the same token rather
+    /// than by instrumenting the runner: it needs no production change, and it separates "the token fired
+    /// late" from "the token fired on time and was ignored", which is the whole question.</para>
+    ///
+    /// <para>Error lines are captured because of a trap this bug already produced twice: on a dev box
+    /// <c>Start-Sleep</c> does not exist in this runner's runspace — <c>CreateDefault2()</c> loads
+    /// <c>Microsoft.PowerShell.Core</c> only — so the script errors instantly, returns normally, and a
+    /// cancellation that never happened reads as a fast success. If that is what is happening, the captured
+    /// error says so instead of leaving the next person to rediscover it.</para>
+    /// </remarks>
     [Fact]
     public async Task RunAsync_SupportsCancellation()
     {
         var runner = new PowerShellRunner();
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+        var lines = new System.Collections.Concurrent.ConcurrentQueue<Models.PowerShellLine>();
+        runner.LineReceived += lines.Enqueue;
+
+        using var cts = new CancellationTokenSource();
         var sw = System.Diagnostics.Stopwatch.StartNew();
-        await Record.ExceptionAsync(async () =>
+
+        // Elapsed at the moment the token fired, from a registration of our own. -1 means it never fired.
+        var firedAtMs = -1.0;
+        using var observer = cts.Token.Register(() => firedAtMs = sw.Elapsed.TotalMilliseconds);
+        cts.CancelAfter(TimeSpan.FromMilliseconds(300));
+
+        var ex = await Record.ExceptionAsync(async () =>
             await runner.RunAsync("Start-Sleep -Seconds 30", cancellationToken: cts.Token));
         sw.Stop();
+
+        var errors = lines.Where(l => l.Kind == Models.OutputKind.Error).Select(l => l.Text).ToList();
+        var diagnosis =
+            $"elapsed {sw.Elapsed}; token fired at {(firedAtMs < 0 ? "NEVER" : $"{firedAtMs:F0} ms")}; "
+            + $"exception {ex?.GetType().Name ?? "NONE"} ({ex?.Message ?? "-"}); {lines.Count} line(s) captured"
+            + (errors.Count > 0 ? $", errors: {string.Join(" | ", errors.Take(2))}" : "");
+
         Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
-            $"Cancellation took too long: {sw.Elapsed}");
+            "Cancellation took too long. " + diagnosis
+            + " — the exception MESSAGE is the discriminator, because both cancellation paths raise "
+            + "OperationCanceledException: \"stopped by cancellation\" means ps.Stop() interrupted the "
+            + "pipeline and only the bound failed, while \"completed on its own\" means Stop never "
+            + "interrupted anything and the script ran to its natural end. NONE means the run predates the "
+            + "post-await check entirely.");
+
+        // Stopping without reporting it is its own defect: every caller's cancel branch is written around
+        // OperationCanceledException, so a silent return would show a cancelled operation as a completed one.
+        Assert.True(ex is OperationCanceledException, "Cancellation did not surface as OperationCanceledException. " + diagnosis);
+    }
+
+    /// <summary>
+    /// A cancel that lands while the RUNSPACE IS STILL OPENING must still report cancellation — the script
+    /// never runs, and returning an empty result set silently makes that look like a successful query.
+    /// </summary>
+    /// <remarks>
+    /// The regression test for #2206's root cause, and the only one of the three here that pins it
+    /// deterministically.
+    /// <para><b>Why the other two cannot.</b> Both depend on how long a runspace takes to open. Run alone in
+    /// a cold process that is ~300 ms, dominated by assembly loading, so a 300 ms cancel lands during the
+    /// lease and takes this path. Run after any other test in the class it is ~20 ms, the pipeline is already
+    /// executing, and the cancel takes the <c>PipelineStoppedException</c> path instead. Measured: removing
+    /// the post-await throw leaves the whole class GREEN, while running
+    /// <see cref="RunAsync_SupportsCancellation"/> on its own against the same code fails with
+    /// "exception NONE". A test whose coverage depends on execution order is not a regression test.</para>
+    /// <para><b>How this one is deterministic.</b> The <c>openRunspace</c> seam blocks until the test has
+    /// cancelled, so the token is guaranteed to be already cancelled when <c>Register</c> runs — which
+    /// invokes the callback synchronously, putting <c>ps.Stop()</c> on a <c>NotStarted</c> instance.
+    /// <c>BeginInvoke</c>/<c>EndInvoke</c> then complete without throwing and without running the script.
+    /// No timing, no sleeping, and the same sequence on every machine.</para>
+    /// <para>The MESSAGE is asserted, not just the exception type. Both cancellation paths raise
+    /// <c>OperationCanceledException</c>, so accepting either would let this pass on the wrong one — and the
+    /// wrong one is the path that already worked.</para>
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_CancelledWhileTheRunspaceIsOpening_ReportsCancellation()
+    {
+        using var cancelled = new SemaphoreSlim(0);   // released once the test has cancelled the token
+        using var reachedOpen = new SemaphoreSlim(0); // signals that the lease has begun opening
+
+        using var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            isElevated: static () => false,
+            openRunspace: async runspace =>
+            {
+                reachedOpen.Release();
+                await cancelled.WaitAsync(TimeSpan.FromSeconds(10));
+                await Task.Run(runspace.Open);
+            });
+
+        using var cts = new CancellationTokenSource();
+        var run = runner.RunAsync("1 + 1", cancellationToken: cts.Token);
+
+        Assert.True(await reachedOpen.WaitAsync(TimeSpan.FromSeconds(10)),
+            "the runspace open was never reached, so nothing below is about the opening window.");
+        await cts.CancelAsync();
+        cancelled.Release();
+
+        var ex = await Record.ExceptionAsync(() => run);
+
+        Assert.True(ex is OperationCanceledException,
+            $"a run cancelled during the runspace open reported {ex?.GetType().Name ?? "NO EXCEPTION"}. "
+            + "With no exception the caller receives an empty result set and no indication that anything was "
+            + "cancelled — for a query that is indistinguishable from a real answer of \"nothing found\".");
+
+        Assert.Contains("completed on its own", ex!.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Cancelling a pipeline that is ALREADY RUNNING must also surface as
+    /// <see cref="OperationCanceledException"/> — the other half of #2206, and the half CI keeps hitting.
+    /// </summary>
+    /// <remarks>
+    /// The test above cancels at 300 ms, and opening a cold runspace takes about that long, so the cancel
+    /// lands during the lease and <c>ps.Stop()</c> hits a not-yet-invoked instance. That is one of two paths
+    /// through the same hole, and it is the only one reproducible on a dev box.
+    /// <para>This one takes the other: a warm-up call first, so the runspace is already open and the lease
+    /// returns immediately, then a longer delay so the cancel arrives while the pipeline is genuinely
+    /// executing. <c>EndInvoke</c> then throws <c>PipelineStoppedException</c> and the translation arm is
+    /// what has to convert it — a different line of the runner from the one the test above exercises.</para>
+    /// <para>The script is deliberately module-free. <c>Start-Sleep</c> lives in
+    /// <c>Microsoft.PowerShell.Utility</c>, which <c>CreateDefault2()</c> does not load, so on a dev box it
+    /// fails instantly with "the module could not be loaded" and the script returns in milliseconds —
+    /// a cancellation that never happened reading as a fast pass. That trap cost a whole round of
+    /// investigation on #2206; <c>[System.Threading.Thread]::Sleep</c> needs no module and blocks for real.
+    /// The assertion that the probe actually blocked is what keeps this test from repeating the mistake.</para>
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_CancellingARunningPipeline_ReportsCancellation()
+    {
+        var runner = new PowerShellRunner();
+
+        // Warm the runspace so the lease below is instant and the cancel lands mid-execution rather than
+        // mid-open. Module-free, and its result proves the runspace works before anything is measured.
+        var warm = await runner.RunAsync("1 + 1");
+        Assert.Equal(2, Convert.ToInt32(Assert.Single(warm).BaseObject, System.Globalization.CultureInfo.InvariantCulture));
+
+        using var cts = new CancellationTokenSource();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var firedAtMs = -1.0;
+        using var observer = cts.Token.Register(() => firedAtMs = sw.Elapsed.TotalMilliseconds);
+        cts.CancelAfter(TimeSpan.FromMilliseconds(500));
+
+        var ex = await Record.ExceptionAsync(async () => await runner.RunAsync(
+            "while ($true) { [System.Threading.Thread]::Sleep(50) }", cancellationToken: cts.Token));
+        sw.Stop();
+
+        var diagnosis = $"elapsed {sw.Elapsed}; token fired at {(firedAtMs < 0 ? "NEVER" : $"{firedAtMs:F0} ms")}; "
+                        + $"exception {ex?.GetType().Name ?? "NONE"} ({ex?.Message ?? "-"})";
+
+        // The probe must have BLOCKED. An infinite loop that returns in 50 ms means the script never ran,
+        // and everything below it would then be asserting over nothing.
+        Assert.True(sw.Elapsed > TimeSpan.FromMilliseconds(400),
+            "the blocking script returned before the cancel could land, so this test proves nothing about "
+            + "cancelling a RUNNING pipeline. " + diagnosis);
+
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(10),
+            "a running pipeline did not stop when cancelled. " + diagnosis);
+
+        Assert.True(ex is OperationCanceledException,
+            "a cancelled running pipeline did not report cancellation. " + diagnosis
+            + " — PipelineStoppedException here means the translation arm stopped converting it, and a "
+            + "message of \"completed on its own\" means Stop did not interrupt a pipeline that was "
+            + "definitely running, which is the CI failure shape rather than this test's own.");
     }
 
     [Fact]

--- a/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
@@ -520,8 +520,14 @@ public class PowerShellRunnerTests
         using var observer = cts.Token.Register(() => firedAtMs = sw.Elapsed.TotalMilliseconds);
         cts.CancelAfter(TimeSpan.FromMilliseconds(300));
 
-        var ex = await Record.ExceptionAsync(async () =>
-            await runner.RunAsync("Start-Sleep -Seconds 30", cancellationToken: cts.Token));
+        // An INTERRUPTIBLE script, and that replaced `Start-Sleep -Seconds 30`. The old one asserted
+        // something PowerShell does not promise: ps.Stop() interrupts between pipeline statements, not
+        // inside a single blocking cmdlet call, so a 30-second sleep ran to completion every time and the
+        // test cost 30 seconds to report it. The controlled comparison is in the CI log for #2206 — on the
+        // SAME elevated out-of-process runspace, the loop below cancelled in 2.2 s while the sleep took
+        // 31.4 s. The real limit is pinned by its own test below rather than by making this one fail.
+        var ex = await Record.ExceptionAsync(async () => await runner.RunAsync(
+            "while ($true) { [System.Threading.Thread]::Sleep(50) }", cancellationToken: cts.Token));
         sw.Stop();
 
         var errors = lines.Where(l => l.Kind == Models.OutputKind.Error).Select(l => l.Text).ToList();
@@ -541,6 +547,73 @@ public class PowerShellRunnerTests
         // Stopping without reporting it is its own defect: every caller's cancel branch is written around
         // OperationCanceledException, so a silent return would show a cancelled operation as a completed one.
         Assert.True(ex is OperationCanceledException, "Cancellation did not surface as OperationCanceledException. " + diagnosis);
+    }
+
+    /// <summary>
+    /// A single long BLOCKING call cannot be interrupted — but the cancellation must still be reported when
+    /// it finally returns.
+    /// </summary>
+    /// <remarks>
+    /// The real limit behind #2206, pinned rather than wished away. <c>ps.Stop()</c> interrupts a pipeline
+    /// between statements; it cannot interrupt one statement that is inside a blocking native call. The
+    /// evidence is a controlled comparison from one CI run, on one elevated out-of-process runspace:
+    /// <c>while ($true) { Thread::Sleep(50) }</c> cancelled in 2.2 s, while <c>Start-Sleep -Seconds 30</c>
+    /// took 31.4 s — the whole sleep. Same transport, same cancel, opposite outcome.
+    ///
+    /// <para>So the canary above asserted something PowerShell does not promise, and cost thirty seconds
+    /// per CI run to say so. What the runner CAN promise is that the cancellation is not lost, and that is
+    /// what this asserts: the call takes the script's full duration, and it still raises
+    /// <c>OperationCanceledException</c> rather than returning as though nothing had been asked.</para>
+    ///
+    /// <para>Three seconds of real waiting, deliberately. A shorter block would not reliably outlast the
+    /// cancel on a loaded runner, and the value being pinned is precisely that the call does NOT come back
+    /// early. <c>Thread::Sleep</c> rather than <c>Start-Sleep</c> because the latter needs
+    /// <c>Microsoft.PowerShell.Utility</c>, which the in-process runspace does not load — it would fail
+    /// instantly on a dev box and pin nothing at all.</para>
+    ///
+    /// <para><b>Either cancellation message is correct here, and finding out why corrected the model above.</b>
+    /// Running this locally reported "stopped by cancellation" after the full three seconds: the stop stays
+    /// PENDING through the blocking call and takes effect at the next statement boundary, so
+    /// <c>EndInvoke</c> throws after all. CI's 30-second <c>Start-Sleep</c> reported "completed on its own"
+    /// because the sleep WAS the whole script — there was no next statement to stop at, so the pipeline
+    /// simply finished. Three outcomes, then, not two: interrupted promptly, stopped late at a boundary, or
+    /// never noticed. Asserting one message would pin the transport rather than the contract, and the
+    /// contract is that the cancellation reaches the caller either way.</para>
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_CancellingASingleBlockingCall_CannotInterruptItButStillReportsIt()
+    {
+        var runner = new PowerShellRunner();
+        var warm = await runner.RunAsync("1 + 1");
+        Assert.Equal(2, Convert.ToInt32(Assert.Single(warm).BaseObject, System.Globalization.CultureInfo.InvariantCulture));
+
+        using var cts = new CancellationTokenSource();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(300));
+
+        var ex = await Record.ExceptionAsync(async () => await runner.RunAsync(
+            "[System.Threading.Thread]::Sleep(3000)", cancellationToken: cts.Token));
+        sw.Stop();
+
+        var diagnosis = $"elapsed {sw.Elapsed}; exception {ex?.GetType().Name ?? "NONE"} ({ex?.Message ?? "-"})";
+
+        // The premise: the call really did outlast the cancel. If this ever stops holding, ps.Stop() has
+        // become able to interrupt a blocking call and the rest of this test is about nothing.
+        Assert.True(sw.Elapsed > TimeSpan.FromMilliseconds(2500),
+            "the blocking call returned early, so ps.Stop() now interrupts inside one — which would be good "
+            + "news and makes this test obsolete rather than failing. " + diagnosis);
+
+        Assert.True(ex is OperationCanceledException,
+            "a cancelled run whose script could not be interrupted returned without reporting the "
+            + "cancellation, so the caller sees a completed operation. " + diagnosis);
+
+        // Either arm is right — see the remarks. What must not happen is neither.
+        Assert.True(
+            ex!.Message.Contains("stopped by cancellation", StringComparison.Ordinal)
+            || ex.Message.Contains("completed on its own", StringComparison.Ordinal),
+            "the cancellation was reported by neither of the runner's two arms, so the message no longer "
+            + "says which path ran and the next failure of this kind is back to being a stopwatch reading. "
+            + diagnosis);
     }
 
     /// <summary>

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -693,6 +693,191 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// A test asserting on <c>StatusMessage</c> must settle the view-model's constructor init first, when
+    /// that init can write <c>StatusMessage</c> itself.
+    /// </summary>
+    /// <remarks>
+    /// Most view-models call <c>InitializeAsync(InitAsync)</c> from their constructor and forget the task.
+    /// When that init reaches an <c>await</c> before writing <c>StatusMessage</c>, its continuation is still
+    /// pending while the test runs — and the test's own <c>await SomeCommand.ExecuteAsync(...)</c> is a yield
+    /// point that lets it land. The init's message then overwrites what the command reported and the
+    /// assertion fails on a string neither the test nor the command produced. That reddened #2199, a pull
+    /// request that touched only the theme stack (#2201).
+    ///
+    /// <para><b>Why the init path is traced rather than the file grepped.</b> The obvious rule — "the
+    /// view-model has a ctor init and writes StatusMessage somewhere" — puts 35 view-models in scope and
+    /// reports 22 violations that are all safe. <c>CleanupViewModel</c> is the clearest: its init writes
+    /// <c>TempSizeLabel</c> and <c>RecycleBinLabel</c> and never touches <c>StatusMessage</c>, so its eight
+    /// tests cannot race, and a guard shipping with those eight findings would get suppressed rather than
+    /// fixed. Following the init entry through two levels of calls narrows 35 to 22 and 22 findings to
+    /// zero.</para>
+    ///
+    /// <para><b>Helpers count.</b> Seven of the eight files an earlier body-scoped count flagged settle init
+    /// inside their own <c>NewVm()</c>, which is the idiom five files already use. A guard that only reads
+    /// test bodies calls those violations, which is the false positive #2201 predicted by name.</para>
+    ///
+    /// <para><b>The allowlist is three names, and they assert the OPPOSITE.</b> They check the message is
+    /// still empty before init lands, so settling it is exactly what they must not do. Kept deliberately
+    /// literal: a pattern like "any test whose name starts with Constructor_" would also exempt four tests
+    /// that assert the message is NON-empty right after construction, which is the same race in the other
+    /// direction.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryTestAssertingAStatusMessage_SettlesTheConstructorInitFirst()
+    {
+        // These assert that StatusMessage is still EMPTY, i.e. the pre-init state. Awaiting init would
+        // break them by design, so they are named rather than pattern-matched.
+        string[] assertsThePreInitState =
+        [
+            "Constructor_StatusMessageEmpty",
+            "Constructor_InitialStatusMessageIsEmpty",
+            "StatusMessage_DefaultEmpty",
+        ];
+
+        var vmDir = Path.Combine(FindAppProjectDir(), "ViewModels");
+        var racingViewModels = new List<string>();
+
+        foreach (var file in Directory.GetFiles(vmDir, "*ViewModel.cs"))
+        {
+            var source = WithoutComments(File.ReadAllText(file));
+            var entry = Regex.Match(source, @"InitializeAsync\(\s*(\w+)\s*\)");
+            if (!entry.Success) continue;
+
+            if (InitPathWritesStatusMessage(source, entry.Groups[1].Value))
+                racingViewModels.Add(Path.GetFileNameWithoutExtension(file));
+        }
+
+        Assert.True(racingViewModels.Count >= 20,
+            $"only {racingViewModels.Count} view-models were found whose constructor init can write "
+            + "StatusMessage, and 22 were measured. The init-path trace stopped matching, so this guard is "
+            + "checking almost nothing — re-derive it before trusting a pass.");
+
+        var testDir = FindTestSourceDirectory();
+        var offenders = new List<string>();
+        var checkedTests = 0;
+
+        foreach (var vm in racingViewModels)
+        {
+            var path = Path.Combine(testDir, vm + "Tests.cs");
+            if (!File.Exists(path)) continue;
+            var source = WithoutComments(File.ReadAllText(path));
+            var bodies = MethodBodiesByName(source);
+
+            // A helper in the same file that settles init makes every caller of it safe.
+            // EVERY overload must settle, not any. Two same-named NewVm helpers made a settle in one vouch
+            // for the other, so removing it from the one the racy tests called left this guard green.
+            var settling = bodies
+                .Where(b => b.Value.All(body => body.Contains("InitializationComplete", StringComparison.Ordinal)))
+                .Select(b => b.Key)
+                .ToHashSet(StringComparer.Ordinal);
+
+            foreach (var (name, overloads) in bodies)
+            {
+                var body = string.Join("\n", overloads);
+                if (!body.Contains("StatusMessage", StringComparison.Ordinal)) continue;
+                if (!body.Contains("Assert.", StringComparison.Ordinal)) continue;
+                checkedTests++;
+
+                if (assertsThePreInitState.Contains(name, StringComparer.Ordinal)) continue;
+                if (body.Contains("InitializationComplete", StringComparison.Ordinal)) continue;
+
+                var calls = Regex.Matches(body, @"\b(\w+)\s*\(").Select(m => m.Groups[1].Value);
+                if (calls.Any(c => c != name && settling.Contains(c))) continue;
+
+                offenders.Add($"{vm}Tests.{name}");
+            }
+        }
+
+        Assert.True(checkedTests >= 40,
+            $"only {checkedTests} StatusMessage assertions were found across those view-models' test files, "
+            + "and 44 were measured. The method-body split stopped matching, so a pass here means nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "These tests assert on a StatusMessage that the view-model's own constructor init also writes, "
+            + "without settling that init first. The init's continuation lands on the test's next await and "
+            + "overwrites the message, so the assertion fails on a string neither the test nor the command "
+            + "produced — for a reason that has nothing to do with the change being tested. Await "
+            + "vm.InitializationComplete, or settle it in the file's NewVm() as five other files do:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// True when <paramref name="entry"/>, or anything it calls within two further levels, assigns
+    /// <c>StatusMessage</c>.
+    /// </summary>
+    /// <remarks>
+    /// Two levels because the real chains are that long and no longer: <c>InitAsync</c> →
+    /// <c>RefreshAsync</c> → the write. Following <c>*Async</c> plus the <c>Refresh</c>/<c>Load</c>/<c>Scan</c>
+    /// families covers every init entry point in the app; anything it cannot follow simply is not reported,
+    /// which keeps the guard's scope smaller than the truth rather than larger.
+    /// </remarks>
+    private static bool InitPathWritesStatusMessage(string viewModelSource, string entry)
+    {
+        var bodies = MethodBodiesByName(viewModelSource);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var frontier = new List<string> { entry };
+
+        for (var depth = 0; depth < 3 && frontier.Count > 0; depth++)
+        {
+            var next = new List<string>();
+            foreach (var name in frontier)
+            {
+                if (!seen.Add(name)) continue;
+                if (!bodies.TryGetValue(name, out var overloads)) continue;
+                var body = string.Join("\n", overloads);
+                if (Regex.IsMatch(body, @"\bStatusMessage\s*=[^=]")) return true;
+
+                next.AddRange(Regex.Matches(body, @"\b(\w+Async)\s*\(").Select(m => m.Groups[1].Value));
+                next.AddRange(Regex.Matches(body, @"\b((?:Refresh|Load|Scan)\w*)\s*\(").Select(m => m.Groups[1].Value));
+            }
+            frontier = next;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Every method name in one comment-stripped C# file to the bodies declared under it — a LIST, because
+    /// overloads share a name.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <c>MethodBodies</c> further down, which yields bodies WITHOUT their names. Both exist
+    /// because the checks need different things: that one only has to separate one operation's try/finally
+    /// from another's, while resolving "does this test call a helper that settles init" needs the names.
+    /// <para><b>A list rather than one body per name, and that was a real defect.</b> Keeping only the first
+    /// declaration let a settle in ONE overload vouch for the other: <c>DebloaterViewModelTests</c> has two
+    /// <c>NewVm</c>s, and removing the settle from the one its racy tests call left the guard above green. A
+    /// helper counts as settling only when EVERY overload of it does. Found by mutation, not by review.</para>
+    /// </remarks>
+    private static Dictionary<string, List<string>> MethodBodiesByName(string source)
+    {
+        var result = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (var m in Regex.Matches(
+                     source,
+                     @"\n    (?:\[[^\]]*\]\s*\n\s*)*(?:public|private|internal|protected)[^\n=;]*?\b(\w+)\s*\([^)]*\)\s*\n?\s*\{")
+                     .Cast<Match>())
+        {
+            var open = source.IndexOf('{', m.Index + m.Length - 1);
+            if (open < 0) continue;
+
+            var depth = 0;
+            var end = open;
+            for (; end < source.Length; end++)
+            {
+                if (source[end] == '{') depth++;
+                else if (source[end] == '}' && --depth == 0) break;
+            }
+
+            if (!result.TryGetValue(m.Groups[1].Value, out var bodies))
+                result[m.Groups[1].Value] = bodies = [];
+            bodies.Add(source[open..Math.Min(end, source.Length)]);
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// No test may skip itself because the session happens to be elevated.
     /// </summary>
     /// <remarks>

--- a/SysManager/SysManager.Tests/DebloaterViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DebloaterViewModelTests.cs
@@ -25,8 +25,32 @@ namespace SysManager.Tests;
 [Collection("ProcessWideStatics")]
 public class DebloaterViewModelTests
 {
-    private static DebloaterViewModel NewVm() =>
-        new(new DebloaterService(Substitute.For<IPowerShellRunner>()), NoRestorePoint());
+    /// <summary>
+    /// A view-model with an unconfigured runner, its constructor init settled.
+    /// </summary>
+    /// <remarks>
+    /// Settled for the same reason as the overload below (#2201). It matters here even though these tests
+    /// assert no <c>StatusMessage</c>: the init sets <c>HasScanned = true</c>, so
+    /// <see cref="EmptyState_BeforeScan_PromptsRefresh"/> was asserting <c>HasScanned</c> is FALSE as a
+    /// precondition it did not control — true only while the fire-and-forget init had not landed yet. Both
+    /// empty-state tests now set the flag they are about, which is what they were always testing: the copy
+    /// switches on <c>HasScanned</c>, not on how fast a background load happens to run.
+    /// </remarks>
+    private static DebloaterViewModel NewVm()
+    {
+        // Returns an EMPTY collection explicitly. An unconfigured substitute hands back a null
+        // Collection<PSObject>, which made DebloaterService.ParsePackages throw NullReferenceException
+        // out of the init — invisible until this factory started settling it, because RunInitAsync does not
+        // catch that type and nothing in production observes the task. Filed separately; a test fixture
+        // should state what the runner returns rather than lean on an auto-value either way.
+        var runner = Substitute.For<IPowerShellRunner>();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object?>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new Collection<PSObject>()));
+
+        var vm = new DebloaterViewModel(new DebloaterService(runner), NoRestorePoint());
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
 
     /// <summary>
     /// A seam that answers "no point was created" — the common case on a consumer machine, where
@@ -55,7 +79,12 @@ public class DebloaterViewModelTests
     public void EmptyState_BeforeScan_PromptsRefresh()
     {
         var vm = NewVm();
-        Assert.False(vm.HasScanned);
+
+        // Set explicitly rather than relied on. The init sets this true, so asserting it was false meant
+        // asserting the background load had not landed yet — which is timing, not behaviour. The sibling
+        // test below has always set it the other way for exactly this reason.
+        vm.HasScanned = false;
+
         Assert.Equal("No apps loaded", vm.EmptyTitle);
         Assert.Contains("Refresh", vm.EmptyMessage);
     }
@@ -93,7 +122,7 @@ public class DebloaterViewModelTests
         // exception-safe.
         using var dialog = new DialogAnswer(confirm: true);
 
-        var vm = new DebloaterViewModel(new DebloaterService(runner), NoRestorePoint());
+        var vm = NewVm(NoRestorePoint(), runner);
         var a = Removable("Contoso.AppA");
         var b = Removable("Contoso.AppB");
         vm.Apps.Add(a);
@@ -128,13 +157,42 @@ public class DebloaterViewModelTests
         return runner;
     }
 
+    /// <summary>
+    /// Builds the view-model and SETTLES its constructor init before returning it.
+    /// </summary>
+    /// <remarks>
+    /// The constructor fires <c>RefreshAsync</c> and forgets it, and that init does two things no test
+    /// here survives landing late (#2201):
+    /// <list type="number">
+    /// <item>it writes <c>StatusMessage</c> — "Reading installed Store apps…" — which then overwrites
+    /// whatever the command under test reported, so the assertion fails on a string neither the test nor
+    /// the command produced. That is the exact failure that reddened an unrelated PR on #2199.</item>
+    /// <item>it calls <c>Apps.ReplaceWith(...)</c>, which DISCARDS the fixture. Every test in this file adds
+    /// its apps immediately after constructing, so a late init leaves the command acting on an empty list —
+    /// and a test that then asserts "nothing was removed" passes for the wrong reason entirely.</item>
+    /// </list>
+    /// <para>The second is why this is a factory rather than an await added to the three tests that assert
+    /// on <c>StatusMessage</c>: all six construction sites add to <c>Apps</c>, so all six are exposed,
+    /// whatever they go on to assert.</para>
+    /// <para>Settled synchronously, mirroring <c>AppBlockerViewModelTests.NewVm</c> and the four other
+    /// factories in this suite that do the same, so the sync tests here need no signature change.</para>
+    /// </remarks>
+    private static DebloaterViewModel NewVm(
+        ISessionRestorePoint restorePoint, IPowerShellRunner? runner = null)
+    {
+        var vm = new DebloaterViewModel(
+            new DebloaterService(runner ?? RunnerThatRemovesSuccessfully()), restorePoint);
+        vm.InitializationComplete.GetAwaiter().GetResult();
+        return vm;
+    }
+
     [Fact]
     public async Task RemoveSelected_TakesTheRestorePointBeforeRemovingAnything()
     {
         var restorePoint = RestorePointTaken();
         using var dialog = new DialogAnswer(confirm: true);
 
-        var vm = new DebloaterViewModel(new DebloaterService(RunnerThatRemovesSuccessfully()), restorePoint);
+        var vm = NewVm(restorePoint);
         vm.Apps.Add(Removable("Contoso.AppA"));
 
         await vm.RemoveSelectedCommand.ExecuteAsync(null);
@@ -149,7 +207,7 @@ public class DebloaterViewModelTests
         var restorePoint = RestorePointTaken();
         using var dialog = new DialogAnswer(confirm: false);
 
-        var vm = new DebloaterViewModel(new DebloaterService(RunnerThatRemovesSuccessfully()), restorePoint);
+        var vm = NewVm(restorePoint);
         vm.Apps.Add(Removable("Contoso.AppA"));
 
         await vm.RemoveSelectedCommand.ExecuteAsync(null);
@@ -162,7 +220,7 @@ public class DebloaterViewModelTests
     public async Task RemoveSelected_WithNothingSelected_TakesNoRestorePoint()
     {
         var restorePoint = RestorePointTaken();
-        var vm = new DebloaterViewModel(new DebloaterService(RunnerThatRemovesSuccessfully()), restorePoint);
+        var vm = NewVm(restorePoint);
         var app = Removable("Contoso.AppA");
         app.IsSelected = false;
         vm.Apps.Add(app);
@@ -177,7 +235,7 @@ public class DebloaterViewModelTests
     {
         using var dialog = new DialogAnswer(confirm: true);
 
-        var vm = new DebloaterViewModel(new DebloaterService(RunnerThatRemovesSuccessfully()), RestorePointTaken());
+        var vm = NewVm(RestorePointTaken());
         vm.Apps.Add(Removable("Contoso.AppA"));
 
         await vm.RemoveSelectedCommand.ExecuteAsync(null);
@@ -199,7 +257,7 @@ public class DebloaterViewModelTests
         // than none at all, because she would press the button on the strength of it.
         using var dialog = new DialogAnswer(confirm: true);
 
-        var vm = new DebloaterViewModel(new DebloaterService(RunnerThatRemovesSuccessfully()), NoRestorePoint());
+        var vm = NewVm(NoRestorePoint());
         vm.Apps.Add(Removable("Contoso.AppA"));
 
         await vm.RemoveSelectedCommand.ExecuteAsync(null);

--- a/SysManager/SysManager.Tests/PipelineStoppedDetectionTests.cs
+++ b/SysManager/SysManager.Tests/PipelineStoppedDetectionTests.cs
@@ -1,0 +1,128 @@
+// SysManager · PipelineStoppedDetectionTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Management.Automation;
+using SysManager.Services;
+
+namespace SysManager.Tests;
+
+/// <summary>
+/// Which exceptions count as "the pipeline was stopped" — the detail that made #2206 invisible locally and
+/// permanent on CI.
+/// </summary>
+/// <remarks>
+/// Cancelling a PowerShell run calls <c>ps.Stop()</c>, and the exception that surfaces depends on WHERE the
+/// pipeline ran. Unelevated, the runspace is in-process and <c>EndInvoke</c> throws
+/// <see cref="PipelineStoppedException"/> directly. Elevated, the runspace is an out-of-process Windows
+/// PowerShell 5.1 child reached over remoting, and the failure comes back as a
+/// <see cref="RemoteException"/> carrying a serialized copy.
+///
+/// <para>The runner's translation arm named the in-process type only, so on an elevated runspace it never
+/// matched and cancellation escaped as a raw PowerShell error rather than as
+/// <c>OperationCanceledException</c>. A developer machine runs unelevated and cannot see that; CI runs as
+/// an administrator and hit it repeatedly, reporting
+/// <c>RemoteException (The pipeline has been stopped.)</c>.</para>
+///
+/// <para>These are unit tests over the predicate rather than integration tests over a real remote failure,
+/// because producing one needs an elevated host. That is the point: the shape CI produced is asserted here
+/// on any machine, at no cost, instead of being discoverable only by shipping.</para>
+/// </remarks>
+public class PipelineStoppedDetectionTests
+{
+    [Fact]
+    public void TheInProcessShape_IsRecognised()
+        => Assert.True(PowerShellRunner.IsPipelineStopped(new PipelineStoppedException()));
+
+    /// <summary>
+    /// A wrapped one counts too — <c>Task.Factory.FromAsync</c> and the runspace plumbing both wrap.
+    /// </summary>
+    [Fact]
+    public void AWrappedOne_IsRecognised()
+        => Assert.True(PowerShellRunner.IsPipelineStopped(
+            new InvalidOperationException("outer", new PipelineStoppedException())));
+
+    /// <summary>
+    /// The remoted shape, built the way remoting actually delivers it: a <c>PSObject</c> whose
+    /// <c>TypeNames</c> carry the <c>Deserialized.</c> prefix.
+    /// </summary>
+    /// <remarks>
+    /// This is the case that would have been missed by an obvious implementation. Remoting does NOT hand
+    /// back the original exception — it rehydrates a <c>PSObject</c> typed
+    /// <c>Deserialized.System.Management.Automation.PipelineStoppedException</c>, so
+    /// <c>SerializedRemoteException.BaseObject is PipelineStoppedException</c> is false and only the type
+    /// NAME identifies it. Asserting the deserialized prefix explicitly is what pins that.
+    /// </remarks>
+    [Fact]
+    public void TheRemotedShape_IsRecognisedByItsDeserializedTypeName()
+    {
+        var serialized = new PSObject(new object());
+        serialized.TypeNames.Clear();
+        serialized.TypeNames.Add("Deserialized.System.Management.Automation.PipelineStoppedException");
+        serialized.TypeNames.Add("Deserialized.System.Management.Automation.RuntimeException");
+
+        var remote = BuildRemoteException(serialized);
+        Assert.True(PowerShellRunner.IsPipelineStopped(remote),
+            "the remoted stopped-pipeline shape was not recognised. Cancelling an ELEVATED run then escapes "
+            + "as a raw PowerShell error instead of OperationCanceledException, which is #2206.");
+    }
+
+    /// <summary>An unrelated failure must NOT be reported as a cancellation, even one from remoting.</summary>
+    /// <remarks>
+    /// Without this the predicate could be "return true" and every test above would still pass — and a real
+    /// script error during a cancelled run would be silently relabelled as "cancelled", hiding it from the
+    /// user and from the log.
+    /// </remarks>
+    [Fact]
+    public void AnUnrelatedRemoteFailure_IsNotRecognised()
+    {
+        var serialized = new PSObject(new object());
+        serialized.TypeNames.Clear();
+        serialized.TypeNames.Add("Deserialized.System.UnauthorizedAccessException");
+
+        Assert.False(PowerShellRunner.IsPipelineStopped(BuildRemoteException(serialized)));
+    }
+
+    [Fact]
+    public void AnUnrelatedException_IsNotRecognised()
+    {
+        Assert.False(PowerShellRunner.IsPipelineStopped(new UnauthorizedAccessException("denied")));
+        Assert.False(PowerShellRunner.IsPipelineStopped(
+            new InvalidOperationException("outer", new TimeoutException())));
+    }
+
+    /// <summary>
+    /// Builds a <see cref="RemoteException"/> carrying <paramref name="serialized"/>.
+    /// </summary>
+    /// <remarks>
+    /// Its constructors that take a serialized payload are not public, so this goes through reflection.
+    /// Deliberately fails loudly rather than returning something approximate: if the shape ever changes,
+    /// these tests must stop and say so instead of quietly asserting over a plain exception and passing for
+    /// the wrong reason.
+    /// </remarks>
+    private static RemoteException BuildRemoteException(PSObject serialized)
+    {
+        var ctor = typeof(RemoteException).GetConstructors(
+                System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Public)
+            .FirstOrDefault(c =>
+            {
+                var p = c.GetParameters();
+                return p.Length >= 2
+                       && p[0].ParameterType == typeof(string)
+                       && p.Any(x => x.ParameterType == typeof(PSObject));
+            });
+
+        Assert.NotNull(ctor);   // the shape changed — fix this helper rather than skipping the case
+
+        var args = ctor!.GetParameters().Select(p =>
+            p.ParameterType == typeof(string) ? (object?)"The pipeline has been stopped."
+            : p.ParameterType == typeof(PSObject) ? serialized
+            : null).ToArray();
+
+        var built = (RemoteException)ctor.Invoke(args);
+        Assert.NotNull(built.SerializedRemoteException);   // the payload really is attached
+        return built;
+    }
+}

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -221,7 +221,47 @@ public sealed class PowerShellRunner : IPowerShellRunner, IDisposable
             // Cancellation calls ps.Stop(), which makes EndInvoke throw PipelineStoppedException.
             // Surface the standard cancellation signal so callers that catch OperationCanceledException
             // treat a cancelled PowerShell run as cancelled rather than as an error.
-            throw new OperationCanceledException(cancellationToken);
+            //
+            // The message distinguishes this from the post-await throw below, and that is diagnostic rather
+            // than decorative: both raise OperationCanceledException, so without it a slow cancellation
+            // cannot be told apart from a stop that never interrupted anything. #2206 was hard precisely
+            // because the only evidence was an elapsed time.
+            throw new OperationCanceledException(
+                "The PowerShell pipeline was stopped by cancellation.", cancellationToken);
+        }
+
+        // A stopped pipeline does NOT always throw, and relying on the catch above alone reported a
+        // cancelled run as a successful one (#2206).
+        //
+        // Two ways to get here with the token cancelled, both measured rather than reasoned about:
+        // opening the runspace above takes a few hundred milliseconds, so a cancel that lands during the
+        // lease runs this callback synchronously (Register does that when the token is already cancelled)
+        // and ps.Stop() hits a NotStarted instance — BeginInvoke/EndInvoke then complete without throwing
+        // and without running the script. Locally that is every time: the token fired at 318 ms, the call
+        // returned at 334 ms, no exception, no output. And on CI the opposite end of the same hole — Stop
+        // failing to interrupt a running pipeline, which then finishes normally 30 seconds later.
+        //
+        // Either way the caller was handed an empty result set and no indication that anything was
+        // cancelled. Every consumer is written around OperationCanceledException — 31 view-models have a
+        // cancel branch and the services deliberately let it propagate — so a silent empty return does not
+        // merely lose the signal, it looks like a successful run that found nothing. Which for a query is
+        // indistinguishable from a real answer.
+        //
+        // Deliberately the OPPOSITE choice from RunProcessAsync, which on the same race lets completion win
+        // ("callers receive the real exit code instead of a false cancellation"). That is right there and
+        // wrong here, and the difference is what the method returns: an exit code from a process that
+        // finished is a true and complete answer worth preserving, whereas an empty collection from a script
+        // that never ran is not an answer at all. There is nothing here to preserve by staying silent.
+        //
+        // Thrown explicitly rather than via ThrowIfCancellationRequested() so the message says WHICH of the
+        // two cancellation paths ran. Reaching here means the pipeline was never interrupted — it either
+        // never started or ran to its natural end — which is a different fact from the catch arm above and
+        // the one #2206 needed five CI failures to establish.
+        if (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(
+                "The PowerShell pipeline was not interrupted by cancellation; it completed on its own.",
+                cancellationToken);
         }
 
         return new Collection<PSObject>(output.ToList());

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -216,11 +216,15 @@ public sealed class PowerShellRunner : IPowerShellRunner, IDisposable
         {
             await task.ConfigureAwait(false);
         }
-        catch (PipelineStoppedException) when (cancellationToken.IsCancellationRequested)
+        catch (Exception ex) when (cancellationToken.IsCancellationRequested && IsPipelineStopped(ex))
         {
-            // Cancellation calls ps.Stop(), which makes EndInvoke throw PipelineStoppedException.
-            // Surface the standard cancellation signal so callers that catch OperationCanceledException
-            // treat a cancelled PowerShell run as cancelled rather than as an error.
+            // Cancellation calls ps.Stop(), which makes EndInvoke throw. Surface the standard cancellation
+            // signal so callers that catch OperationCanceledException treat a cancelled PowerShell run as
+            // cancelled rather than as an error.
+            //
+            // Filtered by IsPipelineStopped rather than by catching PipelineStoppedException directly,
+            // because WHICH type arrives depends on the transport — see that method. This arm used to name
+            // the in-process type only, so on an elevated (out-of-process) runspace it never matched.
             //
             // The message distinguishes this from the post-await throw below, and that is diagnostic rather
             // than decorative: both raise OperationCanceledException, so without it a slow cancellation
@@ -692,6 +696,37 @@ public sealed class PowerShellRunner : IPowerShellRunner, IDisposable
     /// <para><b>A failed open leaves nothing cached.</b> The fresh resources are disposed and the exception
     /// propagates, so the next call starts clean rather than retrying against a half-opened runspace.</para>
     /// </remarks>
+    /// <summary>
+    /// True when <paramref name="ex"/> means "the pipeline was stopped", whichever transport reported it.
+    /// </summary>
+    /// <remarks>
+    /// The type depends on WHERE the pipeline ran, which is why naming one of them was not enough (#2206):
+    /// <list type="bullet">
+    /// <item>unelevated, in-process runspace → <see cref="PipelineStoppedException"/> directly;</item>
+    /// <item>elevated, out-of-process Windows PowerShell 5.1 over remoting →
+    /// <see cref="RemoteException"/> whose <c>SerializedRemoteException</c> is the stopped-pipeline error,
+    /// because the failure happened in the child and was serialized across the transport.</item>
+    /// </list>
+    /// <para>The arm above named the in-process type only, so on an ELEVATED runspace it never matched and
+    /// cancellation escaped as a raw PowerShell error. That is invisible on a developer machine, which runs
+    /// unelevated and takes the first branch, and it is what CI kept hitting: the failure reported
+    /// <c>RemoteException (The pipeline has been stopped.)</c> — the right event, the wrong type, no
+    /// translation. Nine words of a CI log that a local run could not have produced.</para>
+    /// <para><b>The remote arm checks the TYPE NAME, not the type.</b> Remoting does not hand back the
+    /// original exception object — it rehydrates a <c>PSObject</c> whose <c>TypeNames</c> read
+    /// <c>Deserialized.System.Management.Automation.PipelineStoppedException</c>, so an <c>is</c> test
+    /// against the real type is always false. Suffix-matching the type name is what actually holds, and it
+    /// is still locale-independent, unlike matching the message: a non-English Windows would fall out of a
+    /// string comparison on "The pipeline has been stopped." without anything saying so.</para>
+    /// <para><c>internal</c> so the shapes can be asserted directly, rather than needing an elevated host
+    /// to produce a real remote failure.</para>
+    /// </remarks>
+    internal static bool IsPipelineStopped(Exception ex) =>
+        ex is PipelineStoppedException
+        || ex.InnerException is PipelineStoppedException
+        || (ex as RemoteException)?.SerializedRemoteException?.TypeNames
+               .Any(name => name.EndsWith("PipelineStoppedException", StringComparison.Ordinal)) == true;
+
     private async Task<RunspaceLease> LeaseRunspaceAsync()
     {
         if (!_isElevated)

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.96.0</Version>
-    <FileVersion>1.96.0.0</FileVersion>
-    <AssemblyVersion>1.96.0.0</AssemblyVersion>
+    <Version>1.96.1</Version>
+    <FileVersion>1.96.1.0</FileVersion>
+    <AssemblyVersion>1.96.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #2206.

Found by doing what that issue's own plan asked for — **step 2, make the test say more** — rather than by patching the runner. The instrumentation named the root cause on the first local run.

## Root cause

`RunOnLeasedRunspaceAsync` reported cancellation only when `EndInvoke` threw `PipelineStoppedException`. **A stopped pipeline does not always throw.**

Opening the runspace takes a few hundred milliseconds. A cancel landing in that window means the token is already cancelled when `cancellationToken.Register(...)` runs — and `Register` invokes the callback **synchronously** in that case, so `ps.Stop()` lands on a `NotStarted` instance. `BeginInvoke`/`EndInvoke` then complete without throwing *and without running the script*, and the method returns an empty collection.

Reproduced locally on the first attempt, with the new instrumentation:

```
elapsed 00:00:00.3337465; token fired at 318 ms; exception NONE; 0 line(s) captured
```

The caller was handed an empty result set and no indication that anything had been cancelled. For a query like "which DNS servers am I using?" or "what did Defender find?", an empty collection is **indistinguishable from a real answer of "none"** — so the tab renders an empty state instead of saying it was cancelled. 31 view-models have an `OperationCanceledException` branch and the services deliberately let it propagate; this was the one path that never raised it.

The same hole explains the CI shape from the other end: a `Stop()` that fails to interrupt a *running* pipeline, which then finishes normally 30 seconds later — again returning without an exception. That is why all five CI failures sat on the script's own duration (31.12, 30.565, 30.664, 33.82, 32.03 s) with nothing in between.

## The fix, and why it differs from its sibling

One post-await check. Notably it is the **opposite** choice from `RunProcessAsync`, which on the same race deliberately lets completion win — *"callers receive the real exit code instead of a false cancellation"*.

That is right there and wrong here, and the difference is what the method returns: an exit code from a process that finished is a true and complete answer worth preserving, whereas an empty collection from a script that never ran is not an answer at all. There is nothing to preserve by staying silent. The code says so, so the next reader does not have to reconcile the two by guessing.

## The two paths now say which one happened

Both raise `OperationCanceledException`, so before this a slow cancellation could not be told apart from a stop that never interrupted anything — which is precisely why the bug needed five CI failures to pin down. Two distinct messages now:

| message | means |
|---|---|
| "was stopped by cancellation" | `ps.Stop()` interrupted the pipeline. If elapsed is also long, only the bound failed. |
| "was not interrupted by cancellation; it completed on its own" | the script never started, or ran to its natural end. The CI failure shape. |

I found and fixed a flaw in my own diagnostic here: with the post-await throw in place, "OCE + slow elapsed" no longer distinguishes the two, so the message is doing the work the exception type used to.

## Three tests, and why only one is the regression test

**`CancelledWhileTheRunspaceIsOpening`** — deterministic. The `openRunspace` seam blocks until the test has cancelled, so the token is *guaranteed* already cancelled when `Register` runs. No timing, no sleeping, same sequence on every machine. Red before the fix with *"reported NO EXCEPTION"*, green after, **in a full-class run**. It asserts the exception **message**, so it cannot pass on the path that already worked.

**`CancellingARunningPipeline`** — the other path, cancelling a pipeline that is genuinely executing. The script is `while ($true) { [System.Threading.Thread]::Sleep(50) }` and not `Start-Sleep`, because of trap #1 from the issue: `Start-Sleep` lives in `Microsoft.PowerShell.Utility`, which `CreateDefault2()` does not load, so on a dev box it fails instantly and a cancellation that never happened reads as a fast pass. That trap cost a whole round of investigation, so the test asserts the probe **actually blocked** before asserting anything else.

**`SupportsCancellation`** — kept as the CI canary, now reporting elapsed, when the token fired, the exception type *and* its message.

### Why the canary is not the regression test

Its coverage depends on execution order, which I only discovered by mutating:

| run | runspace open | path taken |
|---|---|---|
| alone, cold process | ~300 ms (assembly loading dominates) | cancel lands during the lease → the swallowed path |
| after any other test in the class | ~20 ms | pipeline already running → the throwing path |

**Measured: removing the fix leaves the whole class GREEN, while running that test alone against the same code fails with "exception NONE".** A test whose coverage depends on execution order is not a regression test, so the deterministic one exists.

## Mutations

| mutation | result |
|---|---|
| the post-await throw removed | `CancelledWhileTheRunspaceIsOpening` red — *"reported NO EXCEPTION"* |
| the translation arm downgraded to a bare `rethrow` | both cancellation tests red with `PipelineStoppedException` — proving the two arms cover different paths |
| the post-await condition inverted | **13 red**, proving the condition is what scopes the throw to cancelled runs |

Two earlier mutation attempts did not compile — `when (false)` is rejected as a constant filter (CS8360) and `if (true)` makes the `return` unreachable (CS0162) — so each was rewritten into a shape the compiler accepts. Worth recording, since the obvious mutation is not always available.

## Verification

- All four projects: **0 errors, 0 warnings**.
- Unit suite: **5551 passed, 0 failed**.
- `PowerShellRunnerTests` locally: **27 passed** (25 → 27). Its runspaces are in-process and its one process-spawning test pings loopback by design, so nothing here needs elevation or the network.
- `dotnet format --verify-no-changes`: clean on all four projects.
- Full local pre-commit scan against all 43 current patterns: **0 matches in the added lines**, and no machine name in the diff.
- CHANGELOG in plain language — the user-visible symptom is "Cancel left the tab looking like it had finished with nothing to show". `SECURITY.md` needs no edit: this is a patch, and only the minor line is tracked.
