### PR TITLE
feat: eleven tabs now lead with what they do instead of an acronym

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.99.0] - 2026-09-12
+
+**Eleven tabs stopped opening with a sentence written for someone who already knows Windows.** The line under
+each tab's title is the only explanation most people ever read, and it had drifted into two voices: the newer
+tabs say what the tab is for and what it costs you, while older ones opened with an acronym. "Common fixes for
+DNS, socket, and TCP/IP issues" tells you nothing unless you already knew. Those eleven now lead with what you
+get, put the jargon in brackets after it, and say plainly what the tab will and will not do to your PC.
+
+### Changed
+
+- **DNS & Hosts, Network Repair, Speed Test, Ping, Traceroute** — each says what the thing is for before
+  naming it. Network Repair also warns that two of its four fixes only take effect after a restart, which it
+  never said.
+- **App Updates and Bulk Installer** — "winget" is now explained once as Microsoft's own App Installer,
+  already part of Windows. It had appeared bare on both tabs and was expanded nowhere in the app.
+- **Drivers now says it only reads.** It lists drivers and cannot install, update or remove one — worth
+  saying, because a tab called Drivers sets a different expectation.
+- **File Shredder says the deletion is permanent** before you use it: no Recycle Bin step, no undo, and it
+  refuses Windows' own folders.
+- **Quick Cleanup leads with the outcome** rather than with SFC and DISM, and says the repairs change nothing
+  you can see.
+- **System Health says what it does not do** — everything on it reads rather than changes, except the memory
+  test, which Windows runs on the next restart once you schedule it.
+
+### Fixed
+
+- **Five long explanations were being cut off.** Performance, Services, Duplicate Finder, Privacy & Telemetry
+  and Process Manager had explanations of 84 to 111 characters set to never wrap, so the end of the sentence
+  was simply missing unless the window was maximised. A test now holds that rule for all 51 explanations that
+  are long enough to need it.
+
 ## [1.98.0] - 2026-09-11
 
 **Four tabs never said what they were for, and now all 58 do.** Under its title, every tab has a line of

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ older build, the first step is usually to update.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.98.x   | :white_check_mark: |
-| < 1.98   | :x:                |
+| 1.99.x   | :white_check_mark: |
+| < 1.99   | :x:                |
 
 The supported line is always the newest minor on the
 [releases page](https://github.com/laurentiu021/SystemManager/releases/latest) — if that page shows a

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -6386,6 +6386,14 @@ public partial class ArchitectureTests
         // rewrite of the terse-but-adequate ones, which is a separate judgement (#1654).
         const int shortestUsefulExplanation = 35;
 
+        // Also measured, and the reason this is a rule rather than a habit: 51 explanations are 80 characters
+        // or longer, and five of them set no TextWrapping — Performance (111), Services (106), Duplicate
+        // Finder (102), Privacy (85), Process Manager (84). A Subtle TextBlock does not wrap by default, so
+        // each of those rendered as one line and lost its tail at anything short of a maximised window. 80 is
+        // where the population is unanimous once those five are fixed; it is not a guess about pixels, and it
+        // sits above the longest single-line explanation the app has.
+        const int mustWrapAbove = 80;
+
         var appDir = FindAppProjectDir();
         var viewsDir = Path.Combine(appDir, "Views");
         var files = Directory.EnumerateFiles(viewsDir, "*.xaml", SearchOption.TopDirectoryOnly).ToArray();
@@ -6428,6 +6436,12 @@ public partial class ArchitectureTests
                 offenders.Add($"{file} — the explanation under the title is {words.Length} characters "
                               + $"(\"{words}\"), which is shorter than anything in the app that reads as an "
                               + "explanation. Say what the tab is for in a sentence.");
+            }
+            else if (words.Length >= mustWrapAbove && Attr(subtitle, "TextWrapping") != "Wrap")
+            {
+                offenders.Add($"{file} — the explanation is {words.Length} characters and sets no "
+                              + "TextWrapping, so it renders as ONE line and is cut off at anything short "
+                              + "of a maximised window. Add TextWrapping=\"Wrap\".");
             }
         }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.98.0</Version>
-    <FileVersion>1.98.0.0</FileVersion>
-    <AssemblyVersion>1.98.0.0</AssemblyVersion>
+    <Version>1.99.0</Version>
+    <FileVersion>1.99.0.0</FileVersion>
+    <AssemblyVersion>1.99.0.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AppUpdatesView.xaml
+++ b/SysManager/SysManager/Views/AppUpdatesView.xaml
@@ -16,8 +16,8 @@
 
         <StackPanel Grid.Row="0" Margin="28,24,28,0">
             <TextBlock Text="App Updates" Style="{StaticResource Display}"/>
-            <TextBlock Text="Scan for winget upgrades and install them in bulk."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+            <TextBlock Text="Find the programs on this PC that have a newer version available and update them in one go, through winget — Microsoft's own App Installer, already part of Windows. Nothing is updated until you tick it."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <!-- Elevation banner -->

--- a/SysManager/SysManager/Views/BulkInstallerView.xaml
+++ b/SysManager/SysManager/Views/BulkInstallerView.xaml
@@ -23,8 +23,8 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="Bulk Installer" Style="{StaticResource Display}"/>
-            <TextBlock Text="Select applications to install in bulk via winget."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+            <TextBlock Text="Set a PC up in one pass: tick the programs you want and install them together through winget — Microsoft's own App Installer, already part of Windows. Each program is downloaded from its own publisher."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <!-- Elevation banner -->

--- a/SysManager/SysManager/Views/CleanupView.xaml
+++ b/SysManager/SysManager/Views/CleanupView.xaml
@@ -15,8 +15,8 @@
 
         <StackPanel Grid.Row="0" Margin="28,24,28,0">
             <TextBlock Text="Quick Cleanup" Style="{StaticResource Display}"/>
-            <TextBlock Text="Clear temp files, empty Recycle Bin, or run SFC and DISM to repair Windows."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+            <TextBlock Text="Free up space and repair damaged Windows files: clear out temporary files and the Recycle Bin, or run Windows' own repair tools (SFC and DISM) when something feels broken. The repairs take a while and change nothing you can see — they only replace files that are already damaged."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <!-- Elevation banner -->

--- a/SysManager/SysManager/Views/DnsHostsView.xaml
+++ b/SysManager/SysManager/Views/DnsHostsView.xaml
@@ -14,8 +14,8 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="28,24,28,0">
             <TextBlock Text="DNS &amp; Hosts" Style="{StaticResource Display}"/>
-            <TextBlock Text="Change DNS servers and manage the hosts file."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+            <TextBlock Text="Point your PC at a faster or more private DNS server — the service that turns a website's name into an address — and block a site by adding it to the hosts file. Both are reversible: Restore puts back the DNS you had, and the hosts file is backed up before every save."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <!-- Elevation banner -->

--- a/SysManager/SysManager/Views/DriversView.xaml
+++ b/SysManager/SysManager/Views/DriversView.xaml
@@ -23,8 +23,8 @@
             <!-- Header -->
             <StackPanel Grid.Row="0" Margin="0,0,0,16">
                 <TextBlock Text="Drivers" Style="{StaticResource Display}"/>
-                <TextBlock Text="Installed system drivers — click column headers to sort."
-                           Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+                <TextBlock Text="Every driver Windows has loaded and the device each one belongs to — which is what you need when something has stopped working and you are asked for its name or version. This tab only reads: it never installs, updates or removes a driver."
+                           Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
             </StackPanel>
 
             <!-- Toolbar -->

--- a/SysManager/SysManager/Views/DuplicateFileView.xaml
+++ b/SysManager/SysManager/Views/DuplicateFileView.xaml
@@ -23,7 +23,7 @@
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="Duplicate Finder" Style="{StaticResource Display}"/>
             <TextBlock Text="Find files with identical content. Nothing is deleted — we suggest which copy to keep, and you decide."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <!-- Toolbar -->

--- a/SysManager/SysManager/Views/FileShredderView.xaml
+++ b/SysManager/SysManager/Views/FileShredderView.xaml
@@ -29,8 +29,8 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="28,24,28,0">
             <TextBlock Text="File Shredder" Style="{StaticResource Display}"/>
-            <TextBlock Text="Securely delete files beyond recovery with multi-pass overwrite."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+            <TextBlock Text="Delete a file so it cannot be recovered, by overwriting its contents before removing it — for something you would not want found on a PC you are selling or giving away. This is permanent: there is no Recycle Bin step and no undo, so it asks you to confirm and refuses to touch Windows' own folders."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
             <Border Background="{DynamicResource WarningBgSubtle}" BorderBrush="{DynamicResource WarningBg}" BorderThickness="1" CornerRadius="{StaticResource RadiusMd}"
                     Margin="0,10,0,0" Padding="10,8">
                 <!-- DockPanel, not a horizontal StackPanel: a StackPanel measures children with infinite

--- a/SysManager/SysManager/Views/NetworkRepairView.xaml
+++ b/SysManager/SysManager/Views/NetworkRepairView.xaml
@@ -11,8 +11,8 @@
         </Grid.RowDefinitions>
         <StackPanel Grid.Row="0" Margin="28,24,28,0">
             <TextBlock Text="Network Repair" Style="{StaticResource Display}"/>
-            <TextBlock Text="Common fixes for DNS, socket, and TCP/IP issues."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+            <TextBlock Text="The standard things to try when the internet stops working but the connection still looks fine: renew your address, clear the stored name lookups, and reset the two Windows networking layers (Winsock and TCP/IP). Those last two only take effect after a restart."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <!-- Elevation banner -->

--- a/SysManager/SysManager/Views/PerformanceView.xaml
+++ b/SysManager/SysManager/Views/PerformanceView.xaml
@@ -24,7 +24,7 @@
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="Performance Mode" Style="{StaticResource Display}"/>
             <TextBlock Text="Each setting has its own Apply button. All changes are reversible — Restore All reverts to your original state."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <!-- Elevation banner -->

--- a/SysManager/SysManager/Views/PingView.xaml
+++ b/SysManager/SysManager/Views/PingView.xaml
@@ -20,8 +20,8 @@
         <DockPanel Grid.Row="0" Margin="28,24,28,0">
             <StackPanel>
                 <TextBlock Text="Ping" Style="{StaticResource Display}"/>
-                <TextBlock Text="Live ping monitoring with latency chart and health verdict."
-                           Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+                <TextBlock Text="Watch how long this PC takes to reach a server, second by second, with a chart of the round-trip time and a plain verdict on whether the trouble is here, in your connection, or at the far end. The presets cover the game and streaming servers people ask about most."
+                           Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
                         DockPanel.Dock="Right" VerticalAlignment="Center">

--- a/SysManager/SysManager/Views/PrivacyView.xaml
+++ b/SysManager/SysManager/Views/PrivacyView.xaml
@@ -23,7 +23,7 @@
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="Privacy &amp; Telemetry" Style="{StaticResource Display}"/>
             <TextBlock Text="Control telemetry, ads, and unwanted features. Toggle ON = privacy protection active."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <!-- Elevation banner -->

--- a/SysManager/SysManager/Views/ProcessManagerView.xaml
+++ b/SysManager/SysManager/Views/ProcessManagerView.xaml
@@ -24,7 +24,7 @@
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="Process Manager" Style="{StaticResource Display}"/>
             <TextBlock Text="View running processes, sort by clicking column headers, and kill unresponsive apps."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <!-- Elevation banner -->

--- a/SysManager/SysManager/Views/ServicesView.xaml
+++ b/SysManager/SysManager/Views/ServicesView.xaml
@@ -23,7 +23,7 @@
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="Services" Style="{StaticResource Display}"/>
             <TextBlock Text="Manage Windows services. Gaming recommendations highlight services safe to disable for better performance."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <!-- Elevation banner -->

--- a/SysManager/SysManager/Views/SpeedTestView.xaml
+++ b/SysManager/SysManager/Views/SpeedTestView.xaml
@@ -45,8 +45,8 @@
 
         <StackPanel Grid.Row="0" Margin="28,24,28,0">
             <TextBlock Text="Speed Test" Style="{StaticResource Display}"/>
-            <TextBlock Text="Ookla and HTTP speed tests with history tracking."
-                       Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+            <TextBlock Text="Measure how fast this connection actually is, and keep the results so a slowdown is something you can show your provider rather than describe. Uses the Ookla test where it can and a plain download test otherwise."
+                       Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="28,16,28,28">

--- a/SysManager/SysManager/Views/SystemHealthView.xaml
+++ b/SysManager/SysManager/Views/SystemHealthView.xaml
@@ -12,8 +12,8 @@
                 <DockPanel>
                     <StackPanel>
                         <TextBlock Text="System Health" Style="{StaticResource Display}"/>
-                        <TextBlock Text="OS, CPU, RAM and disk diagnostics with SMART data and memory error detection."
-                                   Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+                        <TextBlock Text="One page for what this PC is made of and how it is holding up: Windows version, processor, memory and drives, including each drive's own self-check (SMART). Everything here reads rather than changes, with one exception — the memory test, which Windows runs on the next restart once you schedule it."
+                                   Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
                     </StackPanel>
                     <Button Content="Scan" Command="{Binding ScanCommand}" Style="{StaticResource PrimaryButton}"
                             AutomationProperties.AutomationId="btn-system-health-scan"

--- a/SysManager/SysManager/Views/TracerouteView.xaml
+++ b/SysManager/SysManager/Views/TracerouteView.xaml
@@ -20,8 +20,8 @@
         <DockPanel Grid.Row="0" Margin="28,24,28,0">
             <StackPanel>
                 <TextBlock Text="Traceroute" Style="{StaticResource Display}"/>
-                <TextBlock Text="Auto-traceroute for all targets + manual trace to any host."
-                           Style="{StaticResource Subtle}" Margin="0,4,0,0"/>
+                <TextBlock Text="Show every relay (“hop”) a connection passes through on its way to a site, so you can see which one is slowing it down. Runs on its own for your saved targets, or on demand for any address you type."
+                           Style="{StaticResource Subtle}" Margin="0,4,0,0" TextWrapping="Wrap"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
                         DockPanel.Dock="Right" VerticalAlignment="Center">


### PR DESCRIPTION
Closes #1654.

## Eleven, not twenty-one, and the count is the argument

Re-measured over `Views/*.xaml` before touching anything: **58** tabs have an explanation, **21** are under 95 characters, **37** are longer. I read all 21 and rewrote **11**.

The other ten are deliberately untouched, because the defect this issue describes is *jargon-first copy*, not *short copy*. `LogsView` — "Windows Event Log, explained in plain English." — is 46 characters and already does everything the formula asks. So do Uninstaller, Disk Analyzer, Process Manager, Privacy, Windows Features, Battery Health, About, Dashboard and File Lock. Rewriting those would be churn, which the issue's own risk note warns against ("Resist over-writing").

The eleven that did lead with jargon, or promised nothing at all:

| tab | was | now leads with |
|---|---|---|
| DNS & Hosts | "Change DNS servers and manage the hosts file." | what a DNS server is *for*, then the term |
| Network Repair | "Common fixes for DNS, socket, and TCP/IP issues." | "when the internet stops working but the connection still looks fine" |
| Speed Test | "Ookla and HTTP speed tests with history tracking." | "so a slowdown is something you can show your provider" |
| App Updates | bare "winget" | "programs … that have a newer version available" |
| Bulk Installer | bare "winget" | "Set a PC up in one pass" |
| Drivers | "click column headers to sort" | what you need it for, **and that it only reads** |
| Ping | "latency chart and health verdict" | "whether the trouble is here, in your connection, or at the far end" |
| Traceroute | "Auto-traceroute for all targets" | "which one is slowing it down" |
| File Shredder | "multi-pass overwrite" | **"This is permanent: no Recycle Bin step and no undo"** |
| Quick Cleanup | "run SFC and DISM" | "Free up space and repair damaged Windows files" |
| System Health | "SMART data and memory error detection" | what the page is, **and the one thing on it that changes something** |

`winget` is now explained once, as Microsoft's own App Installer already part of Windows. The issue is right that it appeared bare on both tabs and was expanded nowhere in the app.

## Checking the copy against the code changed three of them

Every promise was verified before it was written, and three came out different from the issue's draft:

- **Drivers is read-only.** `DriversViewModel` has exactly `ListDriversAsync` and `Cancel` — it cannot install, update or remove a driver. A tab called "Drivers" sets the opposite expectation, so the copy now says so outright. The issue did not ask for this.
- **System Health is *not* purely read-only.** `ScheduleMemoryTest` launches `mdsched.exe`, which schedules a test Windows runs at the next restart. I had written "nothing here changes a setting" and had to correct it — the copy now names that single exception.
- **Network Repair needs a restart, and never said so.** `NeedsReboot: true` on the Winsock and TCP/IP resets, `false` on the DNS flush. Two of four fixes do nothing until you reboot; the header now says which.

The one claim I kept from the issue's draft was verified too: DNS *and* hosts are both reversible — `RestorePreviousDnsAsync`, and `RestoreHostsAsync` with a `.bak` written before every save.

## A real defect the measurement turned up

**Five explanations were being cut off.** A `Subtle` `TextBlock` does not wrap by default, and Performance (111 chars), Services (106), Duplicate Finder (102), Privacy (85) and Process Manager (84) all set no `TextWrapping` — so the end of each sentence was simply missing unless the window was maximised. Nobody had reported it because the first clause reads fine.

Fixed by adding the attribute; no copy on those five changed.

`ArchitectureTests.EveryTabView_ExplainsItselfUnderItsHeader` now holds the rule: an explanation of 80 characters or more must set `TextWrapping="Wrap"`. **80 is measured, not chosen** — it is where the population becomes unanimous once those five are fixed, and it sits above the longest single-line explanation the app has. 51 of the 58 explanations are at or over it.

## One premise of the issue is wrong

> the newer views cap this with `MaxWidth="820"` + `TextWrapping="Wrap"`, which the rewritten ones must copy

Only **10 of 37** long subtitles set `MaxWidth` (9 at 820, one at 900); **34 of 37** set `TextWrapping`. So wrapping is the established pattern and a width cap is not — 27 long explanations run the full width today. I added `TextWrapping` and left `MaxWidth` alone rather than making myself the majority. If a reading measure is wanted it is a separate uniformity pass over all 37, not something to introduce on eleven.

## No guard on the voice itself, and why

I tried to make the jargon rule mechanical — "a listed term must carry a gloss" — and it fought the copy in both directions. `DNS server — the service that turns a website's name into an address` glosses with an em dash, not brackets. `(Winsock and TCP/IP)` *is* the gloss. And "Ookla" is a brand name that needs no expansion, like "Recycle Bin". Every version was either vacuous or produced false positives that would end up suppressed, which is worse than no guard.

So the mechanical part of this rule is what is objectively checkable — every tab has an explanation, of a sensible length, that wraps — and the voice stays a review question. The guard already enforces the first two from #1506; this adds the third.

## Verification

App + tests: **0 errors, 0 warnings**. `dotnet format --verify-no-changes`: clean. Unit suite **5565 passed, 0 failed**. Leak-terms scan over the diff: 43 terms, 0 hits.

Seven mutations, each reverted after measuring — every one red, baseline green either side:

| mutation | guard |
|---|---|
| wrap removed from Performance (111) | **failed**, named the file and the length |
| wrap removed from Services (106) | **failed** |
| wrap removed from Duplicate Finder (102) | **failed** |
| wrap removed from Privacy (85) | **failed** |
| wrap removed from Process Manager (84) | **failed** |
| wrap removed from DNS & Hosts (268, rewritten here) | **failed** — the new copy is covered too |
| the `Display` style read renamed | **failed** — *"only 0 views with a page title … out of 58 measured"* |

## Not verified here

How eleven longer headers *look*. Each grows the header block by a line or two, which pushes toolbars and elevation banners down, and the issue asks for a check that they still clear the fold at `MinHeight="640"`. That is a laptop check and it is the one thing this diff could still get wrong — File Shredder and DNS & Hosts are the longest and the ones to look at first.
