### PR TITLE
fix: a cancelled shortcut scan reported itself as complete, and as a clean PC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.99.2] - 2026-09-12
+
+**Cancelling a Shortcut Cleaner scan no longer tells you your PC is clean.** Pressing Cancel — or Escape,
+which does the same thing and is easy to hit by accident — stopped the scan and then reported it as finished.
+If it had not found anything yet, the tab said "No broken shortcuts found — your system is clean", raised a
+"scan complete" notification, and left a list that was short with no sign that it was short. It now says
+"Scan cancelled.", which is what it was always meant to say.
+
+### Fixed
+
+- A cancelled shortcut scan reports itself as cancelled. The tab already had the wording for it; the scan
+  never told it, so that message could not appear.
+
 ## [1.99.1] - 2026-09-12
 
 **The Large Files scan in Deep Cleanup showed nothing while it worked, then a folder called "Done".** It was

--- a/SysManager/SysManager.IntegrationTests/ShortcutCleanerCancellationTests.cs
+++ b/SysManager/SysManager.IntegrationTests/ShortcutCleanerCancellationTests.cs
@@ -1,0 +1,78 @@
+// SysManager · ShortcutCleanerCancellationTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Services;
+
+namespace SysManager.IntegrationTests;
+
+/// <summary>
+/// Tests that a cancelled shortcut scan reports itself as cancelled rather than as finished.
+/// Here rather than in the unit project because the scan walks the real Start Menu and desktop
+/// locations; there is no seam to substitute.
+/// </summary>
+public class ShortcutCleanerCancellationTests
+{
+    /// <summary>Cancels the scan the first time it reports a location, and records that it did.</summary>
+    private sealed class CancelOnFirstReport(CancellationTokenSource cts) : IProgress<string>
+    {
+        public int Reports { get; private set; }
+
+        public void Report(string value)
+        {
+            Reports++;
+            cts.Cancel();
+        }
+    }
+
+    /// <summary>
+    /// A scan cancelled while it is running surfaces <see cref="OperationCanceledException"/>.
+    /// </summary>
+    /// <remarks>
+    /// The scan breaks out of its loops on cancellation and used to return the partial list normally, so
+    /// the view model took its SUCCESS path: it announced a finished scan, logged "Shortcut scan
+    /// completed", raised a "Shortcut scan complete" toast, and — when nothing had been found yet — said
+    /// "No broken shortcuts found — your system is clean." Its <c>catch (OperationCanceledException)</c>
+    /// branch already existed and was dead code (#2275).
+    /// <para><b>Cancellation is triggered from the progress callback, not from a timer or a pre-cancelled
+    /// token, and both alternatives would have made this test worthless.</b> A pre-cancelled token never
+    /// reaches the method at all — <c>Task.Run(…, ct)</c> refuses to invoke the delegate and the await
+    /// throws <c>TaskCanceledException</c> on its own, so the test would pass against the unfixed code. A
+    /// timer would be a race. The callback fires once per location, before that location is walked, so
+    /// cancelling inside it means the very next loop check breaks and the throw under test is the only
+    /// thing that can raise.</para>
+    /// </remarks>
+    [Fact]
+    public async Task ScanAsync_CancelledWhileRunning_ReportsCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        var progress = new CancelOnFirstReport(cts);
+        var service = new ShortcutCleanerService();
+
+        var ex = await Record.ExceptionAsync(() => service.ScanAsync(progress, cts.Token));
+
+        Assert.True(progress.Reports > 0,
+            "the scan never reported a location, so cancellation never fired and this test proves nothing "
+            + "about a cancelled scan. It needs at least one of the standard shortcut locations to exist.");
+
+        Assert.True(ex is OperationCanceledException,
+            $"a cancelled scan surfaced {ex?.GetType().Name ?? "NO EXCEPTION"}. With no exception the view "
+            + "model takes its success path and announces a finished scan — and if nothing had been found "
+            + "yet, that the PC is clean.");
+    }
+
+    /// <summary>
+    /// A scan that is NOT cancelled still returns normally.
+    /// </summary>
+    /// <remarks>
+    /// The other direction of the same line: a <c>ThrowIfCancellationRequested</c> placed where the token
+    /// is not actually cancelled would break every ordinary scan, and the test above cannot see that.
+    /// </remarks>
+    [Fact]
+    public async Task ScanAsync_NotCancelled_CompletesNormally()
+    {
+        var results = await new ShortcutCleanerService().ScanAsync();
+
+        Assert.NotNull(results);   // a broken shortcut may legitimately not exist on this machine
+    }
+}

--- a/SysManager/SysManager/Services/ShortcutCleanerService.cs
+++ b/SysManager/SysManager/Services/ShortcutCleanerService.cs
@@ -71,6 +71,14 @@ public sealed partial class ShortcutCleanerService
             }
         }
 
+        // A cancelled scan exits the loops above with partial results — they break on cancellation
+        // rather than throwing — so returning normally would hand the caller a short list with no
+        // indication that it is short. The view model's success path then claimed a finished scan and,
+        // if nothing had been found yet, that the PC was clean (#2275). Throw so its existing cancel
+        // branch runs instead; it already says "Scan cancelled." and was dead code until now. Both
+        // sibling scanners end the same way, for the same reason.
+        ct.ThrowIfCancellationRequested();
+
         return results;
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.99.1</Version>
-    <FileVersion>1.99.1.0</FileVersion>
-    <AssemblyVersion>1.99.1.0</AssemblyVersion>
+    <Version>1.99.2</Version>
+    <FileVersion>1.99.2.0</FileVersion>
+    <AssemblyVersion>1.99.2.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #2275.

## What a cancelled scan used to say

`ShortcutCleanerService.Scan` breaks out of its loops on cancellation and returned the partial list normally, never throwing. So the view model took its **success** path:

```csharp
// ShortcutCleanerViewModel.cs:93-99 — what ran after you pressed Cancel
ScanStatus = BrokenCount == 0
    ? "No broken shortcuts found — your system is clean."
    : $"Found {BrokenCount} broken shortcut{…}.";
Log.Information("Shortcut scan completed: {Count} broken shortcuts found", BrokenCount);
ToastService.Instance.Show("Shortcut scan complete", …);
```

```csharp
// :101 — existed, could not fire
catch (OperationCanceledException) { ScanStatus = "Scan cancelled."; }
```

Cancel — or press **Escape**, which is wired to the same command and is easy to hit by accident — and the tab claimed a finished scan, logged that it completed, raised a "complete" toast, and left a short list with no sign that it was short. Early enough, it stated as a finding that the PC was clean.

## The fix is one line, and the view model needed none

`ct.ThrowIfCancellationRequested()` before the return, carrying the comment both sibling scanners already have. The cancel branch was already written and already says the right thing.

## The test cancels from the progress callback, and that is the whole point

The obvious shape — a pre-cancelled token — **would have passed against the unfixed code.** `Task.Run(() => Scan(…), ct)` refuses to invoke the delegate when the token is already cancelled, so the await throws `TaskCanceledException` on its own and the line under test never runs. A timer would be a race.

The progress callback fires once per location, *before* that location is walked. Cancelling inside it means the very next loop check breaks, the loops unwind, and the new throw is the only thing that can raise. No timing, deterministic on any machine.

It also asserts the callback fired at all, so a machine with none of the standard shortcut locations fails loudly instead of passing over an empty population.

A second test pins the other direction: an uncancelled scan still returns normally. Without it, a `ThrowIfCancellationRequested` in the wrong place would break every ordinary scan and the first test could not see it.

## Verification

App + both test projects: **0 errors**. `dotnet format --verify-no-changes`: clean on all three. Unit suite **5565 passed, 0 failed**. Both new tests pass in **0.8s**.

| mutation | result |
|---|---|
| the throw removed (the state before the fix) | **failed** — *"a cancelled scan surfaced NO EXCEPTION"* |
| — and the uncancelled test | stayed green, so the failure is specifically about cancellation |

Baseline green either side.

## The class, measured — and why no guard yet

Nine services stop a loop on `IsCancellationRequested`. Counting `ThrowIfCancellationRequested` per service is what found this one:

| | breaks | throws |
|---|---|---|
| DuplicateFile 4 · DeepCleanup 6 · DiskAnalyzer 3 · LargeFileScanner 1 | | 3 · 2 · 1 · 1 |
| **ShortcutCleaner** | 3 | **0 → 1 here** |
| **BrowserCleaner** | 7 | **0** — filed as #2278, same false all-clear |
| ProcessManager | 2 | 0 — a short process list, refreshed on a timer, with no claim attached |
| PingMonitor · TracerouteMonitor | 1 each | 0 — correct as-is: continuous monitors, where ending the loop *is* the shutdown |

The obvious guard — "break on cancellation implies throw before returning" — is **not** in this PR, deliberately. It would ship with four findings, two of which are correct code, and a guard that lands with legitimate findings gets suppressed rather than fixed. It is worth writing once #2278 and the Process Manager question are settled, with the two monitors as named exemptions.

## Not verified here

That the tab visibly says "Scan cancelled." after pressing Escape. The mechanism is proven — the service throws, and the branch that catches it is the one that sets that text — but seeing it is a laptop check.
