### PR TITLE
fix: Duplicate Finder's scan tooltip showed the same text as the line it was on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.97.1] - 2026-09-11
+
+**Hovering the scan line in Duplicate Finder now tells you which folder it is in.** It showed a tooltip, and
+the tooltip showed the same file name the line already showed — so pointing at it told you nothing. The tab
+was only ever told the file's name, never where it lived, and the same name occurs in dozens of folders, which
+on this tab is the whole point. Hover now shows the full path. Two smaller things came with it: a scan of a
+small folder used to show no file at all, because the first report waited a fifth of a second that the scan
+never lasted, and the line kept showing the last file of the previous stage after the stage had changed.
+
+### Fixed
+
+- The scan reports the file's full path, so the row shows the name and the hover shows the folder. Both are
+  worth having and neither was available before: the line was trimmed to fit and the tooltip repeated it.
+- **A folder that scans in under 200 milliseconds now shows what it is doing.** The rate limit on progress
+  reports was "no sooner than 200 ms from now" rather than "no more often than every 200 ms", so a fast scan
+  produced no report at all and the line stayed blank from start to finish.
+- The stage and the file beside it now change together. The rate limit carried over from finding files into
+  hashing them, so the line could read "Hashing files" while still naming the last file it had *found*.
+
 ## [1.97.0] - 2026-09-11
 
 **Duplicate Finder no longer talks over a screen reader while it scans.** Its one status line carried the

--- a/SysManager/SysManager.IntegrationTests/DuplicateFileServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DuplicateFileServiceTests.cs
@@ -1,0 +1,126 @@
+// SysManager · DuplicateFileServiceTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.Concurrent;
+using System.IO;
+using SysManager.Services;
+
+namespace SysManager.IntegrationTests;
+
+/// <summary>
+/// Tests for the shape of <see cref="DuplicateFileService"/>'s progress reports, against a real folder tree
+/// on disk. Here rather than in the unit project because the reports only exist while a real walk is running:
+/// nothing about them can be observed without a filesystem.
+/// </summary>
+public class DuplicateFileServiceTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "SysManagerTests", "dupe-progress-" + Guid.NewGuid().ToString("N"));
+
+    /// <summary>
+    /// Collects reports on the thread that raises them.
+    /// </summary>
+    /// <remarks>
+    /// NOT <see cref="Progress{T}"/>, which is what production uses: it POSTS each callback to a captured
+    /// synchronization context, so a report raised just before the scan returns can still be in flight when
+    /// the assertions run. That is a test that passes on timing rather than on behaviour. Implementing
+    /// <see cref="IProgress{T}"/> directly makes <c>Report</c> synchronous, so every report has arrived by
+    /// the time the awaited scan completes.
+    /// </remarks>
+    private sealed class SynchronousProgress<T> : IProgress<T>
+    {
+        public ConcurrentQueue<T> Reports { get; } = new();
+        public void Report(T value) => Reports.Enqueue(value);
+    }
+
+    /// <summary>Two identical files in a subfolder, so the walk descends and finds a duplicate pair.</summary>
+    private string SeedTree()
+    {
+        var nested = Path.Combine(_root, "photos", "2019");
+        Directory.CreateDirectory(nested);
+        var content = new byte[8 * 1024];
+        Random.Shared.NextBytes(content);
+        File.WriteAllBytes(Path.Combine(nested, "holiday.bin"), content);
+        File.WriteAllBytes(Path.Combine(nested, "holiday-copy.bin"), content);
+        return nested;
+    }
+
+    private static bool IsPerFile(DuplicateFileService.ScanProgress r) =>
+        !string.Equals(r.Phase, DuplicateFileService.CompletePhase, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Every per-file report carries the file's full path, not its name.
+    /// </summary>
+    /// <remarks>
+    /// The consumer shows the leaf on its status row and the whole path on hover. While this reported
+    /// <c>FileInfo.Name</c>, the hover was a copy of the row it was attached to — the same words, so pointing
+    /// at the row told the user nothing (#2262). The same file name occurs in many folders, and which folder
+    /// the scan is in is the one thing a single row cannot show.
+    /// <para>Asserted as "a rooted path under the folder we asked about", not merely "contains a separator":
+    /// a name with a separator in it would satisfy the weaker form.</para>
+    /// </remarks>
+    [Fact]
+    public async Task ScanAsync_ReportsTheFullPathOfEachFile_NotJustItsName()
+    {
+        var nested = SeedTree();
+        var progress = new SynchronousProgress<DuplicateFileService.ScanProgress>();
+
+        await new DuplicateFileService().ScanAsync(_root, minSizeBytes: 1, progress);
+
+        // The final report is a placeholder rather than a file, excluded by its named phase for the same
+        // reason the view model skips it.
+        var perFile = progress.Reports.Where(IsPerFile).ToList();
+
+        Assert.NotEmpty(perFile);   // else everything below asserts over nothing
+
+        // BOTH report sites have to be exercised, or this proves the shape of one and says nothing about the
+        // other — which is exactly what happened: with the hashing pass unreported on a folder this small,
+        // putting the bare name back at that site left the test green. The two phases are the two sites.
+        Assert.Contains(perFile, r => r.Phase.StartsWith("Discovering", StringComparison.Ordinal));
+        Assert.Contains(perFile, r => r.Phase.StartsWith("Hashing", StringComparison.Ordinal));
+
+        foreach (var r in perFile)
+        {
+            Assert.True(Path.IsPathRooted(r.CurrentFile),
+                $"a progress report named \"{r.CurrentFile}\", which is not a rooted path. The consumer puts "
+                + "this on a tooltip beside a row that already shows the file name, so a bare name makes the "
+                + "tooltip a copy of the row.");
+            Assert.StartsWith(nested, r.CurrentFile, StringComparison.OrdinalIgnoreCase);
+            Assert.NotEqual(Path.GetFileName(r.CurrentFile), r.CurrentFile);
+        }
+    }
+
+    /// <summary>
+    /// A scan short enough to finish inside the report throttle still reports a file from its FIRST phase.
+    /// </summary>
+    /// <remarks>
+    /// The throttle is "not more often than every 200 ms". Seeding its timestamp with the current tick made
+    /// it "not before 200 ms have passed" as well, so a folder that scans faster than that produced no
+    /// discovery report at all and the readout stayed blank until hashing began. This tree is deliberately
+    /// tiny, which is what makes it the case that used to fail.
+    /// <para>Asserted on the first report's PHASE rather than on "some report exists": the test above already
+    /// requires reports from both phases, so a mere existence check here would duplicate it and pin nothing
+    /// of its own. What only this test can see is whether the very first one had to wait.</para>
+    /// </remarks>
+    [Fact]
+    public async Task ScanAsync_OnATreeFasterThanTheThrottle_StillReportsItsFirstDiscoveredFile()
+    {
+        SeedTree();
+        var progress = new SynchronousProgress<DuplicateFileService.ScanProgress>();
+
+        await new DuplicateFileService().ScanAsync(_root, minSizeBytes: 1, progress);
+
+        var first = progress.Reports.FirstOrDefault(IsPerFile);
+        Assert.NotNull(first);
+        Assert.StartsWith("Discovering", first.Phase, StringComparison.Ordinal);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); }
+        catch (IOException) { /* a temp tree left behind is not a test failure */ }
+        catch (UnauthorizedAccessException) { /* ditto */ }
+        GC.SuppressFinalize(this);
+    }
+}

--- a/SysManager/SysManager/Services/DuplicateFileService.cs
+++ b/SysManager/SysManager/Services/DuplicateFileService.cs
@@ -22,6 +22,17 @@ namespace SysManager.Services;
 public sealed class DuplicateFileService
 {
     /// <summary>Progress payload.</summary>
+    /// <param name="FilesDiscovered">Files seen so far that clear the minimum size.</param>
+    /// <param name="FilesHashed">Files whose content has been hashed so far.</param>
+    /// <param name="BytesProcessed">Total bytes read by the hashing pass.</param>
+    /// <param name="CurrentFile">
+    /// The FULL path of the file being read — not its name. A consumer showing a single row wants the leaf
+    /// and can take it with <see cref="Path.GetFileName(string)"/>; one that reported only the name could
+    /// not go the other way, which left a tooltip promising the path showing the row's own text (#2262).
+    /// The one exception is the final report, whose value is the placeholder described on
+    /// <see cref="CompletePhase"/>.
+    /// </param>
+    /// <param name="Phase">Plain-language stage, or <see cref="CompletePhase"/> for the final report.</param>
     public sealed record ScanProgress(
         long FilesDiscovered,
         long FilesHashed,
@@ -74,7 +85,13 @@ public sealed class DuplicateFileService
         long discovered = 0;
         var stack = new Stack<string>();
         stack.Push(rootPath);
-        var lastReport = Environment.TickCount64;
+
+        // Zero, not the current tick: the throttle below is "not more often than every 200 ms", and seeding
+        // it with now made that "not before 200 ms have passed" as well. A folder that scans in less than
+        // that reported no file at all, so the readout stayed blank for the whole scan — and it also made
+        // the report shape untestable, because no test folder is slow enough to produce one. TickCount64 is
+        // time since boot, so the first file always clears the gap and every file after it is throttled.
+        var lastReport = 0L;
 
         while (stack.Count > 0 && !ct.IsCancellationRequested)
         {
@@ -110,7 +127,11 @@ public sealed class DuplicateFileService
                     var now = Environment.TickCount64;
                     if (now - lastReport >= 200)
                     {
-                        progress?.Report(new ScanProgress(discovered, 0, 0, fi.Name, "Discovering files…"));
+                        // The FULL path, not fi.Name: the consumer shows the leaf on its status row and the
+                        // whole path on hover, and reporting the name made the hover a copy of the row
+                        // (#2262). The same name occurs in many folders, and which folder the scan is in is
+                        // the one thing the row cannot show.
+                        progress?.Report(new ScanProgress(discovered, 0, 0, fi.FullName, "Discovering files…"));
                         lastReport = now;
                     }
                 }
@@ -139,6 +160,13 @@ public sealed class DuplicateFileService
         long hashed = 0;
         long bytesProcessed = 0;
         var hashGroups = new Dictionary<string, DuplicateFileGroup>();
+
+        // Reset the throttle at the phase boundary, for the same reason it starts at zero: the phase the
+        // consumer announces changes here, and without this the first hashed file is only reported if 200 ms
+        // happen to have passed since the last discovered one. On a small folder they have not, so the line
+        // said "Hashing files…" while the file beside it was still the last one DISCOVERED — or, if discovery
+        // itself was short, showed nothing at all.
+        lastReport = 0L;
 
         foreach (var group in candidates)
         {
@@ -191,7 +219,8 @@ public sealed class DuplicateFileService
                         var now = Environment.TickCount64;
                         if (now - lastReport >= 200)
                         {
-                            progress?.Report(new ScanProgress(discovered, hashed, bytesProcessed, fi.Name, "Hashing files…"));
+                            // Full path, for the reason given at the discovery report above (#2262).
+                            progress?.Report(new ScanProgress(discovered, hashed, bytesProcessed, fi.FullName, "Hashing files…"));
                             lastReport = now;
                         }
                     }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.97.0</Version>
-    <FileVersion>1.97.0.0</FileVersion>
-    <AssemblyVersion>1.97.0.0</AssemblyVersion>
+    <Version>1.97.1</Version>
+    <FileVersion>1.97.1.0</FileVersion>
+    <AssemblyVersion>1.97.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DuplicateFileViewModel.cs
@@ -249,9 +249,9 @@ public sealed partial class DuplicateFileViewModel : ViewModelBase
     /// <para>The file name was reported by the service and assigned to <see cref="CurrentFile"/> on every
     /// progress tick, but nothing displayed it — so a scan of a large folder showed only rising numbers,
     /// with no sign of which file it was on or whether it had stalled on one.</para>
-    /// <para><see cref="Path.GetFileName(string)"/> is applied defensively rather than to shorten anything:
-    /// the service reports <c>FileInfo.Name</c>, so what arrives is already a bare name. It stays because
-    /// this method has no way to know that and a full path would otherwise dominate the row.</para>
+    /// <para>Only the leaf is shown: the service reports the full path, and a deep one would dominate the
+    /// row. The whole path is on the row's tooltip, so nothing is lost — that pairing is the point, and it
+    /// did not hold until the service stopped reporting a bare name (#2262).</para>
     /// <para>The phase is NOT repeated here: it is what the announced status line beside this one carries,
     /// so printing it twice would put the same word on the row twice (#2143).</para>
     /// <para>Pure and static so the formatting is testable without running a scan.</para>


### PR DESCRIPTION
Closes #2262.

## The tooltip

`DuplicateFileService` reported `FileInfo.Name` on both of its per-file progress sites, so `CurrentFile` never held a path — while the view and the view model both documented the tooltip as showing the full one:

> the full path goes in the row's tooltip, because a deep path would otherwise dominate the line

Hovering the status row therefore showed the file name the row already ended in. `Path.GetFileName` in the readout builder was a no-op on it.

Reporting `fi.FullName` makes the pair do what it claimed: the leaf on the row, the folder on hover. Deleting the tooltip was the smaller option and the wrong one — the same file name occurs in dozens of folders, and on a tab whose entire subject is *which copy is which*, "where is it" is the question the trimmed row cannot answer.

The cost is one string allocation per **report**, not per file: both sites sit behind the 200 ms gate.

## Two throttle defects, found while making that testable

Neither was in the issue. Both surfaced because no test folder is slow enough to produce a report, which is itself the symptom.

**The gate was seeded with the current tick.** `var lastReport = Environment.TickCount64;` makes `now - lastReport >= 200` false until 200 ms have elapsed, so the rule was "no report before 200 ms have passed" rather than "no more often than every 200 ms". A folder that scanned faster than that produced **no per-file report at all** and the readout line stayed blank from start to finish. `TickCount64` is time since boot, so seeding with `0` lets the first file through and throttles every file after it.

**The gate carried across the phase boundary.** One `lastReport` covers both passes, so the first hashed file was reported only if 200 ms happened to have elapsed since the last discovered one. On a small folder they had not — so the announced phase changed to "Hashing files…" while the file named beside it was still the last one *discovered*. It is now reset where the phase changes.

That second one is also what exposed a gap in my own test: with the hashing site never reporting, putting the bare name back **there** left the test green. See mutation 2 below — it was green in the first pass and is red now.

## Verification

All four projects: **0 errors, 0 warnings**. `dotnet format --verify-no-changes`: clean. Unit suite **5563 passed, 0 failed**. New integration tests: 2, and the closest existing class (`LargeFileScannerTests`) still green — 17 passed together.

Four mutations, each reverted after measuring:

| mutation | `ReportsTheFullPath…` | `…StillReportsItsFirstDiscoveredFile` |
|---|---|---|
| 1 discovery site reports `fi.Name` again | **failed** | green |
| 2 hashing site reports `fi.Name` again | **failed** | green |
| 3 gate seeded with the current tick again | **failed** — no discovery report | **failed** — first report is from hashing |
| 4 gate no longer reset at the phase boundary | **failed** — no hashing report | green |

Baseline green before and after each. The two tests pin different things on purpose: the first requires reports from **both** phases carrying a rooted path under the folder that was asked about; the second checks only whether the *first* report had to wait, which is the one thing the first test cannot see.

## Two notes on how the tests are written

**Not `Progress<T>`.** Production uses it, but it *posts* each callback to a captured synchronization context, so a report raised just before the scan returns can still be in flight when the assertions run — a test that passes on timing. The fixture implements `IProgress<T>` directly, making `Report` synchronous, so every report has arrived by the time the awaited scan completes.

**Asserted as "a rooted path under the folder we asked about", not "contains a separator".** A name with a separator in it would satisfy the weaker form, and `Assert.NotEqual(Path.GetFileName(x), x)` closes the last gap.

## Not verified here

That the tooltip *looks* right — a deep path in a hover box at a small window size — is a laptop check, along with confirming the readout now appears immediately on a small folder rather than staying blank.
