### PR TITLE
fix: the Large Files scan reported no progress, then a folder called "Done"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.99.1] - 2026-09-12
+
+**The Large Files scan in Deep Cleanup showed nothing while it worked, then a folder called "Done".** It was
+supposed to name the folder it was searching and count what it had found so far, but on any scan that finished
+quickly it reported neither — the panel sat at 0 files and a blank folder line from start to finish, and the
+one thing it did eventually show was the word "Done" where a folder name goes. Both are fixed, and the scan now
+names a real folder from the first one it opens.
+
+### Fixed
+
+- **A fast scan reports its progress.** The limit on how often progress could be sent was being measured from
+  the moment the scan started, so it also blocked the *first* report — and since progress is sent once per
+  folder, a small folder tree used up all its chances before the limit expired.
+- **"Done" is no longer displayed as a folder name.** The scan sends one last message so the totals land on
+  their final numbers, and that message used to carry the word "Done" where the folder goes. It now carries
+  nothing, which is the truth: no folder is being searched by then.
+
 ## [1.99.0] - 2026-09-12
 
 **Eleven tabs stopped opening with a sentence written for someone who already knows Windows.** The line under

--- a/SysManager/SysManager.IntegrationTests/DuplicateFileServiceTests.cs
+++ b/SysManager/SysManager.IntegrationTests/DuplicateFileServiceTests.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Collections.Concurrent;
 using System.IO;
 using SysManager.Services;
 
@@ -17,22 +16,6 @@ public class DuplicateFileServiceTests : IDisposable
 {
     private readonly string _root =
         Path.Combine(Path.GetTempPath(), "SysManagerTests", "dupe-progress-" + Guid.NewGuid().ToString("N"));
-
-    /// <summary>
-    /// Collects reports on the thread that raises them.
-    /// </summary>
-    /// <remarks>
-    /// NOT <see cref="Progress{T}"/>, which is what production uses: it POSTS each callback to a captured
-    /// synchronization context, so a report raised just before the scan returns can still be in flight when
-    /// the assertions run. That is a test that passes on timing rather than on behaviour. Implementing
-    /// <see cref="IProgress{T}"/> directly makes <c>Report</c> synchronous, so every report has arrived by
-    /// the time the awaited scan completes.
-    /// </remarks>
-    private sealed class SynchronousProgress<T> : IProgress<T>
-    {
-        public ConcurrentQueue<T> Reports { get; } = new();
-        public void Report(T value) => Reports.Enqueue(value);
-    }
 
     /// <summary>Two identical files in a subfolder, so the walk descends and finds a duplicate pair.</summary>
     private string SeedTree()

--- a/SysManager/SysManager.IntegrationTests/LargeFileScannerProgressTests.cs
+++ b/SysManager/SysManager.IntegrationTests/LargeFileScannerProgressTests.cs
@@ -2,7 +2,6 @@
 // Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
 // License: MIT
 
-using System.Collections.Concurrent;
 using System.IO;
 using SysManager.Services;
 
@@ -16,22 +15,6 @@ public class LargeFileScannerProgressTests : IDisposable
 {
     private readonly string _root =
         Path.Combine(Path.GetTempPath(), "SysManagerTests", "large-progress-" + Guid.NewGuid().ToString("N"));
-
-    /// <summary>
-    /// Collects reports on the thread that raises them.
-    /// </summary>
-    /// <remarks>
-    /// NOT <see cref="Progress{T}"/>, which is what production uses: it POSTS each callback to a captured
-    /// synchronization context, so a report raised just before the scan returns can still be in flight when
-    /// the assertions run — a test that passes on timing rather than on behaviour. Implementing
-    /// <see cref="IProgress{T}"/> directly makes <c>Report</c> synchronous. Same reasoning as
-    /// <see cref="DuplicateFileServiceTests"/>, which pins the identical defect in the other scanner.
-    /// </remarks>
-    private sealed class SynchronousProgress<T> : IProgress<T>
-    {
-        public ConcurrentQueue<T> Reports { get; } = new();
-        public void Report(T value) => Reports.Enqueue(value);
-    }
 
     /// <summary>
     /// Files big enough to clear the scan's minimum size, some in the root and some below it.

--- a/SysManager/SysManager.IntegrationTests/LargeFileScannerProgressTests.cs
+++ b/SysManager/SysManager.IntegrationTests/LargeFileScannerProgressTests.cs
@@ -1,0 +1,107 @@
+// SysManager · LargeFileScannerProgressTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.Concurrent;
+using System.IO;
+using SysManager.Services;
+
+namespace SysManager.IntegrationTests;
+
+/// <summary>
+/// Tests that <see cref="LargeFileScanner"/> reports progress at all on a scan that finishes quickly.
+/// Here rather than in the unit project because progress only exists while a real walk is running.
+/// </summary>
+public class LargeFileScannerProgressTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "SysManagerTests", "large-progress-" + Guid.NewGuid().ToString("N"));
+
+    /// <summary>
+    /// Collects reports on the thread that raises them.
+    /// </summary>
+    /// <remarks>
+    /// NOT <see cref="Progress{T}"/>, which is what production uses: it POSTS each callback to a captured
+    /// synchronization context, so a report raised just before the scan returns can still be in flight when
+    /// the assertions run — a test that passes on timing rather than on behaviour. Implementing
+    /// <see cref="IProgress{T}"/> directly makes <c>Report</c> synchronous. Same reasoning as
+    /// <see cref="DuplicateFileServiceTests"/>, which pins the identical defect in the other scanner.
+    /// </remarks>
+    private sealed class SynchronousProgress<T> : IProgress<T>
+    {
+        public ConcurrentQueue<T> Reports { get; } = new();
+        public void Report(T value) => Reports.Enqueue(value);
+    }
+
+    /// <summary>
+    /// Files big enough to clear the scan's minimum size, some in the root and some below it.
+    /// </summary>
+    /// <remarks>
+    /// The root deliberately holds files of its own. Progress is reported at the end of each DIRECTORY's
+    /// file loop, and the first directory walked is the root — so a tree whose root is empty reports a real
+    /// folder with a count of zero, which is honest but proves nothing about the counts. Three files across
+    /// two levels makes the first report carry both.
+    /// </remarks>
+    private void SeedTree()
+    {
+        var nested = Path.Combine(_root, "videos");
+        Directory.CreateDirectory(nested);
+        File.WriteAllBytes(Path.Combine(_root, "clip-one.bin"), new byte[64 * 1024]);
+        File.WriteAllBytes(Path.Combine(_root, "clip-two.bin"), new byte[96 * 1024]);
+        File.WriteAllBytes(Path.Combine(nested, "clip-three.bin"), new byte[48 * 1024]);
+    }
+
+    /// <summary>
+    /// A scan short enough to finish inside the report throttle still reports its progress.
+    /// </summary>
+    /// <remarks>
+    /// The throttle is "not more often than every 200 ms", but seeding its timestamp with the current tick
+    /// made it "not before 200 ms have passed" as well. The report also sits at the end of each DIRECTORY's
+    /// file loop, so on a shallow tree there are only a handful of opportunities and all of them can fall
+    /// inside that first window — leaving Deep Cleanup's Large Files panel showing 0 files, 0 bytes and a
+    /// blank folder line for the whole scan (#2273). This tree is deliberately tiny, which is what makes it
+    /// the case that used to report nothing.
+    /// <para>Asserted on the first report's CONTENT as well as its existence: a report naming no folder and
+    /// counting no files would satisfy "something was reported" while telling the user nothing.</para>
+    /// </remarks>
+    [Fact]
+    public async Task ScanAsync_OnATreeFasterThanTheThrottle_StillReportsProgress()
+    {
+        SeedTree();
+        var progress = new SynchronousProgress<LargeFileScanner.LargeFileProgress>();
+
+        var results = await new LargeFileScanner().ScanAsync(
+            _root, minSizeBytes: 1024, top: 10, progress: progress);
+
+        Assert.Equal(3, results.Count);   // else the scan itself did not work and the rest proves nothing
+
+        var reports = progress.Reports.ToList();
+
+        // The FIRST report has to name a real folder inside the tree. Before the fix the only report on a
+        // tree this size was the final one, whose folder was the literal string "Done" — so this assertion
+        // failed on "Done" rather than on there being no report at all, which is how the second half of
+        // #2273 was found.
+        var first = reports.FirstOrDefault();
+        Assert.NotNull(first);
+        Assert.StartsWith(_root, first.CurrentFolder, StringComparison.OrdinalIgnoreCase);
+        Assert.True(first.FilesScanned > 0,
+            $"the first progress report counted {first.FilesScanned} files, so the panel it feeds would "
+            + "show a folder name beside a count of zero.");
+
+        // The LAST report exists to settle the counts and must name no folder, because the consumer renders
+        // CurrentFolder verbatim into a line that says which folder is being scanned.
+        var last = reports[^1];
+        Assert.Equal(3, last.FilesScanned);
+        Assert.True(string.IsNullOrEmpty(last.CurrentFolder),
+            $"the final report named \"{last.CurrentFolder}\" as the folder being scanned. Nothing is being "
+            + "scanned by then, and the panel shows that value as a folder name.");
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); }
+        catch (IOException) { /* a temp tree left behind is not a test failure */ }
+        catch (UnauthorizedAccessException) { /* ditto */ }
+        GC.SuppressFinalize(this);
+    }
+}

--- a/SysManager/SysManager.IntegrationTests/SynchronousProgress.cs
+++ b/SysManager/SysManager.IntegrationTests/SynchronousProgress.cs
@@ -1,0 +1,33 @@
+// SysManager · SynchronousProgress
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using System.Collections.Concurrent;
+
+namespace SysManager.IntegrationTests;
+
+/// <summary>
+/// Collects <see cref="IProgress{T}"/> reports on the thread that raises them, for a test that asserts on
+/// what a long-running operation reported.
+/// </summary>
+/// <remarks>
+/// <b>NOT <see cref="Progress{T}"/>, which is what production uses.</b> That one POSTS each callback to a
+/// captured synchronization context, so a report raised just before the awaited operation returns can still
+/// be in flight when the assertions run — a test that passes on timing rather than on behaviour, and one that
+/// would fail rarely and on a loaded machine. Implementing <see cref="IProgress{T}"/> directly makes
+/// <c>Report</c> synchronous, so every report has arrived by the time the operation completes.
+/// <para>A <see cref="ConcurrentQueue{T}"/> rather than a list: the reporting thread is not the test's
+/// thread, and a queue's enumerator is a moment-in-time snapshot, so an enqueue arriving mid-read cannot
+/// invalidate it. Enqueue order is preserved, so a test asserting a sequence keeps working. Same reasoning as
+/// <c>PropertyChangeRecorder</c> in the unit project.</para>
+/// <para>Shared because the second copy of it appeared within an hour of the first, in the test for the same
+/// defect in the sibling scanner.</para>
+/// </remarks>
+public sealed class SynchronousProgress<T> : IProgress<T>
+{
+    /// <summary>Every report raised so far, in order.</summary>
+    public ConcurrentQueue<T> Reports { get; } = new();
+
+    /// <inheritdoc/>
+    public void Report(T value) => Reports.Enqueue(value);
+}

--- a/SysManager/SysManager/Services/LargeFileScanner.cs
+++ b/SysManager/SysManager/Services/LargeFileScanner.cs
@@ -63,7 +63,14 @@ public sealed class LargeFileScanner
         stack.Push(rootPath);
         long scanned = 0;
         long bytesScanned = 0;
-        var lastReport = Environment.TickCount64;
+        // Zero, not the current tick. The throttle below is "not more often than every 200 ms", and
+        // seeding it with now made it "not before 200 ms have passed" as well — so a scan that finished
+        // inside that window reported nothing at all and the panel showed 0 files, 0 bytes and a blank
+        // folder for its whole duration (#2273). It bites harder here than in the sibling scanner because
+        // the report sits at the end of each DIRECTORY's loop, so a shallow tree gets only a handful of
+        // opportunities and all of them can fall in the first window. TickCount64 is time since boot, so
+        // the first directory always clears the gap and every one after it is throttled.
+        var lastReport = 0L;
 
         while (stack.Count > 0 && !ct.IsCancellationRequested)
         {
@@ -140,11 +147,16 @@ public sealed class LargeFileScanner
             }
         }
 
-        // A cancelled scan exits the loop with partial results; surfacing them as
-        // "Done" would mislead the user. Throw so the caller's cancel branch handles it.
+        // A cancelled scan exits the loop with partial results; surfacing them as finished
+        // would mislead the user. Throw so the caller's cancel branch handles it.
         ct.ThrowIfCancellationRequested();
 
-        progress?.Report(new LargeFileProgress(scanned, bytesScanned, "Done"));
+        // One last report so the counts settle on their final numbers, with an EMPTY folder — it used to
+        // say "Done", and the consumer renders CurrentFolder verbatim into a line that names the folder
+        // being scanned, so the panel showed a folder called "Done" (#2273). Empty is the honest value:
+        // these are the final counts and no folder is being scanned any more. Nothing has to recognise a
+        // sentinel to avoid displaying it.
+        progress?.Report(new LargeFileProgress(scanned, bytesScanned, string.Empty));
         return heap.Reverse().Select(h => meta[h.Path]).ToArray();
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.99.0</Version>
-    <FileVersion>1.99.0.0</FileVersion>
-    <AssemblyVersion>1.99.0.0</AssemblyVersion>
+    <Version>1.99.1</Version>
+    <FileVersion>1.99.1.0</FileVersion>
+    <AssemblyVersion>1.99.1.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #2273.

## Two defects, both shapes already fixed in the sibling scanner

Found by grepping `TickCount64` after fixing the identical throttle in `DuplicateFileService` (#2262) — "fix the class, not the instance". The sweep found exactly two throttles of this kind in the app, and this was the remaining one.

**1. The throttle suppressed its own first report.**

```csharp
var lastReport = Environment.TickCount64;   // was
...
// Throttle progress to every ~200 ms so the UI doesn't drown in events.
if (now - lastReport >= 200) { … }
```

Seeding with the current tick makes the rule *"no report before 200 ms have passed"*, not *"no more often than every 200 ms"*. `TickCount64` is time since boot, so `0` lets the first one through and throttles the rest.

It bites harder here than in Duplicate Finder: the report sits at the end of each **directory's** file loop, so a shallow tree gets only a handful of opportunities and all of them can fall inside that first window. Deep Cleanup's Large Files panel then sat at 0 files, 0 bytes and a blank folder line for the whole scan.

**2. The settling report displayed a folder called "Done".**

```csharp
progress?.Report(new LargeFileProgress(scanned, bytesScanned, "Done"));   // was
```

`DeepCleanupViewModel` (`:361-366`) renders `CurrentFolder` verbatim into the line that names the folder being scanned, so the panel showed a folder literally called "Done". It now carries `string.Empty`, which is the honest value — nothing is being scanned by then — and needs no sentinel for a consumer to recognise.

That is deliberately a *different* fix from Duplicate Finder's, where the terminal report also carried a fake **file** name and would have announced completion twice, so the phase had to be named and the consumer had to skip it. Here the folder is the only fake value, so emptying it is enough and no view-model change is needed.

## How the second defect was found

The regression test failed on the **wrong assertion**. It was written to prove "no report at all" and instead got one:

```
Assert.StartsWith() Failure: String start does not match
String:  "Done"
```

That is the whole argument for confirming a test fails for the *expected* reason rather than just failing.

## One correction to the issue's own text

My first version of the test seeded files only in a subfolder, and the first report legitimately named the **root** with a count of **zero** — because progress is reported at the end of each directory's loop and the root is walked first. That is not a defect. But it means a count assertion pins nothing unless the root has files of its own, so the fixture now spreads three files across two levels.

## Verification

App + integration tests: **0 errors, 0 warnings**. `dotnet format --verify-no-changes`: clean on both. Unit suite **5565 passed, 0 failed**. The new test and the two existing scanner tests pass together.

Both halves proven load-bearing — reverting either turns the test red, on its own assertion:

| mutation | result |
|---|---|
| throttle seeded with the current tick again | **failed** — the only report is the terminal one, folder `"Done"` |
| final report names `"Done"` again | **failed** — *"the final report named "Done" as the folder being scanned"* |

Baseline green before and after each.

## The shared helper, and why it is in this PR

This PR's test needed the synchronous `IProgress<T>` collector that #2265's test introduced an hour earlier — so the second copy of it was created **by this change**. Rather than ship two, it moves to `SynchronousProgress.cs` with the reasoning it carries: why not `Progress<T>` (it posts, so a report can still be in flight when the assertions run), and why a `ConcurrentQueue` (the reporting thread is not the test's thread).

## Not verified here

That the panel now visibly counts up on a real drive. The mechanism is proven — a real folder in the first report, honest counts, nothing named "Done" — but watching it is a laptop check.
