### PR TITLE
refactor: reject a null collection at the two public parsers instead of dereferencing it

### DIFF
--- a/SysManager/SysManager.Tests/DebloaterServiceTests.cs
+++ b/SysManager/SysManager.Tests/DebloaterServiceTests.cs
@@ -155,6 +155,25 @@ public class DebloaterServiceTests
     public void Parse_EmptyInput_ReturnsEmpty()
         => Assert.Empty(DebloaterService.ParsePackages([]));
 
+    /// <summary>
+    /// A null collection is rejected at the boundary, naming the argument — not dereferenced.
+    /// </summary>
+    /// <remarks>
+    /// Empty and null are different answers and only one of them was handled. The per-element <c>is null</c>
+    /// check inside showed nulls were thought about; the collection itself was missed, on a method that is
+    /// public and documented for direct use (#2259).
+    /// <para>How it was found is the argument for asserting it: an unconfigured test substitute returned a
+    /// null collection, the <c>NullReferenceException</c> travelled up through a view-model's constructor
+    /// init, and the init swallowed it — so a genuine fault was invisible until something awaited the task.
+    /// An <c>ArgumentNullException</c> naming <c>objects</c> would have said what was wrong immediately.</para>
+    /// </remarks>
+    [Fact]
+    public void Parse_NullInput_ThrowsNamingTheArgument()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => DebloaterService.ParsePackages(null!));
+        Assert.Equal("objects", ex.ParamName);
+    }
+
     // ---------- RemoveAsync safety gates ----------
 
     private static StoreApp App(string name, string full, bool isProtected = false) => new()

--- a/SysManager/SysManager.Tests/RestorePointServiceTests.cs
+++ b/SysManager/SysManager.Tests/RestorePointServiceTests.cs
@@ -94,6 +94,22 @@ public class RestorePointServiceTests
     public void Parse_EmptyInput_ReturnsEmpty()
         => Assert.Empty(RestorePointService.ParseRestorePoints([]));
 
+    /// <summary>
+    /// A null collection is rejected at the boundary, naming the argument — not dereferenced.
+    /// </summary>
+    /// <remarks>
+    /// The sibling of <c>DebloaterService.ParsePackages</c>, same shape and same omission: per-element nulls
+    /// handled, the collection itself not, on a method that is public and documented for direct use (#2259).
+    /// Fixed together because fixing only the one that happened to be found is how the second one gets found
+    /// the same way later.
+    /// </remarks>
+    [Fact]
+    public void Parse_NullInput_ThrowsNamingTheArgument()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => RestorePointService.ParseRestorePoints(null!));
+        Assert.Equal("objects", ex.ParamName);
+    }
+
     [Fact]
     public async Task CreateAsync_PowerShellHostUnavailable_ReturnsFalse()
     {

--- a/SysManager/SysManager/Services/DebloaterService.cs
+++ b/SysManager/SysManager/Services/DebloaterService.cs
@@ -130,8 +130,15 @@ public sealed partial class DebloaterService
     /// Parses <c>Get-AppxPackage</c> output into <see cref="StoreApp"/> records, applying the
     /// denylist and curated catalog. Pure and runner-agnostic for unit testing.
     /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="objects"/> is null.</exception>
     public static IReadOnlyList<StoreApp> ParsePackages(IEnumerable<PSObject> objects)
     {
+        // The individual nulls below are handled and the collection itself was not (#2259). Found the hard
+        // way: an unconfigured test substitute returned a null collection, this threw NullReferenceException
+        // inside a view-model's constructor init, and the init swallowed it — so a real fault was invisible
+        // until something awaited the task. Failing here says which argument was wrong.
+        ArgumentNullException.ThrowIfNull(objects);
+
         List<StoreApp> apps = [];
         foreach (var obj in objects)
         {

--- a/SysManager/SysManager/Services/RestorePointService.cs
+++ b/SysManager/SysManager/Services/RestorePointService.cs
@@ -58,8 +58,15 @@ public sealed class RestorePointService
     /// Parses <c>Get-ComputerRestorePoint</c> output into <see cref="RestorePoint"/> records,
     /// sorted newest-first. Pure and runner-agnostic so it can be unit-tested directly.
     /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="objects"/> is null.</exception>
     public static IReadOnlyList<RestorePoint> ParseRestorePoints(IEnumerable<PSObject> objects)
     {
+        // The individual nulls below are handled and the collection itself was not, which is the asymmetry
+        // worth closing on a method that is public and documented for direct use (#2259). Not reachable from
+        // production — PowerShellRunner.RunAsync always returns a collection — so this is about the contract
+        // a caller can rely on, and about failing at the boundary instead of somewhere inside the loop.
+        ArgumentNullException.ThrowIfNull(objects);
+
         List<RestorePoint> points = [];
         foreach (var obj in objects)
         {


### PR DESCRIPTION
Closes #2259.

## The pair, not the instance

`ParsePackages` and `ParseRestorePoints` are the same shape: `public static`, documented *"pure and runner-agnostic so it can be unit-tested directly"*, taking `IEnumerable<PSObject>`, and both handle per-element nulls with `if (obj is null) continue;` while never checking the collection. The asymmetry is the tell — nulls **were** thought about, the argument was missed.

Fixed together, because fixing only the one that happened to be found is how the second one gets found the same way later.

## Not reachable from production, and that is why this is `refactor:`

`PowerShellRunner.RunAsync` ends with `return new Collection<PSObject>(output.ToList())` and never returns null. So this is a contract fix on a public surface, not a user-facing one — a `fix:` would cut a release whose changelog entry has nothing to tell a user.

## Why the tests assert `ParamName`

How this surfaced is the whole argument for guarding it. An unconfigured NSubstitute runner returned a **null** collection, and the resulting `NullReferenceException` travelled up:

```
System.NullReferenceException
   at DebloaterService.ParsePackages(IEnumerable`1 objects)
   at DebloaterViewModel.RefreshAsync()
   at ViewModelBase.RunInitAsync(...)
```

…where the constructor init swallowed it (that half is #2258). So a genuine fault was invisible until something awaited the task. An `ArgumentNullException` naming `objects` would have said what was wrong at the boundary, immediately. Both tests assert the parameter name and not merely the exception type, and both go red with the guard removed.

## Scope, decided by measurement

A sweep over the whole app found **34** `public`/`internal` statics that take a collection and dereference it with no guard, across 24 files:

```
BandwidthFormat.SummarizePorts          ResourceHistoryService.Prune/Downsample/ToCsv
BandwidthHistoryService.Prune/Downsample  ResourceHistoryViewModel.BuildSummary
BandwidthMonitorViewModel.BuildHistorySummary  RestorePointService.ParseRestorePoints  ← fixed
ConnectionBandwidthSource.AggregateConnections/CollectTcp/CollectUdp
CpuAffinityService.MaskFromIndices      SettingsWatchdogService.DetectChanges
DebloaterService.ParsePackages  ← fixed  ShortcutCleanerService.DeleteShortcuts
EnvironmentVariableService.Deduplicate  StartupService.EnrichWithDescriptions/VerifySignatures
FileShredderViewModel.DescribeSkipped   TemperatureService.ApplyStorageNames
GamingProfileService.RunApplyAsync/RunRevertAsync/PerformanceCoreMask
HealthAnalyzer.Analyze                  TweaksHubService.PendingApplyCount/PendingUndoCount
PerformanceService.ParsePlanGuidByName/ParseProcessorMinPercent
ProcessManagerService.VerifySignatures  UninstallerService.EnrichFromRegistry
                                        VolumePresetService.Upsert
                                        WindowsFeaturesService.ParseFeatureList
```

**Guarding all 34 would be a bulk change nobody asked for.** C#'s nullable-reference analysis already flags a null passed to a non-nullable parameter, which covers every in-repo caller; the value is concentrated in the public surface that parses external data and would otherwise fail deep inside a loop. That is these two.

The list is above so the remaining 32 are a decision rather than an oversight. My own read: leave them. If any becomes public and starts taking data from outside the process, guard it then.

## Verification

- App + tests: **0 errors, 0 warnings**.
- Unit suite: **5559 passed, 0 failed** (5557 → 5559).
- Both new tests proven red with the guards removed, green with them.
- `dotnet format --verify-no-changes`: clean.
