### PR TITLE
feat: every tab now explains itself under its own title, not just 54 of 58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.98.0] - 2026-09-11
+
+**Four tabs never said what they were for, and now all 58 do.** Under its title, every tab has a line of
+plain language explaining what it does — that is the app's oldest habit and the main reason it reads well if
+you are not a technician. Four tabs put a live status message in that spot instead, so they had a title, a
+number that kept changing, and no explanation anywhere on the page. New App Alerts opened with "Starting
+monitoring…", Shortcut Cleaner with "Click Scan to find broken shortcuts.", the Dashboard with your Windows
+version and how long the PC had been on, and App Blocker with a count of what was blocked. The status line is
+still there; the explanation now comes first.
+
+### Added
+
+- **App Blocker says what it does and that you can undo it.** It was the worst of the four and the one that
+  matters most: it is the tab that changes the Windows registry, and the only text describing it was the
+  yellow banner saying it needs administrator rights — which explains the permission, not the purpose.
+- **Shortcut Cleaner says where the shortcuts go.** They go to the Recycle Bin unless you tick otherwise, so
+  you can put any of them back; the old line was an instruction to press Scan.
+- **New App Alerts says it only watches.** It tells you when a program installs itself; removing one is a
+  different tab, and now it says so.
+- **The Dashboard says what the screen is for**, in one short line — it is the first thing anyone reads on
+  opening the app, and it described the PC rather than the page. Kept short on purpose: that header shares a
+  row with the buttons beside it.
+- A test now holds the rule for every tab, including any added later, so this cannot come back one tab at a
+  time. It needs no list of exceptions: a file with no page title is not a tab.
+
 ## [1.97.1] - 2026-09-11
 
 **Hovering the scan line in Duplicate Finder now tells you which folder it is in.** It showed a tooltip, and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.97.x   | :white_check_mark: |
-| < 1.97   | :x:                |
+| 1.98.x   | :white_check_mark: |
+| < 1.98   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -6294,6 +6294,114 @@ public partial class ArchitectureTests
             + "user instead of informing them:\n  " + string.Join("\n  ", overAnnounced));
     }
 
+    /// <summary>
+    /// Every tab explains itself in writing under its own title.
+    /// <para>The convention is a <c>Display</c> header followed by a <c>Subtle</c> line of plain language
+    /// saying what the tab is for — and it is the main reason the app reads well for someone who is not a
+    /// technician. Four views bound that slot to a live status string instead, so they had a title, a
+    /// changing status, and no explanation anywhere on the page: App Alerts opened with "Starting
+    /// monitoring…", Shortcut Cleaner with "Click Scan to find broken shortcuts.", the Dashboard with the OS
+    /// name and uptime, and App Blocker — the one tab that writes IFEO registry keys — with a count of what
+    /// was blocked. Its only descriptive text was the elevation banner, which explains the PERMISSION and
+    /// never the purpose or how to undo it (#1506).</para>
+    /// <para>The population needs no allowlist, which is what makes this rule survivable: a file with no
+    /// <c>Display</c> header is not a tab and is skipped mechanically. The six that skip are exactly the
+    /// non-tab controls (AdminBanner, ConsoleView, DevelopmentBanner, EmptyState, StatusFooter, ThemePopup),
+    /// so a new tab is covered the moment it exists rather than when someone remembers to list it.</para>
+    /// <para>BOTH spellings of a bound subtitle are rejected. The sweep that first counted these found three
+    /// because it read the <c>Text</c> ATTRIBUTE; a <c>TextBlock</c> with no <c>Text</c> attribute whose
+    /// <c>&lt;Run&gt;</c> children carry the bindings reads as empty rather than as bound, and that is the
+    /// form the Dashboard used — the fourth, and the first subtitle anyone sees on opening the app.</para>
+    /// </summary>
+    [Fact]
+    public void EveryTabView_ExplainsItselfUnderItsHeader()
+    {
+        // Measured: the shortest real explanation is AboutView's 40 characters ("Version info, updates and
+        // release notes."). The floor sits below it so this guard rejects a placeholder without forcing a
+        // rewrite of the terse-but-adequate ones, which is a separate judgement (#1654).
+        const int shortestUsefulExplanation = 35;
+
+        var appDir = FindAppProjectDir();
+        var viewsDir = Path.Combine(appDir, "Views");
+        var files = Directory.EnumerateFiles(viewsDir, "*.xaml", SearchOption.TopDirectoryOnly).ToArray();
+
+        var offenders = new List<string>();
+        var tabsChecked = 0;
+
+        foreach (var path in files)
+        {
+            var root = System.Xml.Linq.XDocument.Load(path).Root;
+            if (root is null) continue;
+            var file = Path.GetFileName(path);
+
+            var blocks = root.DescendantsAndSelf()
+                .Where(e => e.Name.LocalName == "TextBlock")
+                .ToList();
+
+            var headerAt = blocks.FindIndex(e => Attr(e, "Style") == "{StaticResource Display}");
+            if (headerAt < 0) continue;   // not a tab: no page title
+            tabsChecked++;
+
+            var subtitle = blocks.Skip(headerAt + 1)
+                .FirstOrDefault(e => Attr(e, "Style") == "{StaticResource Subtle}");
+            if (subtitle is null)
+            {
+                offenders.Add($"{file} — has a page title and no Subtle line under it at all, so the tab "
+                              + "never says what it is for");
+                continue;
+            }
+
+            var words = StaticSubtitleWords(subtitle);
+            if (words is null)
+            {
+                offenders.Add($"{file} — the first Subtle line under the title is bound to a view-model "
+                              + "property, so the slot the explanation belongs in carries live status "
+                              + "instead. Put the static sentence first and leave the status beneath it.");
+            }
+            else if (words.Length < shortestUsefulExplanation)
+            {
+                offenders.Add($"{file} — the explanation under the title is {words.Length} characters "
+                              + $"(\"{words}\"), which is shorter than anything in the app that reads as an "
+                              + "explanation. Say what the tab is for in a sentence.");
+            }
+        }
+
+        // Vacuity floor: 58 views carry a Display header, measured. A drop means the style read stopped
+        // matching and an absence-of-offenders pass would prove nothing.
+        Assert.True(tabsChecked >= 55,
+            $"only {tabsChecked} views with a page title were found across {files.Length} view files, out of "
+            + "58 measured — the Display header read is out of date, so a pass here means nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "these tabs do not explain themselves under their own title, which is the one thing every other "
+            + "tab does and the reason the app reads well for someone who is not a technician:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The literal words a subtitle shows, or null when every part of it is bound to a property.
+    /// </summary>
+    /// <remarks>
+    /// Both spellings, because only one of them is obvious: a <c>Text</c> attribute holding a sentence, and a
+    /// <c>TextBlock</c> whose <c>&lt;Run&gt;</c> children hold it. The separators between Runs (" · ") are
+    /// literal too, so they are trimmed off — otherwise a subtitle made entirely of bindings would read as
+    /// having two characters of static copy and pass.
+    /// </remarks>
+    private static string? StaticSubtitleWords(System.Xml.Linq.XElement subtitle)
+    {
+        var attribute = Attr(subtitle, "Text");
+        if (attribute is not null)
+            return attribute.TrimStart().StartsWith("{Binding", StringComparison.Ordinal) ? null : attribute;
+
+        var literal = subtitle.DescendantsAndSelf()
+            .Where(e => e.Name.LocalName == "Run")
+            .Select(e => Attr(e, "Text") ?? "")
+            .Where(t => !t.TrimStart().StartsWith("{Binding", StringComparison.Ordinal));
+
+        var joined = string.Concat(literal).Trim(' ', '·', '·', '-', '—');
+        return joined.Length == 0 ? null : joined;
+    }
+
     /// <summary>An attribute's value by local name, ignoring the namespace prefix.</summary>
     private static string? Attr(System.Xml.Linq.XElement element, string localName) =>
         element.Attributes().FirstOrDefault(a => a.Name.LocalName == localName)?.Value;

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.97.1</Version>
-    <FileVersion>1.97.1.0</FileVersion>
-    <AssemblyVersion>1.97.1.0</AssemblyVersion>
+    <Version>1.98.0</Version>
+    <FileVersion>1.98.0.0</FileVersion>
+    <AssemblyVersion>1.98.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppAlertsView.xaml
+++ b/SysManager/SysManager/Views/AppAlertsView.xaml
@@ -21,7 +21,12 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="New App Alerts" Style="{StaticResource Display}"/>
-            <TextBlock Text="{Binding MonitorStatus}" Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+            <!-- The explanation is STATIC and comes first; the live status sits under it. This slot used to
+                 hold MonitorStatus alone, so the tab opened saying "Starting monitoring…" and never said what
+                 it was for (#1506). -->
+            <TextBlock Text="Get told when a new program installs itself on this PC, so nothing arrives unnoticed. This tab only watches and reports — removing a program is Apps → Uninstaller."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+            <TextBlock Text="{Binding MonitorStatus}" Style="{StaticResource Subtle}" Margin="0,2,0,0"/>
         </StackPanel>
 
         <!-- Toolbar -->

--- a/SysManager/SysManager/Views/AppBlockerView.xaml
+++ b/SysManager/SysManager/Views/AppBlockerView.xaml
@@ -23,7 +23,13 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="App Blocker" Style="{StaticResource Display}" />
-            <TextBlock Text="{Binding BlockStatus}" Style="{StaticResource Subtle}" Margin="0,4,0,0" />
+            <!-- The explanation is STATIC and comes first; the live status sits under it. This slot used to
+                 hold BlockStatus alone, so the only thing describing the tab was the elevation banner below,
+                 which explains the PERMISSION and not the purpose — on the one tab here that writes registry
+                 keys (#1506). Reversibility is stated for the same reason every comparable tab states it. -->
+            <TextBlock Text="Stop a specific program from starting — for example a game launcher that opens itself with Windows. Unblock any time; the program stays installed and nothing is deleted."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap" />
+            <TextBlock Text="{Binding BlockStatus}" Style="{StaticResource Subtle}" Margin="0,2,0,0" />
         </StackPanel>
 
         <!-- Elevation banner -->

--- a/SysManager/SysManager/Views/DashboardView.xaml
+++ b/SysManager/SysManager/Views/DashboardView.xaml
@@ -48,7 +48,15 @@
                 </StackPanel>
                 <StackPanel DockPanel.Dock="Left">
                     <TextBlock Text="Dashboard" Style="{StaticResource Display}"/>
-                    <TextBlock Style="{StaticResource Subtle}" Margin="0,4,0,0">
+                    <!-- The explanation is STATIC and comes first; the live OS and uptime line sits under it.
+                         This slot held only those two bindings, so the first subtitle anyone reads on opening
+                         the app said what this PC IS and never what the screen is for (#1506).
+                         Deliberately shorter than the other tabs' explanations: this header shares its row
+                         with the action buttons to its right, and the elevation banner is directly below, so
+                         a line that wraps here costs content on a small window. -->
+                    <TextBlock Text="What this PC is, how it is doing right now, and anything worth a closer look."
+                               Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+                    <TextBlock Style="{StaticResource Subtle}" Margin="0,2,0,0">
                         <Run Text="{Binding OsLine, Mode=OneWay}"/>
                         <Run Text=" · "/>
                         <Run Text="{Binding UptimeLine, Mode=OneWay}"/>

--- a/SysManager/SysManager/Views/ShortcutCleanerView.xaml
+++ b/SysManager/SysManager/Views/ShortcutCleanerView.xaml
@@ -21,7 +21,12 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="28,24,28,0">
             <TextBlock Text="Shortcut Cleaner" Style="{StaticResource Display}"/>
-            <TextBlock Text="{Binding ScanStatus}" Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+            <!-- The explanation is STATIC and comes first; the live status sits under it. This slot used to
+                 hold ScanStatus alone, so the tab opened saying "Click Scan to find broken shortcuts." — an
+                 instruction, not an explanation of what a broken shortcut is or where they go (#1506). -->
+            <TextBlock Text="Find shortcuts that point at programs you have already removed, and clear out the dead ones. They go to the Recycle Bin by default, so you can put any of them back."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+            <TextBlock Text="{Binding ScanStatus}" Style="{StaticResource Subtle}" Margin="0,2,0,0"/>
             <TextBlock Text="{Binding CurrentLocation}" Style="{StaticResource Subtle}" Margin="0,2,0,0"
                        Opacity="0.6"
                        Visibility="{Binding IsScanning, Converter={StaticResource BoolToVis}}"/>


### PR DESCRIPTION
Closes #1506.

## It was four, not three

The count in the issue came from a sweep over the `Text` **attribute** of the first `Subtle` line under each `Display` header. That misses a `TextBlock` with no `Text` attribute whose `<Run>` children carry the bindings — which is what the Dashboard had:

```xml
<TextBlock Text="Dashboard" Style="{StaticResource Display}"/>
<TextBlock Style="{StaticResource Subtle}" Margin="0,4,0,0">
    <Run Text="{Binding OsLine, Mode=OneWay}"/>
    <Run Text=" · "/>
    <Run Text="{Binding UptimeLine, Mode=OneWay}"/>
</TextBlock>
```

So the first subtitle anyone reads on opening the app said what the PC *is* and never what the screen is *for*. Re-measured over `Views/*.xaml`, counting both spellings:

| | before | after |
|---|---|---|
| views with a `Display` header | 58 | 58 |
| first `Subtle` is a static explanation | 54 | **58** |
| first `Subtle` carries no explanation | **4** | 0 |

`PlaceholderView.xaml`, which the issue lists among the legitimate non-matches, has since been deleted; `AdminBanner.xaml` and `StatusFooter.xaml` have joined that set. Which is the useful part: **the exclusion list does not need to exist.** A view with no `Display` header is not a tab and is skipped mechanically, and the six that skip are exactly the non-tab controls.

## The copy, checked against what each tab can actually do

Not written from the tab names. Verified in the code first:

- **App Blocker** — `AppBlockerService.UnblockApp` exists and a block is an IFEO `Debugger` value, so "Unblock any time; the program stays installed and nothing is deleted" is true. This is the tab that most needed it: it writes registry keys, and its only descriptive text was the elevation banner, which explains the **permission** and never the purpose or the undo.
- **Shortcut Cleaner** — it does delete, and `MoveToRecycleBin` defaults to `true` (`ShortcutCleanerViewModel.cs:42`), so the reversibility other tabs promise can be promised honestly here.
- **New App Alerts** — its commands are start/stop monitoring, acknowledge, clear history, refresh, export. It removes no programs, so it says so and points at Apps → Uninstaller (group name and tab label both re-derived from `MainWindowViewModel`).
- **Dashboard** — deliberately the shortest of the four, one line that should not wrap. Its header shares a row with the action buttons to its right and sits directly above the elevation banner, so a wrapped line there costs content on a small window.

## No Grid rows move

The issue's risk note says three views gain a `Grid` row and the `RowDefinition` indices shift. They do not: in all four the header is a `StackPanel` holding the title and the subtitle, so the new line goes inside it. The vertical-space risk is real and unchanged — one more line pushes the toolbar or banner down — but nothing re-indexes.

## The guard

`ArchitectureTests.EveryTabView_ExplainsItselfUnderItsHeader`, in the blocking unit suite. For every view with a `Display` header, the first `Subtle` line under it must carry literal words, and at least 35 characters of them.

- **35 is measured**, not chosen: the shortest real explanation in the app is `AboutView`'s 40 (*"Version info, updates and release notes."*). The floor sits below it so the guard rejects a placeholder without forcing a rewrite of the terse-but-adequate ones — that is #1654's judgement, not this one's.
- **Both spellings of "bound" are rejected**, including the `<Run>` form, because reading only the attribute is exactly how the original count came out one short.
- **Vacuity floor of 55** against 58 measured, so a broken style read fails loudly instead of passing over an empty population.

## Verification

App + tests: **0 errors, 0 warnings**. `dotnet format --verify-no-changes`: clean. Unit suite **5564 passed, 0 failed** (5563 → 5564).

Six mutations, each reverted after measuring. Every one red, baseline green before and after:

| mutation | guard |
|---|---|
| 1 App Alerts back to a bound-only subtitle | **failed** — named the file and the reason |
| 2 App Blocker back to a bound-only subtitle | **failed** |
| 3 Shortcut Cleaner back to a bound-only subtitle | **failed** |
| 4 Dashboard back to the `<Run>`-only subtitle | **failed** — the form the old sweep read as empty |
| 5 an explanation shortened to "New apps." | **failed** — *"9 characters, shorter than anything in the app that reads as an explanation"* |
| 6 the `Display` style read renamed | **failed** — *"only 0 views with a page title were found across 64 view files, out of 58 measured"* |

## Not verified here

How the four headers *look*. Each gains one wrapped line, which pushes the toolbar or banner down, and the issue asks for a check that the elevation banner still clears the fold at `MinHeight="640"`. That is a laptop check, and it is the one thing this diff could still get wrong.
