### PR TITLE
test: bound the cancellation probe so a cancel that fails to land cannot hang the suite

### DIFF
--- a/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
@@ -12,6 +12,57 @@ namespace SysManager.IntegrationTests;
 public class PowerShellRunnerTests
 {
     /// <summary>
+    /// A script that blocks, can be interrupted, and always ends by itself.
+    /// </summary>
+    /// <remarks>
+    /// Three properties, each load-bearing and each learned the hard way.
+    /// <para><b>It yields every 50 ms</b>, so <c>ps.Stop()</c> has a statement boundary to interrupt at.
+    /// <c>Start-Sleep -Seconds 30</c> gives it none — Stop interrupts BETWEEN pipeline statements, never
+    /// inside one blocking cmdlet call — so the sleep ran to completion every time. The controlled comparison
+    /// is in the CI log for #2206: on the same elevated out-of-process runspace, this loop cancelled in 2.2 s
+    /// while the sleep took 31.4 s.</para>
+    /// <para><b>It has a DEADLINE of its own.</b> This was <c>while ($true)</c>, which has none, and that is
+    /// the whole defect: a cancel that failed to land left the script running until CI killed the entire job
+    /// at its 30-minute ceiling — three times on 2026-09-11, each time reporting nothing at all about the
+    /// other 635 tests (#2263). The bound does not weaken what is measured: every caller asserts cancellation
+    /// lands in a few SECONDS, so 20 turns an all-or-nothing hang into an ordinary failure carrying its
+    /// diagnosis.</para>
+    /// <para><b><c>[DateTime]::UtcNow</c> rather than <c>Get-Date</c></b>, and <c>Thread::Sleep</c> rather
+    /// than <c>Start-Sleep</c>: the unelevated transport builds its runspace from
+    /// <c>InitialSessionState.CreateDefault2()</c>, which loads <c>Microsoft.PowerShell.Core</c> ONLY. Both
+    /// cmdlets live in <c>Microsoft.PowerShell.Utility</c> and would error instantly, returning normally — so
+    /// a cancellation that never happened would read as a fast success. A .NET static call needs no module.
+    /// </para>
+    /// </remarks>
+    private const string BlockingScript =
+        "$deadline = [DateTime]::UtcNow.AddSeconds(20); "
+        + "while ([DateTime]::UtcNow -lt $deadline) { [System.Threading.Thread]::Sleep(50) }";
+
+    /// <summary>
+    /// Awaits <paramref name="work"/>, failing the test if it does not finish rather than waiting forever.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BlockingScript"/> bounds the SCRIPT; this bounds everything else. A cancellation test's
+    /// natural shape is "await the thing that should have been interrupted", and if the runner itself never
+    /// returns then the await never returns either — which is a 30-minute job timeout that says nothing,
+    /// instead of one named failure (#2263). The ceiling is generous on purpose: it is a backstop for a hang,
+    /// not the measurement, and each caller asserts its own much tighter elapsed bound.
+    /// </remarks>
+    private static async Task<Exception?> BoundedAsync(ValueTask<Exception?> work, string testName)
+    {
+        // AsTask because a ValueTask may be awaited only once and Task.WhenAny needs to hold on to it.
+        var task = work.AsTask();
+        var ceiling = TimeSpan.FromSeconds(60);
+
+        if (await Task.WhenAny(task, Task.Delay(ceiling)).ConfigureAwait(false) != task)
+            Assert.Fail($"{testName} did not finish within {ceiling.TotalSeconds:F0}s. The script it runs "
+                        + "ends itself after 20s, so the run never returning points at the runner rather "
+                        + "than at the script — and hanging here would cost the whole suite.");
+
+        return await task.ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Disposing the runner STOPS the child process its runspace was built with, rather than only dropping
     /// the handle.
     /// </summary>
@@ -520,14 +571,10 @@ public class PowerShellRunnerTests
         using var observer = cts.Token.Register(() => firedAtMs = sw.Elapsed.TotalMilliseconds);
         cts.CancelAfter(TimeSpan.FromMilliseconds(300));
 
-        // An INTERRUPTIBLE script, and that replaced `Start-Sleep -Seconds 30`. The old one asserted
-        // something PowerShell does not promise: ps.Stop() interrupts between pipeline statements, not
-        // inside a single blocking cmdlet call, so a 30-second sleep ran to completion every time and the
-        // test cost 30 seconds to report it. The controlled comparison is in the CI log for #2206 — on the
-        // SAME elevated out-of-process runspace, the loop below cancelled in 2.2 s while the sleep took
-        // 31.4 s. The real limit is pinned by its own test below rather than by making this one fail.
-        var ex = await Record.ExceptionAsync(async () => await runner.RunAsync(
-            "while ($true) { [System.Threading.Thread]::Sleep(50) }", cancellationToken: cts.Token));
+        var ex = await BoundedAsync(
+            Record.ExceptionAsync(async () => await runner.RunAsync(
+                BlockingScript, cancellationToken: cts.Token)),
+            nameof(RunAsync_SupportsCancellation));
         sw.Stop();
 
         var errors = lines.Where(l => l.Kind == Models.OutputKind.Error).Select(l => l.Text).ToList();
@@ -708,8 +755,10 @@ public class PowerShellRunnerTests
         using var observer = cts.Token.Register(() => firedAtMs = sw.Elapsed.TotalMilliseconds);
         cts.CancelAfter(TimeSpan.FromMilliseconds(500));
 
-        var ex = await Record.ExceptionAsync(async () => await runner.RunAsync(
-            "while ($true) { [System.Threading.Thread]::Sleep(50) }", cancellationToken: cts.Token));
+        var ex = await BoundedAsync(
+            Record.ExceptionAsync(async () => await runner.RunAsync(
+                BlockingScript, cancellationToken: cts.Token)),
+            nameof(RunAsync_CancellingARunningPipeline_ReportsCancellation));
         sw.Stop();
 
         var diagnosis = $"elapsed {sw.Elapsed}; token fired at {(firedAtMs < 0 ? "NEVER" : $"{firedAtMs:F0} ms")}; "

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -944,6 +944,71 @@ public partial class ArchitectureTests
     private static partial Regex ElevationSelfSkip();
 
     /// <summary>
+    /// No test hands the PowerShell runner a script that can run forever.
+    /// </summary>
+    /// <remarks>
+    /// A cancellation test's shape is "start something slow, cancel it, assert it stopped", and the slow thing
+    /// has to block long enough for the cancel to land. An endless loop does that — and if the cancel fails to
+    /// land, nothing ends it. On 2026-09-11 that cost three CI runs their whole 30-minute ceiling, each
+    /// reporting nothing about the other 635 tests, and it was the same probe every time (#2263). The suite is
+    /// serial, so one test that never returns takes the run with it.
+    /// <para>The fix is a script with a deadline of its own, which does not weaken the measurement: every
+    /// caller asserts cancellation lands within a few SECONDS, so the deadline only decides whether a failure
+    /// is reported or the job is killed. This holds that shape.</para>
+    /// <para>The needle is built by concatenation because this file is one of the files scanned — a guard
+    /// spelling its own forbidden pattern flags itself. Comment lines are dropped for the same reason: the
+    /// paragraph above would otherwise be a violation.</para>
+    /// </remarks>
+    [Fact]
+    public void NoTestScript_CanRunForever()
+    {
+        // Assembled, never spelled: see the remark above.
+        var forbidden = "while (" + "$true)";
+
+        var root = FindRepoRoot();
+        var offenders = new List<string>();
+        var scanned = 0;
+
+        foreach (var project in new[] { "SysManager.Tests", "SysManager.IntegrationTests", "SysManager.UITests" })
+        {
+            var dir = Path.Combine(root, "SysManager", project);
+            Assert.True(Directory.Exists(dir), $"{dir} not found — this guard would pass vacuously");
+
+            foreach (var file in Directory.GetFiles(dir, "*.cs"))
+            {
+                if (Path.GetFileName(file) == "ArchitectureTests.cs") continue;   // this file, prose and all
+
+                scanned++;
+                var lines = File.ReadAllLines(file);
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    if (!IsCode(lines[i])) continue;
+                    if (lines[i].Contains(forbidden, StringComparison.Ordinal))
+                        offenders.Add($"{Path.GetFileName(file)}:{i + 1}");
+                }
+            }
+        }
+
+        Assert.True(scanned >= 100,
+            $"only {scanned} test source files were scanned across the three test projects, which is far "
+            + "below the ~140 that exist — the enumeration is wrong, so a pass here proves nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "these scripts have no end of their own, so a cancellation that fails to land hangs the whole "
+            + "serial suite until CI kills the job — 30 minutes reporting nothing about any other test. Give "
+            + "the loop a deadline, as PowerShellRunnerTests.BlockingScript does:\n  "
+            + string.Join("\n  ", offenders));
+
+        // The replacement has to still BE bounded, or the rule above is satisfied by a loop that spells its
+        // condition differently and runs just as long. Asserted on the comparison that does the work, not on
+        // the presence of the word "deadline".
+        var probe = File.ReadAllText(Path.Combine(
+            root, "SysManager", "SysManager.IntegrationTests", "PowerShellRunnerTests.cs"));
+        Assert.Contains("[DateTime]::UtcNow.AddSeconds(", probe, StringComparison.Ordinal);
+        Assert.Contains("while ([DateTime]::UtcNow -lt $deadline)", probe, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// An audio route SysManager cannot read must be shown as unknown, not as the system default.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
Refs #2263 — this is the cause, found and fixed. The CI-visibility half of that issue stays open.

## What was hanging, and how it was identified

Three integration runs today died at their 30-minute ceiling with the identical signature: `Running tests from …IntegrationTests.exe`, then **28 minutes of no output at all**, then `Canceling the test session…`. No failure, no test name, nothing about the other 635 tests.

The name was in the artifact all along. `--hangdump` had fired and uploaded 189 MB across three files, two of which are 92 bytes:

```
powershell_17784_hang.log                    [00:05:00] …PowerShellRunnerTests.RunAsync_SupportsCancellation
SysManager.IntegrationTests_8748_hang.log    [00:05:00] …PowerShellRunnerTests.RunAsync_SupportsCancellation
```

A hung `powershell.exe` alongside the hung test host, both blamed on the same probe.

## The defect, and it is mine

`RunAsync_SupportsCancellation` and `RunAsync_CancellingARunningPipeline_ReportsCancellation` both ran:

```csharp
"while ($true) { [System.Threading.Thread]::Sleep(50) }"
```

and awaited the result with no bound. That loop replaced `Start-Sleep -Seconds 30` in v1.96.1 for a good reason — `ps.Stop()` interrupts *between* pipeline statements and never inside one blocking cmdlet call, so a 30-second sleep ran to completion every time — but the replacement dropped the one property the sleep had: **it ended by itself.**

So on a run where the cancel failed to land, nothing anywhere ended the script. The suite is serial (`maxParallelThreads: 1`), so one test that never returns takes the whole run with it.

Measured, with no cancellation at all:

```
BOUNDED script returned after 20.0s     (wall clock 20.2s)
the OLD shape, given 8s:  still running at 8s -- nothing in the script ends it
```

## The fix

A shared constant, so the two call sites cannot drift:

```csharp
private const string BlockingScript =
    "$deadline = [DateTime]::UtcNow.AddSeconds(20); "
    + "while ([DateTime]::UtcNow -lt $deadline) { [System.Threading.Thread]::Sleep(50) }";
```

Three properties, each load-bearing and each documented on it:

- **Yields every 50 ms**, so `Stop()` has a boundary to interrupt at — the reason the loop exists.
- **Has a deadline**, so a cancel that fails to land produces an ordinary failure carrying the full diagnosis string instead of a dead job. 20 seconds is orders of magnitude above the few seconds each caller asserts, so it changes what a failure *reports* and not what the test *measures*.
- **`[DateTime]::UtcNow`, not `Get-Date`; `Thread::Sleep`, not `Start-Sleep`.** The unelevated transport builds its runspace from `InitialSessionState.CreateDefault2()`, which loads `Microsoft.PowerShell.Core` only. Both cmdlets live in `Microsoft.PowerShell.Utility` and would error instantly and return normally — so a cancellation that never happened would read as a fast success. A .NET static call needs no module.

`BoundedAsync` covers everything the script cannot: if the runner itself never returns, one test fails at 60 seconds naming itself, instead of the job dying at 30 minutes saying nothing.

## The rule, mechanically

`ArchitectureTests.NoTestScript_CanRunForever` — blocking, over all three test projects. No test source may contain the endless-loop shape, and the replacement must still compare against a deadline (asserted on the comparison, not on the word "deadline", so renaming the variable does not slip through).

Its needle is **assembled rather than spelled**, and comment lines are dropped, because the first file it would otherwise flag is itself — and the explanation above would be a violation.

## Verification

Integration + unit projects: **0 errors, 0 warnings**. `dotnet format --verify-no-changes`: clean. Unit suite **5564 passed, 0 failed**. Both affected tests pass locally in **1.0s** (unelevated in-process transport, where cancellation lands immediately).

| proof | result |
|---|---|
| the bounded script ends with no cancellation at all | returned after **20.0s** |
| the old shape, given 8s | still running — nothing ends it |
| the forbidden shape added to a test file | guard **failed**, naming file and line |
| the deadline comparison renamed | guard **failed** |
| baseline, before and after each | green |

## What stays open on #2263

The cause is fixed; the **visibility** is not. A hang still produces no annotation, because that step is gated on `outcome == 'failure' && !cancelled()` and a job-timeout kill satisfies neither — so the name sat inside a 189 MB artifact that nothing points a reader at. Its three proposals still stand, and the cheap one is a `cancelled()` branch that prints those 92-byte logs into the job output.
