### PR TITLE
docs: put BleachBit in the comparison table and add the row nothing else has

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,26 +92,36 @@ Most Windows utilities do one thing, or bundle telemetry and upsells. SysManager
 is a single, local-first app that covers the whole maintenance surface — and it's
 fully open source.
 
-| | **SysManager** | CCleaner | Wintoys | O&O ShutUp10 | HWiNFO |
-|---|:---:|:---:|:---:|:---:|:---:|
-| Open source (MIT) | ✅ | ❌ | ❌ | ❌ | ❌ |
-| No telemetry / no account | ✅ | ❌ | ❌ | ✅ | ✅ |
-| Fully local (no cloud) | ✅ | ❌ | ✅ | ✅ | ✅ |
-| Portable single `.exe` | ✅ | ❌ | ✅ | ✅ | ✅ |
-| Code-signed binary | ❌ | ✅ | ✅ | ✅ | ✅ |
-| Disk / cache cleanup | ✅ | ✅ | ✅ | ❌ | ❌ |
-| Privacy & telemetry toggles | ✅ | ⚠️ | ✅ | ✅ | ❌ |
-| Network diagnostics (ping / traceroute / speed) | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Disk / RAM SMART health | ✅ | ⚠️ | ❌ | ❌ | ✅ |
-| App updates + bulk install (winget) | ✅ | ❌ | ⚠️ | ❌ | ❌ |
-| Free | ✅ | ⚠️ | ✅ | ✅ | ✅ |
+| | **SysManager** | BleachBit | CCleaner | Wintoys | O&O ShutUp10 | HWiNFO |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Open source | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| No telemetry / no account | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ |
+| Fully local (no cloud) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
+| Portable single `.exe` | ✅ | ⚠️ | ❌ | ✅ | ✅ | ✅ |
+| Code-signed binary | ❌ | ⚠️ | ✅ | ✅ | ✅ | ✅ |
+| Disk / cache cleanup | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Privacy & telemetry toggles | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | ❌ |
+| Network diagnostics (ping / traceroute / speed) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Disk / RAM SMART health | ✅ | ❌ | ⚠️ | ❌ | ❌ | ✅ |
+| App updates + bulk install (winget) | ✅ | ❌ | ❌ | ⚠️ | ❌ | ❌ |
+| Game-server latency tools (ping presets, timer resolution) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Free | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ |
 
 <sub>⚠️ = partial, paywalled, or limited. Comparison reflects the free editions as of 2026; features evolve — corrections welcome via an issue.</sub>
+
+<sub>**BleachBit is here because it is the rival that ties on the rows above.** A table whose top three rows
+exclude the best-known open-source Windows cleaner is cherry-picked, and a reader who knows BleachBit spots
+that immediately. Its ⚠️ cells are specifics, not hedges: it ships a portable **zip** of many files rather
+than one `.exe`; it cleans tracking data thoroughly but does not toggle Windows' own telemetry settings; and
+its current Windows release publishes a detached GPG signature for the zip rather than stating an Authenticode
+signature, which is a different thing from what stops the SmartScreen warning. Licences differ — SysManager is
+MIT, BleachBit is GPL-3.0 — which is why that row no longer names one.</sub>
 
 <sub>The signing row is the one where SysManager loses, and it is here on purpose — a table a project wins
 every row of tells you nothing. Builds are unsigned, so Windows shows a warning on first launch. Why, what
 that warning looks like, and how to check the download yourself:
-[First launch](#first-launch-windows-will-warn-you) · [Verifying the download](#verifying-the-download).</sub>
+[First launch](#first-launch-windows-will-warn-you) · [Verifying the download](#verifying-the-download).
+Sponsorship goes toward that certificate — see [Support](#support).</sub>
 
 ## Features
 


### PR DESCRIPTION
Closes #1667.

## The problem, in one sentence

The table's top three rows — open source, no telemetry, fully local — were a clean sweep only because the best-known open-source Windows cleaner was not in the table. A reader who knows BleachBit reads that as cherry-picking, which costs exactly the credibility a comparison table exists to build. The repo's own topics (`ccleaner-alternative`, `pc-optimizer`) invite the comparison.

## What changed

BleachBit sits beside SysManager, and **ties on four rows outright**: open source, no telemetry / no account, fully local, free. That honest tie is what makes the remaining wins believable.

Its three `⚠️` cells are specifics rather than hedges, each checked against the project's own releases rather than from memory:

- **Portable single `.exe`** — it publishes `BleachBit-6.0.4-portable.zip`, a portable *zip of many files*, not one executable.
- **Privacy & telemetry toggles** — it cleans tracking data thoroughly; it does not toggle Windows' own telemetry settings, which is what this row asks. Its own README describes it as cleaning "files to free disk space and to maintain privacy", and lists no settings surface.
- **Code-signed binary** — the current Windows release publishes a *detached GPG signature* for the zip (`…portable.zip.sig`) and does not state an Authenticode signature. Those are different things, and only the second stops the SmartScreen warning. The legacy 4.7.0 release does describe dual-signed installers, but that is 4.7.0.

Also verified from the source: BleachBit's README claims no network diagnostics, no SMART health and no application updating, so those rows are `❌`.

**"Open source (MIT)" became "Open source"**, because two entries now qualify under different licences. MIT and GPL-3.0 are named in the note underneath instead of in a row header that would be wrong for one of them.

## The new row

**Game-server latency tools (ping presets, timer resolution)** — `✅` for SysManager, `❌` for all five rivals. Re-derived from source rather than taken from the issue's word:

| claim | where |
|---|---|
| CS2 / FACEIT / PUBG ping presets | `Models/TargetPreset.cs` |
| timer resolution | `Services/ITimerResolutionService.cs` |
| CPU affinity | `Services/CpuAffinityService.cs` |
| standby list | `Services/GamingTweaks.cs` |

## Glary Utilities is deliberately left out

The issue asked for two columns and offered its own fallback: *"if it wraps awkwardly, the honest fallback is to keep BleachBit (the credibility-critical one) and skip Glary."* I took it, for two reasons rather than one.

Width is the smaller reason — seven columns already push this table's limit on a narrow screen. The real reason is that **I could not verify Glary's cells from a primary source**, and a comparison table where some cells are checked and others are recalled is worse than a shorter one. Glary's absence is not a credibility problem in the way BleachBit's was: it is not open source, so it changes none of the top rows, which is the whole complaint this issue makes. If you want it in, it needs its own verification pass and I will do that as a follow-up.

## Verification

Unit suite **5565 passed, 0 failed**, which includes the doc-set anchor sweep — the new `[Support](#support)` link resolves. Table shape checked mechanically: 14 rows, every one exactly 7 cells. Leak-terms scan over the diff: 43 terms loaded, 0 hits.

## Not verified here

How the seven-column table wraps on a phone. That is a look-at-it-on-github judgement, and if it reads badly the fallback is already written down: drop a column rather than a row, and BleachBit is the one that stays.
