### PR TITLE
docs: lead the README with the app instead of eight lines of prose and eleven badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,18 @@
 # SysManager for Windows
 
-A modern Windows system monitoring and management toolkit: live network
-diagnostics with gamer-friendly presets, Windows updates, disk and memory
-health, gaming launcher cache cleanup, app updates and bulk install via
-winget, performance tuning, privacy and telemetry controls, context menu
-management, secure file shredding, DNS & hosts editor, duplicate finder,
-battery health, process management with built-in descriptions, startup
-control, shortcut cleanup, app blocking, install alerts, Windows features
-toggle, and a friendly Event Log viewer — all in one WPF desktop app.
+One portable app for keeping a Windows PC healthy — 58 tabs of network diagnostics, cleanup, privacy
+controls, app updates and hardware health, with no telemetry and no account.
 
-[![CI](https://github.com/laurentiu021/SystemManager/actions/workflows/ci.yml/badge.svg)](https://github.com/laurentiu021/SystemManager/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/laurentiu021/SystemManager/actions/workflows/codeql.yml/badge.svg)](https://github.com/laurentiu021/SystemManager/actions/workflows/codeql.yml)
-[![codecov](https://codecov.io/gh/laurentiu021/SystemManager/branch/main/graph/badge.svg)](https://codecov.io/gh/laurentiu021/SystemManager)
+<p align="center">
+<img src="docs/gifs/feature-tour.gif" width="720" alt="Feature tour — Dashboard, Tweaks Hub, Resource History, Settings Watchdog, Scheduled Maintenance, CLI, Ping, Disk Analyzer"><br>
+<em>A quick tour: Dashboard, Tweaks Hub, Resource History, Settings Watchdog, Scheduled Maintenance, CLI, Ping, Disk Analyzer. More below ↓</em>
+</p>
+
 [![Release](https://img.shields.io/github/v/release/laurentiu021/SystemManager?display_name=tag&sort=semver)](https://github.com/laurentiu021/SystemManager/releases/latest)
 [![Asset downloads](https://img.shields.io/github/downloads/laurentiu021/SystemManager/total?label=asset%20downloads)](https://github.com/laurentiu021/SystemManager/releases)
-[![Issues](https://img.shields.io/github/issues/laurentiu021/SystemManager)](https://github.com/laurentiu021/SystemManager/issues)
 ![Platform](https://img.shields.io/badge/platform-Windows%2010%2B-blue)
 ![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)
-[![winget](https://img.shields.io/badge/winget-laurentiu021.SysManager-0078D4?logo=windows)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/l/laurentiu021/SysManager)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/laurentiu021/SystemManager?style=social)](https://github.com/laurentiu021/SystemManager/stargazers)
 
 ---
 
@@ -88,10 +81,10 @@ Built with gamers in mind — live ping overlays for CS2, FACEIT, PUBG and strea
 endpoints, Steam/Epic/Battle.net/Riot/GOG/EA launcher cache cleanup, and
 an honest "is it my PC, my ISP, or the server?" verdict.
 
-<p align="center">
-<img src="docs/gifs/feature-tour.gif" width="720" alt="Feature tour — Dashboard, Tweaks Hub, Resource History, Settings Watchdog, Scheduled Maintenance, CLI, Ping, Disk Analyzer"><br>
-<em>A quick tour: Dashboard, Tweaks Hub, Resource History, Settings Watchdog, Scheduled Maintenance, CLI, Ping, Disk Analyzer. More below ↓</em>
-</p>
+Beyond those, the rest of the 58 tabs cover performance tuning, DNS and hosts editing, duplicate files,
+battery health, processes with plain-English descriptions, startup entries, shortcut cleanup, app blocking,
+new-install alerts and Windows optional features. [The full list is below](#features), grouped as the sidebar
+groups them.
 
 ## Why SysManager?
 
@@ -1784,6 +1777,16 @@ Windows Update / winget endpoints).
 PRs welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for the build
 setup, coding conventions, and pull-request workflow. New contributors are
 expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+**Project health** — the badges a contributor looks for, kept here rather than at the top, where they told a
+visitor nothing about the app:
+
+[![CI](https://github.com/laurentiu021/SystemManager/actions/workflows/ci.yml/badge.svg)](https://github.com/laurentiu021/SystemManager/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/laurentiu021/SystemManager/actions/workflows/codeql.yml/badge.svg)](https://github.com/laurentiu021/SystemManager/actions/workflows/codeql.yml)
+[![codecov](https://codecov.io/gh/laurentiu021/SystemManager/branch/main/graph/badge.svg)](https://codecov.io/gh/laurentiu021/SystemManager)
+[![Issues](https://img.shields.io/github/issues/laurentiu021/SystemManager)](https://github.com/laurentiu021/SystemManager/issues)
+[![winget](https://img.shields.io/badge/winget-laurentiu021.SysManager-0078D4?logo=windows)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/l/laurentiu021/SysManager)
+[![Stars](https://img.shields.io/github/stars/laurentiu021/SystemManager?style=social)](https://github.com/laurentiu021/SystemManager/stargazers)
 
 ## Support
 


### PR DESCRIPTION
Closes #1677.

## Before

Everything above the fold was text. One unbroken sentence cramming roughly twenty features into eight lines, then **eleven** badges — four of which report CI plumbing to a visitor who has not decided whether to download the thing. The only picture of the app, `docs/gifs/feature-tour.gif`, already existed and is good, and sat below all of it.

## After

Title → one sentence → the GIF → five badges → the `winget` one-liner → the star ask.

The five: **Release, Downloads, Platform, .NET, License** — freshness, popularity, will-it-run, what-it-is-built-with, can-I-use-it. **CI, CodeQL, codecov, Issues, winget and Stars** moved to a *Project health* line just above Contributing, where a contributor actually looks. All eleven still exist; five of them are just no longer the first thing a stranger reads.

## Two deviations from the issue, both deliberate

**The eight-line paragraph is dropped, not demoted.** The issue said to move it into "What it is", split into three sentences. Reading both first: "What it is" already covers the same ground in better prose, and the Features section lists all 58 tabs, so moving it would have produced a third enumeration of the same app. I compared the two lists and added **one** sentence to "What it is" for the categories it did not name — performance tuning, DNS and hosts, duplicate files, battery health, processes, startup, shortcut cleanup, app blocking, install alerts, optional features — pointing at the full list. Nothing the paragraph told a reader is now missing.

**Section order is untouched**, so "Why SysManager?" and its comparison table still follow "What it is". The issue asked for the table right after the hero, and that was written when the hero ended at line 36 with the GIF at 61 — the near-fold visual it wanted is now the GIF itself. Putting a competitor table of ✅/❌ *before* the app is described reads oddly. Say the word and I will move it; it is a two-line change and it is your front page.

## What was verified rather than assumed

**The tagline says "58 tabs", and 58 is re-derived.** `Tab<…ViewModel>` appears 55 times in `MainWindowViewModel`, which is not the answer — three tabs (Dashboard, Dark Mode Scheduler, About) register through `EagerItem` because they are built at startup, and a 56th `Tab<TVm>` match is the generic helper's own declaration. Counting the `nav-` ids gives **58**, and `grp-` gives **12**, which is what the README already claims elsewhere. So the existing claim is correct and the new one matches it.

**All eleven badges are still present** — 5 in the hero, 6 under Project health, counted after the edit.

**The anchor guard passes.** `ArchitectureTests` sweeps every in-page and cross-page link in the doc set; the new `[The full list is below](#features)` resolves, and the Table of contents still matches its headings. Full unit suite: **5563 passed, 0 failed**.

One premise in the issue has already gone stale, worth noting since it was filed as a separate finding: it reports `grep -i 'table of contents' README.md` → no matches. There is a Table of contents now.

## Not verified here

How it *renders*. This is judged by eye on github.com, and no browser is opened from here — the diff is the proposal. The GIF block is moved verbatim, so nothing about its markup is new; what changed is where it sits and which badges surround it.
