### PR TITLE
feat: Duplicate Finder announces the scan phase instead of a five-per-second file feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.97.0] - 2026-09-11
+
+**Duplicate Finder no longer talks over a screen reader while it scans.** Its one status line carried the
+running counts and the name of the file being read, and it changed about five times a second for the whole
+scan — so a screen reader started a new sentence roughly every 200 milliseconds and finished none of them.
+The line is now two: the phase it is in, spoken; and the counts and current file, shown but silent. On screen
+the row looks the same as before. Spoken, a scan of any folder is now three sentences — "Discovering files",
+"Hashing files", "Scan complete" — instead of hundreds of half-finished ones.
+
+### Changed
+
+- **The scan's spoken status is the phase, not the file.** The counts and the file name moved to their own
+  line beside it, which is announced to nobody. Both lines use the same size and colour, so nothing looks
+  different; the difference is entirely in what gets read aloud.
+- Two sentences per scan whatever the folder holds. Rounding the counts instead — announcing every thousand
+  files, say — would have been worse the bigger the folder: any fixed step announces more often the more
+  there is to count.
+- The last report of a scan is no longer rendered. It exists so the counts settle on their final numbers, and
+  it names no real file, so it used to flash a file called "Done" and say the scan had finished twice.
+- The counts clear when a scan ends, however it ends. The totals it produced stay in the summary above.
+
 ## [1.96.1] - 2026-09-11
 
 **Pressing Cancel could leave a tab looking like it had finished successfully with nothing to show.** When a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.96.x   | :white_check_mark: |
-| < 1.96   | :x:                |
+| 1.97.x   | :white_check_mark: |
+| < 1.97   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -6190,14 +6190,15 @@ public partial class ArchitectureTests
         // The rule is "announce the coarsest line each tab has", which is why this list is not simply
         // "anything that updates often". Deep Cleanup's percentage and folder path can be silent because
         // ScanStatusLine says the same thing more slowly; the SFC and DISM ETAs can be silent because the
-        // verdict and the tab's status line cover start and finish. Duplicate Finder's status line updates
-        // five times a second and carries a file name, and is announced anyway — it is the only line that tab
-        // has, so silencing it would leave a screen-reader user with nothing at all, including no "Scan
-        // complete." Splitting a coarse line out of it, the way Deep Cleanup already does, is #2143 — and
-        // when that lands, the per-file property belongs in this list.
+        // verdict and the tab's status line cover start and finish. Duplicate Finder's ScanReadout is the
+        // newest row and the reason this list has no exceptions left: that tab's status line used to carry
+        // the counts and the file name itself, so the one announced line changed five times a second, and
+        // this guard recorded it as a deliberate exception because silencing it would have left a
+        // screen-reader user with nothing at all. #2143 split the phase out into the status line and moved
+        // the fast half here.
         string[] mustStaySilent =
         [
-            "ScanProgress", "LargeCurrentFolder", "SfcEtaText", "DismEtaText",
+            "ScanProgress", "LargeCurrentFolder", "SfcEtaText", "DismEtaText", "ScanReadout",
         ];
 
         var appDir = FindAppProjectDir();
@@ -6708,7 +6709,7 @@ public partial class ArchitectureTests
     /// <summary>
     /// No remaining-time text is a hardcoded duration.
     /// <para>This is a different invariant from
-    /// <see cref="EveryEtaTextProperty_IsClearedWhenItsOperationEnds"/>: that one asks whether the text
+    /// <see cref="EveryTransientReadout_IsClearedWhenItsOperationEnds"/>: that one asks whether the text
     /// is taken DOWN when the work ends, this one asks whether it was ever TRUE. Both can fail
     /// independently, and the Dashboard failed only the second — it dutifully cleared a number it had
     /// invented.</para>
@@ -8446,19 +8447,20 @@ public partial class ArchitectureTests
     // collapse rule serves both, so it is not redeclared here.
 
     /// <summary>
-    /// Every ETA text property must either be cleared when its operation ends, or live inside a section
-    /// the view hides when the operation is not running. Otherwise the last value stays on screen: Speed
-    /// Test left the literal word "done" under BOTH its cards — they share one property — until the next
-    /// run, and after a cancel it stranded whatever the last tick produced, typically "a few seconds".
+    /// Every readout that belongs to one run — an ETA, a per-file line — must either be cleared when its
+    /// operation ends, or live inside a section the view hides when the operation is not running. Otherwise
+    /// the last value stays on screen: Speed Test left the literal word "done" under BOTH its cards — they
+    /// share one property — until the next run, and after a cancel it stranded whatever the last tick
+    /// produced, typically "a few seconds".
     /// <para>Two accepted shapes, because both are already in use and both are correct: clear it in
-    /// <c>finally</c> (AppUpdates, BulkInstaller, Uninstaller, Cleanup, and now SpeedTest), or gate the
-    /// containing panel on an <c>Is…ing</c> flag (DeepCleanup). What is NOT accepted is neither.</para>
+    /// <c>finally</c> (AppUpdates, BulkInstaller, Uninstaller, Cleanup, SpeedTest, DuplicateFile), or gate
+    /// the containing panel on an <c>Is…ing</c> flag (DeepCleanup). What is NOT accepted is neither.</para>
     /// <para>Matched on the CLEARING STATEMENT, not on the words of this comment: a guard that keys on
     /// prose passes because of its own explanation. The population is enumerated from the view models that
     /// actually own an ETA property, so adding a seventh consumer without clearing it fails here.</para>
     /// </summary>
     [Fact]
-    public void EveryEtaTextProperty_IsClearedWhenItsOperationEnds()
+    public void EveryTransientReadout_IsClearedWhenItsOperationEnds()
     {
         var appDir = FindAppProjectDir();
         var vmDir = Path.Combine(appDir, "ViewModels");
@@ -8472,7 +8474,7 @@ public partial class ArchitectureTests
             var source = File.ReadAllText(file);
             var vmName = Path.GetFileNameWithoutExtension(file);
 
-            foreach (var property in EtaTextProperties(source))
+            foreach (var property in TransientReadoutProperties(source))
             {
                 checkedProperties++;
 
@@ -8494,7 +8496,7 @@ public partial class ArchitectureTests
                 // Visibility bindings on its ProgressBar and Cancel button, which have nothing to do with
                 // the ETA TextBlock — leaving this guard green against the exact defect it was written for.
                 var viewPath = Path.Combine(viewsDir, vmName.Replace("ViewModel", "View") + ".xaml");
-                if (File.Exists(viewPath) && EtaElementSitsInAFlagGatedContainer(viewPath, property))
+                if (File.Exists(viewPath) && ReadoutElementSitsInAFlagGatedContainer(viewPath, property))
                     continue;
 
                 offenders.Add($"{vmName}.{property}");
@@ -8502,14 +8504,15 @@ public partial class ArchitectureTests
         }
 
         // Vacuity floor from an enumerated population: AppUpdates, BulkInstaller, Cleanup (×2),
-        // DeepCleanup (×2), SpeedTest, Uninstaller — eight ETA properties across six view models. A
-        // regex that silently stopped matching would otherwise make this pass by checking nothing.
-        Assert.True(checkedProperties >= 8,
-            $"only {checkedProperties} ETA properties were found — EtaBackingField() has stopped "
-          + "matching, so this guard is measuring nothing.");
+        // DeepCleanup (×2), SpeedTest, Uninstaller — eight ETA properties across six view models — plus
+        // DuplicateFile's scan readout, nine. A regex that silently stopped matching would otherwise make
+        // this pass by checking nothing.
+        Assert.True(checkedProperties >= 9,
+            $"only {checkedProperties} transient readouts were found — TransientReadoutBackingField() has "
+          + "stopped matching, so this guard is measuring nothing.");
 
         Assert.True(offenders.Count == 0,
-            "these ETA texts are neither cleared in a finally nor hidden with their section, so the last "
+            "these readouts are neither cleared in a finally nor hidden with their section, so the last "
           + "value stays on screen after the operation ends: " + string.Join(", ", offenders));
     }
 
@@ -8517,9 +8520,9 @@ public partial class ArchitectureTests
     /// Names of the ETA text properties a view model owns. Matches the <c>[ObservableProperty]</c> backing
     /// field, whose generated property is what the view binds.
     /// </summary>
-    private static IEnumerable<string> EtaTextProperties(string source)
+    private static IEnumerable<string> TransientReadoutProperties(string source)
     {
-        foreach (Match m in EtaBackingField().Matches(source))
+        foreach (Match m in TransientReadoutBackingField().Matches(source))
         {
             var field = m.Groups["name"].Value;   // _upgradeEtaText
             yield return char.ToUpperInvariant(field[1]) + field[2..];
@@ -8534,7 +8537,7 @@ public partial class ArchitectureTests
     /// <c>Visibility</c> on the ETA element itself: binding an element's visibility to the very string it
     /// displays is not a gate, it is what kept the stale text on screen.</para>
     /// </summary>
-    private static bool EtaElementSitsInAFlagGatedContainer(string viewPath, string property)
+    private static bool ReadoutElementSitsInAFlagGatedContainer(string viewPath, string property)
     {
         var root = System.Xml.Linq.XDocument.Load(viewPath).Root;
         if (root is null) return false;
@@ -8561,16 +8564,36 @@ public partial class ArchitectureTests
     /// </summary>
     private static List<string> TryFinallyBlocksFeeding(string source, string property)
     {
+        var byName = MethodBodiesByName(source);
         var bodies = new List<string>();
-        foreach (var method in MethodBodies(source))
-        {
-            // An assignment FROM the ETA calculator is what makes this method a feeder; the clear itself
-            // (`= string.Empty`) must not count, or a method that only resets it would look like one.
-            if (!Regex.IsMatch(method, Regex.Escape(property) + @"\s*=\s*(?!string\.Empty|"""")"))
-                continue;
 
-            var finallyBodies = FinallyBodies(method).ToList();
-            bodies.Add(finallyBodies.Count > 0 ? string.Join('\n', finallyBodies) : string.Empty);
+        foreach (var (name, overloads) in byName)
+        {
+            foreach (var method in overloads)
+            {
+                // An assignment FROM the ETA calculator is what makes this method a feeder; the clear itself
+                // (`= string.Empty`) must not count, or a method that only resets it would look like one.
+                if (!Regex.IsMatch(method, Regex.Escape(property) + @"\s*=\s*(?!string\.Empty|"""")"))
+                    continue;
+
+                var finallyBodies = FinallyBodies(method).ToList();
+
+                // A feeder with no try/finally of its own is a progress callback: the operation that invokes
+                // it owns the run, so the clear lives in THAT method's finally. Fall back to the callers'
+                // finally blocks rather than reporting the split as a gap — Duplicate Finder assigns its
+                // readout in ApplyScanProgress and clears it in ScanAsync's finally, which is correct and is
+                // the shape this guard used to fail. The rule is unchanged: whatever block is found still has
+                // to contain the clear, and every feeder still has to be covered.
+                if (finallyBodies.Count == 0)
+                    finallyBodies = byName
+                        .Where(other => !string.Equals(other.Key, name, StringComparison.Ordinal))
+                        .SelectMany(other => other.Value)
+                        .Where(body => Regex.IsMatch(body, @"\b" + Regex.Escape(name) + @"\b"))
+                        .SelectMany(FinallyBodies)
+                        .ToList();
+
+                bodies.Add(finallyBodies.Count > 0 ? string.Join('\n', finallyBodies) : string.Empty);
+            }
         }
         return bodies;
     }
@@ -8640,13 +8663,19 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
-    /// An <c>[ObservableProperty]</c> field holding ETA text — the thing that must not go stale. Both
-    /// spellings in use are matched: seven fields are named <c>…EtaText</c>, and Speed Test's is
-    /// <c>_estimatedTime</c>. Keying on "eta" alone missed exactly the one that carried the defect.
+    /// An <c>[ObservableProperty]</c> field holding text that belongs to one run and must not outlive it.
+    /// All three spellings in use are matched: seven fields are named <c>…EtaText</c>, Speed Test's is
+    /// <c>_estimatedTime</c>, and Duplicate Finder's per-file line is <c>_scanReadout</c>. Keying on "eta"
+    /// alone missed exactly the one that carried the original defect.
+    /// <para>"readout" is a deliberate third alternative, not a convenience: the rule is about text that
+    /// goes stale when an operation ends, which is not a property of ETAs specifically. It also removes an
+    /// accident — the field was first called <c>_scanDetail</c>, which this regex matched anyway because
+    /// "Detail" contains "eta", so the coverage was luck rather than intent.</para>
     /// </summary>
-    [GeneratedRegex(@"\[ObservableProperty\]\s*private\s+string\s+(?<name>_\w*(?:[Ee]ta|[Ee]stimated)\w*)\s*=",
+    [GeneratedRegex(@"\[ObservableProperty\]\s*private\s+string\s+"
+                    + @"(?<name>_\w*(?:[Ee]ta|[Ee]stimated|[Rr]eadout)\w*)\s*=",
                     RegexOptions.Compiled)]
-    private static partial Regex EtaBackingField();
+    private static partial Regex TransientReadoutBackingField();
 
     /// <summary>
     /// Every write on <c>IAudioMixerService</c> that reports whether it was applied must have that answer

--- a/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DuplicateFileViewModelTests.cs
@@ -310,58 +310,143 @@ public class DuplicateFileViewModelTests
     // whether it had stalled on one.
 
     [Fact]
-    public void ScanStatus_NamesTheFileBeingRead()
+    public void ScanReadout_NamesTheFileBeingRead()
     {
-        var status = DuplicateFileViewModel.BuildScanStatus(new Services.DuplicateFileService.ScanProgress(
+        var readout = DuplicateFileViewModel.BuildScanReadout(new Services.DuplicateFileService.ScanProgress(
             FilesDiscovered: 1_234, FilesHashed: 567, BytesProcessed: 0,
             CurrentFile: @"C:\Users\someone\Pictures\holiday-2019\DSC_0042.jpg",
-            Phase: "Hashing"));
+            Phase: "Hashing files…"));
 
-        Assert.Contains("Hashing", status);
-        Assert.Contains("1,234 found", status);
-        Assert.Contains("567 hashed", status);
-        Assert.Contains("DSC_0042.jpg", status);
+        Assert.Contains("1,234 found", readout);
+        Assert.Contains("567 hashed", readout);
+        Assert.Contains("DSC_0042.jpg", readout);
 
         // Only the name: a deep path would dominate a single-line status row. The full path is the tooltip.
-        Assert.DoesNotContain("Pictures", status);
+        Assert.DoesNotContain("Pictures", readout);
+
+        // The phase belongs to the announced line beside this one, so repeating it here would print the
+        // same word on the row twice (#2143).
+        Assert.DoesNotContain("Hashing", readout);
     }
 
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public void ScanStatus_OmitsTheFileWhenThereIsNone(string current)
+    public void ScanReadout_OmitsTheFileWhenThereIsNone(string current)
     {
         // The discovery phase reports ticks before it has a file in hand; the line must not end in a
         // dangling separator.
-        var status = DuplicateFileViewModel.BuildScanStatus(new Services.DuplicateFileService.ScanProgress(
+        var readout = DuplicateFileViewModel.BuildScanReadout(new Services.DuplicateFileService.ScanProgress(
             FilesDiscovered: 10, FilesHashed: 0, BytesProcessed: 0, CurrentFile: current, Phase: "Scanning"));
 
-        Assert.Equal("Scanning — 10 found, 0 hashed", status);
+        Assert.Equal("10 found, 0 hashed", readout);
     }
 
     [Fact]
-    public void ScanStatus_HandlesAFolderPathWithATrailingSeparator()
+    public void ScanReadout_HandlesAFolderPathWithATrailingSeparator()
     {
         // Path.GetFileName returns "" for a path ending in a separator, which would have shown nothing at
         // all after the separator. Discovery reports folders too.
-        var status = DuplicateFileViewModel.BuildScanStatus(new Services.DuplicateFileService.ScanProgress(
+        var readout = DuplicateFileViewModel.BuildScanReadout(new Services.DuplicateFileService.ScanProgress(
             FilesDiscovered: 5, FilesHashed: 0, BytesProcessed: 0,
             CurrentFile: @"C:\Users\someone\Downloads\", Phase: "Scanning"));
 
-        Assert.Contains("Downloads", status);
-        Assert.DoesNotContain("· ·", status);
+        Assert.Contains("Downloads", readout);
+        Assert.DoesNotContain("· ·", readout);
+    }
+
+    // ── The announced half vs the shown half (#2143) ──
+    // The status line is a live region and it used to carry the counts and the file name, so it changed
+    // about five times a second for the whole scan: a screen reader began a new sentence before finishing
+    // the last. The phase now goes to the announced line and the fast half to a silent one beside it.
+
+    private static Services.DuplicateFileService.ScanProgress Tick(
+        long discovered, long hashed, string file, string phase) =>
+        new(discovered, hashed, BytesProcessed: hashed * 1024, CurrentFile: file, Phase: phase);
+
+    [Fact]
+    public void TheAnnouncedLine_ChangesOncePerPhase_WhileTheReadoutChangesEveryTick()
+    {
+        var vm = NewVm();
+        var announced = vm.RecordChangesOf(nameof(vm.StatusMessage), () => vm.StatusMessage);
+        var raised = vm.RecordPropertyChanges();
+
+        // The shape the service produces: it throttles reports to one every 200 ms, so 40 of them is eight
+        // seconds of scanning — a different file and higher counts on each.
+        for (var i = 1; i <= 20; i++)
+            vm.ApplyScanProgress(Tick(i, 0, $"file{i}.jpg", "Discovering files…"));
+        for (var i = 1; i <= 20; i++)
+            vm.ApplyScanProgress(Tick(20, i, $"file{i}.jpg", "Hashing files…"));
+
+        // Two announcements for forty reports. The assertion is on the SEQUENCE, not a count: a count would
+        // also pass if the line said the wrong two things.
+        Assert.Equal(["Discovering files…", "Hashing files…"], announced);
+
+        // …while the eye still gets every tick. Without this half the test would pass on a status line that
+        // simply stopped reporting.
+        Assert.Equal(40, raised.Count(n => n == nameof(vm.ScanReadout)));
     }
 
     [Fact]
-    public void DuplicateFileView_ShowsTheScanStatusWithTheFullPathOnHover()
+    public void TheFinalReport_IsNotRendered_BecauseItsFileNameIsAPlaceholder()
     {
-        // The pure formatter above would pass on the unfixed code, because the view model always built a
-        // status string — what was missing was the file name in it, and the path anywhere at all. Only the
-        // shipped markup can show the tooltip is wired.
-        var xaml = File.ReadAllText(ViewPath("DuplicateFileView.xaml"));
+        // The service sends one last report with settled counts and "Done" where a file path goes. The lines
+        // after the await say the same thing in a full sentence, so rendering it would show a file that does
+        // not exist and announce completion twice.
+        var vm = NewVm();
+        vm.ApplyScanProgress(Tick(900, 900, "photo.jpg", "Hashing files…"));
+        var status = vm.StatusMessage;
+        var readout = vm.ScanReadout;
 
-        Assert.Contains("ToolTip=\"{Binding CurrentFile}\"", xaml);
-        Assert.Contains("TextTrimming=\"CharacterEllipsis\"", xaml);
+        vm.ApplyScanProgress(Tick(900, 900, "Done", "Complete"));
+
+        Assert.Equal(status, vm.StatusMessage);
+        Assert.Equal(readout, vm.ScanReadout);
+        Assert.Equal("photo.jpg", vm.CurrentFile);
+        Assert.DoesNotContain("Done", vm.ScanReadout);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AReportWithNoPhase_LeavesTheAnnouncedLineSayingSomething(string phase)
+    {
+        // A live region set to an empty string announces nothing, so the tab would go silent mid-scan.
+        var vm = NewVm();
+        vm.ApplyScanProgress(Tick(5, 0, "file.jpg", phase));
+
+        Assert.Equal("Scanning…", vm.StatusMessage);
+    }
+
+    [Fact]
+    public void DuplicateFileView_AnnouncesThePhase_AndShowsTheReadoutSilently()
+    {
+        // The view model assertions above would pass on markup that still bound the old single line, and the
+        // live-region rule itself is enforced in ArchitectureTests. What only the shipped markup can show is
+        // which line each half landed on: the tooltip and the trimming belong to the readout now, because the
+        // readout is what carries a file name.
+        var root = System.Xml.Linq.XDocument.Load(ViewPath("DuplicateFileView.xaml")).Root;
+        Assert.NotNull(root);
+
+        System.Xml.Linq.XElement BoundTo(string property) =>
+            Assert.Single(root!.Descendants(),
+                e => e.Name.LocalName == "TextBlock"
+                     && e.Attribute("Text")?.Value == $"{{Binding {property}}}");
+
+        var coarse = BoundTo("StatusMessage");
+        Assert.Equal("{StaticResource StatusLine}", coarse.Attribute("Style")?.Value);
+        Assert.Null(coarse.Attribute("ToolTip"));
+
+        var readout = BoundTo("ScanReadout");
+        Assert.Equal("{Binding CurrentFile}", readout.Attribute("ToolTip")?.Value);
+        Assert.Equal("CharacterEllipsis", readout.Attribute("TextTrimming")?.Value);
+
+        // Caption, not StatusLine: StatusLine IS Caption plus AutomationProperties.LiveSetting, so basing the
+        // readout on it would look identical and quietly put the fast half back into the announcements.
+        var inline = Assert.Single(readout.Elements()
+            .Where(e => e.Name.LocalName == "TextBlock.Style")
+            .SelectMany(e => e.Elements().Where(s => s.Name.LocalName == "Style")));
+        Assert.Equal("{StaticResource Caption}", inline.Attribute("BasedOn")?.Value);
     }
 
     // Walks up from the test binaries to the app project — .xaml is not copied to the output.

--- a/SysManager/SysManager/Services/DuplicateFileService.cs
+++ b/SysManager/SysManager/Services/DuplicateFileService.cs
@@ -29,6 +29,14 @@ public sealed class DuplicateFileService
         string CurrentFile,
         string Phase);
 
+    /// <summary>
+    /// The <see cref="ScanProgress.Phase"/> of the one final report, sent after the walk finishes so a
+    /// consumer sees settled counts. Named because a caller has to be able to recognise it: its
+    /// <see cref="ScanProgress.CurrentFile"/> is the placeholder "Done" rather than a file, so a UI that
+    /// renders every report verbatim would show a file that does not exist.
+    /// </summary>
+    internal const string CompletePhase = "Complete";
+
     // Skip system subtrees that are slow, protected, or pointless.
     private static readonly string[] SkipSegments =
     {
@@ -198,7 +206,7 @@ public sealed class DuplicateFileService
         // branch shows "Scan cancelled." — mirroring LargeFileScanner's finalize.
         ct.ThrowIfCancellationRequested();
 
-        progress?.Report(new ScanProgress(discovered, hashed, bytesProcessed, "Done", "Complete"));
+        progress?.Report(new ScanProgress(discovered, hashed, bytesProcessed, "Done", CompletePhase));
 
         // Only return groups with 2+ files (actual duplicates).
         return hashGroups.Values

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.96.1</Version>
-    <FileVersion>1.96.1.0</FileVersion>
-    <AssemblyVersion>1.96.1.0</AssemblyVersion>
+    <Version>1.97.0</Version>
+    <FileVersion>1.97.0.0</FileVersion>
+    <AssemblyVersion>1.97.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -55,6 +55,18 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
     [ObservableProperty] private string _scanSummary = "Select a folder and click Scan.";
     [ObservableProperty] private string _currentFile = "";
 
+    /// <summary>
+    /// The fast half of the scan report — running counts and the file being read — kept OUT of
+    /// <see cref="ViewModelBase.StatusMessage"/> so it is shown without being announced.
+    /// <para>The status line is a live region, and it used to carry this. The service throttles its reports
+    /// to one every 200 ms, so the announced line changed about five times a second for the length of the
+    /// scan: a screen reader started a new sentence before finishing the last one and conveyed less than a
+    /// line every few seconds would (#2143). Splitting the two is the shape Deep Cleanup already uses —
+    /// announce the coarsest line the tab has, leave the fine readouts silent — and this tab was the only
+    /// exception left.</para>
+    /// </summary>
+    [ObservableProperty] private string _scanReadout = "";
+
     // Distinguishes the un-run state from a completed zero-result scan so the big empty-state overlay
     // doesn't claim "No duplicates found" before the user has ever scanned. Set true only after a scan
     // actually completes (see ScanAsync); a cancelled/failed scan leaves it as-is.
@@ -132,7 +144,7 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
 
         IsBusy = true;
         IsProgressIndeterminate = true;
-        StatusMessage = "Scanning…";
+        StatusMessage = ScanningLabel;
         Groups.Clear();
         TotalWasted = 0;
         GroupCount = 0;
@@ -141,11 +153,7 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
         try
         {
             var minBytes = MinBytesFor(MinSizeKb);
-            var progress = new Progress<DuplicateFileService.ScanProgress>(p =>
-            {
-                CurrentFile = p.CurrentFile;
-                StatusMessage = BuildScanStatus(p);
-            });
+            var progress = new Progress<DuplicateFileService.ScanProgress>(ApplyScanProgress);
 
             var results = await _service.ScanAsync(SelectedFolder, minBytes, progress, ct);
 
@@ -186,7 +194,37 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
             IsBusy = false;
             IsProgressIndeterminate = false;
             CurrentFile = "";
+            // The counts belong to a scan that is over; the summary bar carries the totals from here.
+            // Leaving them would also leave the last file name sitting beside "Scan complete."
+            ScanReadout = "";
         }
+    }
+
+    /// <summary>The status line while a scan is starting, and the fallback if a report carries no phase.</summary>
+    private const string ScanningLabel = "Scanning…";
+
+    /// <summary>
+    /// Applies one progress report: the phase to the announced status line, the counts and current file to
+    /// the silent <see cref="ScanReadout"/>.
+    /// <para>The phase is assigned on every report, five times a second, and that is deliberate rather than
+    /// wasteful: the generated setter drops a value equal to the current one, so PropertyChanged — and with
+    /// it the announcement — fires only when the phase actually changes. That is twice per scan whatever the
+    /// folder contains, which is the pace a spoken line can keep up with. A rounded count would not have
+    /// that property: any fixed rounding step announces more often the bigger the folder is.</para>
+    /// <para>Internal so a test can drive the real callback body with a synthetic stream of reports; the
+    /// split only holds if the announced property is assigned the coarse half, and nothing else can see
+    /// that.</para>
+    /// </summary>
+    internal void ApplyScanProgress(DuplicateFileService.ScanProgress p)
+    {
+        // The final report exists so a consumer sees settled counts, and its CurrentFile is the placeholder
+        // "Done" rather than a file. The lines after the await say the same thing in a full sentence, so
+        // rendering it here would both show a file that does not exist and announce completion twice.
+        if (string.Equals(p.Phase, DuplicateFileService.CompletePhase, StringComparison.Ordinal)) return;
+
+        CurrentFile = p.CurrentFile;
+        StatusMessage = string.IsNullOrWhiteSpace(p.Phase) ? ScanningLabel : p.Phase;
+        ScanReadout = BuildScanReadout(p);
     }
 
     /// <summary>The largest <see cref="MinSizeKb"/> that still scales into a <c>long</c> byte count.</summary>
@@ -207,16 +245,20 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
     internal static long MinBytesFor(long minSizeKb) => Math.Clamp(minSizeKb, 0, MaxMinSizeKb) * 1024;
 
     /// <summary>
-    /// The scan's status line: phase, running counts, and the file currently being read.
+    /// The silent half of the scan report: running counts and the file currently being read.
     /// <para>The file name was reported by the service and assigned to <see cref="CurrentFile"/> on every
     /// progress tick, but nothing displayed it — so a scan of a large folder showed only rising numbers,
-    /// with no sign of which file it was on or whether it had stalled on one. Only the name is shown; the
-    /// full path goes in the row's tooltip, because a deep path would otherwise dominate the line.</para>
+    /// with no sign of which file it was on or whether it had stalled on one.</para>
+    /// <para><see cref="Path.GetFileName(string)"/> is applied defensively rather than to shorten anything:
+    /// the service reports <c>FileInfo.Name</c>, so what arrives is already a bare name. It stays because
+    /// this method has no way to know that and a full path would otherwise dominate the row.</para>
+    /// <para>The phase is NOT repeated here: it is what the announced status line beside this one carries,
+    /// so printing it twice would put the same word on the row twice (#2143).</para>
     /// <para>Pure and static so the formatting is testable without running a scan.</para>
     /// </summary>
-    internal static string BuildScanStatus(DuplicateFileService.ScanProgress p)
+    internal static string BuildScanReadout(DuplicateFileService.ScanProgress p)
     {
-        var counts = string.Create(CultureInfo.InvariantCulture, $"{p.Phase} — {p.FilesDiscovered:N0} found, {p.FilesHashed:N0} hashed");
+        var counts = string.Create(CultureInfo.InvariantCulture, $"{p.FilesDiscovered:N0} found, {p.FilesHashed:N0} hashed");
 
         // Path.GetFileName returns "" for a directory path ending in a separator, and the discovery phase
         // reports folders as well as files; fall back to the raw value rather than showing nothing.

--- a/SysManager/SysManager/Views/DuplicateFileView.xaml
+++ b/SysManager/SysManager/Views/DuplicateFileView.xaml
@@ -183,17 +183,22 @@
             <ProgressBar AutomationProperties.Name="Duplicate file scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
                          IsIndeterminate="{Binding IsProgressIndeterminate}"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <!-- The status text now carries the file being read, so it can be long; trim it rather than
-                 letting a deep path stretch the row. The full path is on hover — the scan reported it on
-                 every tick and nothing ever showed it. -->
-            <TextBlock Text="{Binding StatusMessage}"
+            <!-- Two lines, not one, and they look identical on purpose: StatusLine IS Caption plus
+                 AutomationProperties.LiveSetting. So the row reads the same as before while only its coarse
+                 half is spoken. The status line carried the counts and the file name and changed five times
+                 a second, which announced a new sentence before the last one finished (#2143). -->
+            <TextBlock DockPanel.Dock="Left" Text="{Binding StatusMessage}"
+                       Style="{StaticResource StatusLine}" Margin="0,0,8,0"/>
+            <!-- Trimmed rather than allowed to stretch the row: the counts plus a long file name can exceed
+                 the width at a small window size. The tooltip carries CurrentFile, which the scan reports on
+                 every tick and nothing else shows. -->
+            <TextBlock Text="{Binding ScanReadout}"
                        TextTrimming="CharacterEllipsis"
                        ToolTip="{Binding CurrentFile}">
                 <TextBlock.Style>
-                    <!-- BasedOn StatusLine, not Caption: this is the one status line in the app declared as
-                         an inline style rather than a style reference, because it adds a tooltip trigger.
-                         It still has to be announced like the other 51. -->
-                    <Style TargetType="TextBlock" BasedOn="{StaticResource StatusLine}">
+                    <!-- BasedOn Caption, NOT StatusLine: same appearance, no live region. Declared inline
+                         rather than as a style reference because it adds a tooltip trigger. -->
+                    <Style TargetType="TextBlock" BasedOn="{StaticResource Caption}">
                         <!-- No tooltip outside a scan: an empty one renders as a stray blank box. -->
                         <Setter Property="ToolTipService.IsEnabled" Value="False"/>
                         <Style.Triggers>


### PR DESCRIPTION
Closes #2143.

## What was wrong

`DuplicateFileViewModel` set `StatusMessage = BuildScanStatus(p)` on every progress report, and that string carried the running counts *and* the file being read. `DuplicateFileService` throttles its reports to one every 200 ms, so the tab's only announced line changed about five times a second for the length of a scan — a screen reader began a new sentence roughly every 200 ms and finished none of them.

The codebase's rule is *announce the coarsest line each tab has*. Deep Cleanup announces `ScanStatusLine` and leaves its percentage and folder path silent; Quick Cleanup announces the SFC and DISM verdicts and leaves the ETAs silent. Duplicate Finder had no coarse line, so `ArchitectureTests.EveryStatusLine_IsALiveRegion_AndTheFastReadoutsAreNot` recorded it as a deliberate exception — announcing nothing would have left a screen-reader user with no start, no progress and no "Scan complete." That exception is now gone; the list has none.

## The split

| | carries | announced |
|---|---|---|
| `StatusMessage` | the phase | yes (`StatusLine`) |
| `ScanReadout` | `1,234 found, 567 hashed · DSC_0042.jpg` | no (`Caption`) |

`StatusLine` **is** `Caption` plus `AutomationProperties.LiveSetting`, so the two lines are visually identical and the row reads exactly as it did. The whole change is in what gets spoken.

**The phase is assigned on every report and that is deliberate, not wasteful.** The generated `[ObservableProperty]` setter drops a value equal to the current one, so `PropertyChanged` — and with it the announcement — fires only when the phase actually changes. Two announcements per scan whatever the folder holds.

**Why not round the counts**, which is what the issue proposed ("as round numbers tick over"): any fixed rounding step announces *more* often the bigger the folder is. Rounding to the nearest thousand is three announcements for a 3,000-file folder and two hundred for a 200,000-file one, and the second case is where a spoken line matters most. Bounding the rate properly needs a time-based throttle in the view model, which is a second throttle on top of the service's and a bigger design than this. The phase is bounded at 2 by construction.

## Also in the diff

- **The service's terminal report is no longer rendered.** It exists so a consumer sees settled counts, and its `CurrentFile` is the placeholder `"Done"` — so it used to flash a file that does not exist and announce completion twice, once as "Complete" and once as "Scan complete." The sentinel is now `DuplicateFileService.CompletePhase` rather than a bare string in two places.
- **A false comment corrected.** The view and the view model both claimed "the full path goes in the row's tooltip". The service reports `FileInfo.Name`, so `CurrentFile` has never held a path and the tooltip shows the same text as the line's tail. The comments now say what is true; the tooltip being redundant is filed separately rather than fixed here, because it is user-visible and belongs in its own release note.
- **`ScanReadout` is cleared in the scan's `finally`,** so a cancelled or failed scan leaves no counts behind. The totals live in the summary card above.

## The guard change, and why it is in this PR

`EveryEtaTextProperty_IsClearedWhenItsOperationEnds` failed on the first version of this diff, for two reasons worth stating.

**One: the field was called `_scanDetail`, and that regex matched it** — `_\w*[Ee]ta\w*` matches "_scanD**eta**il". The coverage was luck. Renaming to `_scanReadout` and adding `[Rr]eadout` as an explicit third alternative makes it intent: the rule is about text that goes stale when an operation ends, which is not a property of ETAs. The guard, its helpers and its messages are renamed to match (`EveryTransientReadout_IsClearedWhenItsOperationEnds`), and its vacuity floor moves 8 → 9.

**Two: the guard could not see a clear that lives in a different method from the assignment.** It looked for a `try/finally` in the method that *feeds* the property; here the feed is `ApplyScanProgress` (a progress callback, no try of its own) and the clear is in `ScanAsync`'s `finally`. It now falls back to the finally blocks of the methods that reference the feeder. The rule is unchanged — whatever block it finds still has to contain the clear, and every feeder still has to be covered — so mutation 8 below is the one that matters.

## Verification

App + all four test projects: **0 errors, 0 warnings**. `dotnet format --verify-no-changes`: clean. Unit suite **5563 passed, 0 failed** (5559 → 5563).

Nine mutations, each reverted after measuring. Every one red, restored baseline green:

| mutation | result |
|---|---|
| 1 announced line carries the fast half again (the defect) | 3 failed |
| 2 terminal report rendered like any other | 1 failed |
| 3 empty phase blanks the live region | 2 failed |
| 4 phase back into the readout | 3 failed |
| 5 readout based on `StatusLine`, so it is announced | markup + live-region guard failed |
| 6 readout bound back to `StatusMessage` | markup + live-region guard failed |
| 7 the scan's `finally` no longer clears the readout | readout guard failed |
| 8 an **existing** ETA's clear removed — did widening blind the old eight? | readout guard failed |
| 9 caller-following fallback removed — is it load-bearing? | readout guard failed |

The new behavioural test drives the real callback with 40 synthetic reports (twenty discovery, twenty hashing, a different file and higher counts on each) and asserts the announced **sequence** is exactly `["Discovering files…", "Hashing files…"]` while `ScanReadout` raised 40 times. A count alone would pass on a line that said the wrong two things; the readout half is there so it cannot pass on a status line that simply went quiet.

## Not verified here

Whether the new pace *sounds* right is a Narrator question, and the issue asked for that pass. It is deferred to the secondary workstation along with the visual check that the two-line row still fits at a small window size. What is proven here is the mechanism: two announcements instead of hundreds, and the row rendering the same text as before.
