### PR TITLE
fix: a cancelled browser scan reported that there was nothing to clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.99.3] - 2026-09-12
+
+**Cancelling a Browser Cleaner scan no longer reports that there is nothing to clean.** Stopping the scan
+early made the tab say "No cleanable browser data found." — stated as a finding, about browsers it had not
+finished looking at. It now says "Cancelled.", the wording the tab already had and could never reach. This is
+the same fault fixed for Shortcut Cleaner in 1.99.2, and a test now holds the rule for every scan in the app
+so it cannot appear in a third place.
+
+### Fixed
+
+- A cancelled browser-data scan reports itself as cancelled instead of as a completed scan that found nothing.
+- Cleaning is deliberately left as it is: when you stop a clean, the count of files already removed is true,
+  and reporting a cancellation instead would throw that number away. The gap there was a missing word, not a
+  wrong one.
+
 ## [1.99.2] - 2026-09-12
 
 **Cancelling a Shortcut Cleaner scan no longer tells you your PC is clean.** Pressing Cancel — or Escape,

--- a/SysManager/SysManager.IntegrationTests/BrowserCleanerCancellationTests.cs
+++ b/SysManager/SysManager.IntegrationTests/BrowserCleanerCancellationTests.cs
@@ -1,0 +1,54 @@
+// SysManager · BrowserCleanerCancellationTests
+// Author: laurentiu021 · https://github.com/laurentiu021/SystemManager
+// License: MIT
+
+using SysManager.Models;
+using SysManager.Services;
+
+namespace SysManager.IntegrationTests;
+
+/// <summary>
+/// Behavioural tests for the two directions of <see cref="BrowserCleanerService"/>'s cancellation
+/// contract. That a cancelled scan THROWS is pinned in the unit project instead — see
+/// <c>ArchitectureTests.EveryScanThatBreaksOnCancellation_ThrowsBeforeReturning</c> — because this scan
+/// takes no progress callback, so there is no deterministic point at which a test can cancel it: on a
+/// machine with no browser profiles it finishes in microseconds and would legitimately beat the cancel.
+/// A test that accepted "either outcome" would pass against the unfixed code, which is what it must not do.
+/// </summary>
+public class BrowserCleanerCancellationTests
+{
+    /// <summary>
+    /// A scan that is NOT cancelled returns normally.
+    /// </summary>
+    /// <remarks>
+    /// The other direction of the new throw: placed where the token is not actually cancelled, it would
+    /// break every ordinary scan — and no source-shape guard can see that.
+    /// </remarks>
+    [Fact]
+    public async Task ScanAsync_NotCancelled_CompletesNormally()
+    {
+        var items = await new BrowserCleanerService().ScanAsync();
+
+        Assert.NotNull(items);   // a machine may legitimately have no browser data to clean
+    }
+
+    /// <summary>
+    /// Cleaning an empty selection deletes nothing and returns zero.
+    /// </summary>
+    /// <remarks>
+    /// The clean path deliberately has NO cancellation throw, unlike the scan: its count is true either way
+    /// — those files really were deleted — and an exception would discard it, trading a missing word for
+    /// missing information (#2278). That asymmetry is not expressible as a behavioural test, because
+    /// <c>Task.Run(…, ct)</c> refuses to invoke the delegate for an already-cancelled token and the await
+    /// throws before the body is reached, whatever the body does. So the guard in the unit project checks
+    /// the clean path's SHAPE, and this covers the ordinary path it must not break.
+    /// </remarks>
+    [Fact]
+    public async Task CleanAsync_WithNothingSelected_ReturnsZero()
+    {
+        var deleted = await new BrowserCleanerService()
+            .CleanAsync(Array.Empty<BrowserCleanupItem>());
+
+        Assert.Equal(0, deleted);
+    }
+}

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -8923,6 +8923,83 @@ public partial class ArchitectureTests
     private static partial Regex BoolReturningMember();
 
     /// <summary>The app project directory — .xaml is not copied to the test output.</summary>
+    /// <summary>
+    /// A service that stops a loop on cancellation must throw before returning, so a partial result is
+    /// never handed back as a finished one.
+    /// </summary>
+    /// <remarks>
+    /// Breaking out of a loop and returning normally gives the caller a short list with no way to know it is
+    /// short — and every caller here is written around <c>catch (OperationCanceledException)</c>, so the
+    /// cancel branch simply never runs and the SUCCESS path reports the partial result. Three instances, all
+    /// user-visible, all the same one-line fix:
+    /// <list type="bullet">
+    /// <item>#2206 — a cancelled PowerShell query returned as a successful empty result.</item>
+    /// <item>#2275 — a cancelled shortcut scan said "No broken shortcuts found — your system is clean."</item>
+    /// <item>#2278 — a cancelled browser scan said "No cleanable browser data found."</item>
+    /// </list>
+    /// <para>The first two were each fixed alone, which is why this exists: the third was found by counting
+    /// <c>ThrowIfCancellationRequested</c> per service rather than by using the tab.</para>
+    /// <para><b>The exemptions are reasoned, not convenient</b>, and there are three of nine. A continuous
+    /// monitor's loop ENDING is its shutdown, not a truncated answer, so Ping and Traceroute are correct as
+    /// written. Process Manager returns a list that carries no claim and is refreshed on a timer, so a short
+    /// one is a display artefact rather than a false statement; it is listed rather than fixed because
+    /// changing it would alter behaviour nothing complains about.</para>
+    /// <para>Keyed on the break SHAPE — <c>if (…IsCancellationRequested) break;</c> and its
+    /// <c>yield break</c>/<c>return</c> variants — because that is the construct that produces the defect. A
+    /// service that only checks the flag to skip one item never returns a truncated result.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryScanThatBreaksOnCancellation_ThrowsBeforeReturning()
+    {
+        // Correct as written, with the reason. Not an allowlist to grow: adding a name here means arguing
+        // that a truncated result is honest for that service.
+        string[] exempt =
+        [
+            "PingMonitorService.cs",        // continuous monitor: the loop ending IS the shutdown
+            "TracerouteMonitorService.cs",  // ditto
+            "ProcessManagerService.cs",     // a list with no claim attached, refreshed on a timer
+        ];
+
+        var servicesDir = Path.Combine(FindAppProjectDir(), "Services");
+        var offenders = new List<string>();
+        var population = 0;
+
+        foreach (var path in Directory.EnumerateFiles(servicesDir, "*.cs", SearchOption.TopDirectoryOnly))
+        {
+            var file = Path.GetFileName(path);
+            var code = string.Join("\n", File.ReadAllLines(path).Where(IsCode));
+
+            if (!CancellationBreak().IsMatch(code)) continue;
+            population++;
+
+            if (exempt.Contains(file, StringComparer.Ordinal)) continue;
+            if (code.Contains("ThrowIfCancellationRequested", StringComparison.Ordinal)) continue;
+
+            offenders.Add(file);
+        }
+
+        // Vacuity floor: nine services stop a loop on cancellation, measured. A drop means the break shape
+        // stopped matching and an absence-of-offenders pass would prove nothing.
+        Assert.True(population >= 8,
+            $"only {population} services were found that stop a loop on cancellation, out of 9 measured — "
+            + "the break shape is out of date, so a pass here means nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "these services break out of a loop on cancellation and then return normally, so the caller "
+            + "receives a partial result and its catch (OperationCanceledException) branch never runs — it "
+            + "reports a finished operation, and for a scan that means telling the user nothing was found:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// A loop stopped by cancellation: the construct that returns a truncated result. Matched on the
+    /// statement rather than on the flag alone, because checking the flag to skip ONE item is a different
+    /// thing and is not a defect.
+    /// </summary>
+    [GeneratedRegex(@"IsCancellationRequested\s*\)\s*\{?\s*(break|yield\s+break|return)\b",
+                    RegexOptions.Compiled)]
+    private static partial Regex CancellationBreak();
+
     private static string FindAppProjectDir()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);

--- a/SysManager/SysManager/Services/BrowserCleanerService.cs
+++ b/SysManager/SysManager/Services/BrowserCleanerService.cs
@@ -263,6 +263,14 @@ public sealed class BrowserCleanerService
                     IsSelected = !d.Sensitive   // cache/history pre-selected; cookies/sessions opt-in
                 });
             }
+
+            // A cancelled scan exits the loops above with partial results — they break on cancellation
+            // rather than throwing — so returning normally handed the caller a short list with no way to
+            // know it was short. The view model's success path then claimed a finished scan and, with
+            // nothing found yet, said "No cleanable browser data found." (#2278). Throw so its existing
+            // cancel branch runs; it already says "Cancelled." and was dead code until now.
+            ct.ThrowIfCancellationRequested();
+
             return items;
         }, ct);
 
@@ -284,6 +292,14 @@ public sealed class BrowserCleanerService
                 }
             }
             Log.Information("BrowserCleaner: deleted {Count} files across {Items} items", deleted, items.Count);
+
+            // NOT ct.ThrowIfCancellationRequested() here, unlike the scan above, and the difference is
+            // deliberate. This count is TRUE whether or not the run was cancelled — those files really were
+            // deleted — so the caller reporting "Removed N file(s)" is not a false statement, only a silent
+            // one about having stopped. Throwing would send the view model down its cancel branch, which
+            // discards the count and skips the re-scan, so it would trade a missing word for missing
+            // information. Saying "cancelled after removing N" needs the count to survive, which an
+            // exception cannot carry (#2278).
             return deleted;
         }, ct);
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.99.2</Version>
-    <FileVersion>1.99.2.0</FileVersion>
-    <AssemblyVersion>1.99.2.0</AssemblyVersion>
+    <Version>1.99.3</Version>
+    <FileVersion>1.99.3.0</FileVersion>
+    <AssemblyVersion>1.99.3.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #2278. Third instance of this class, so it also brings the guard.

## The defect

`BrowserCleanerService.ScanAsync` breaks out of its loops on cancellation (7 sites) and returned the partial list normally, never throwing. The view model then took its success path:

```csharp
// BrowserCleanerViewModel.cs:84-86 — what ran after a cancel
StatusMessage = Items.Count == 0
    ? "No cleanable browser data found."
    : $"Found {Items.Count} categories across your browsers — {total} total. …";
```

```csharp
// :89 — existed, could not fire
catch (OperationCanceledException) { StatusMessage = "Cancelled."; }
```

So stopping the scan produced a *finding* — "there is nothing to clean" — about browsers it had not finished looking at. One `ThrowIfCancellationRequested()` before the return fixes it; the view model needed no change, because the wording was already written.

## The clean path is deliberately NOT changed

I added the same throw to `CleanAsync`, then took it out. Its count is **true either way** — those files really were deleted before the cancel — so `"Removed N file(s)"` is not a false statement, only a silent one about having stopped. Throwing would send the caller down a branch that discards the count and skips the re-scan: a missing word traded for missing information. Saying "cancelled after removing N" needs the number to survive, which an exception cannot carry.

That reasoning is now a comment on the method, because the next person to run the same sweep will otherwise "fix" it.

## The guard, and why now

Three instances in three weeks, each fixed alone:

| | said |
|---|---|
| #2206 (v1.96.1) | a cancelled PowerShell query returned as a successful empty result |
| #2275 (v1.99.2) | "No broken shortcuts found — your system is clean." |
| **this** | "No cleanable browser data found." |

`ArchitectureTests.EveryScanThatBreaksOnCancellation_ThrowsBeforeReturning` now covers all **nine** services that stop a loop on cancellation. Keyed on the break *shape* — `if (…IsCancellationRequested) break;` and its `yield break` / `return` variants — because checking the flag to skip one item is a different thing and is not a defect.

**Three exemptions, each with the reason in the code**, and the issue I filed argued against writing this guard until they were down to that:

- `PingMonitorService`, `TracerouteMonitorService` — continuous monitors, where the loop **ending** is the shutdown, not a truncated answer.
- `ProcessManagerService` — a list that carries no claim and is refreshed on a timer, so a short one is a display artefact. Listed rather than fixed, because changing it would alter behaviour nothing complains about.

## Why the behavioural test for the throw is NOT here

I wrote one and deleted it. This scan takes no progress callback, so there is no deterministic point at which a test can cancel it — and the two obvious alternatives are both worthless:

- **A pre-cancelled token never reaches the method.** `Task.Run(…, ct)` refuses to invoke the delegate and the await throws `TaskCanceledException` on its own, so the test passes against the unfixed code.
- **Cancelling from another thread and accepting "either outcome"** passes when the scan wins the race — and on a machine with no browser profiles it always wins. `ex is null` is exactly what the bug produced.

So the throw is pinned by the guard, which fails without it, and the two behavioural tests here cover what a source check cannot: that an ordinary scan still returns, and that cleaning nothing still returns zero.

That is the difference from #2279, where `ShortcutCleanerService` *does* take a progress callback — one that fires per location before walking it — so cancelling inside it is deterministic and the throw is pinned behaviourally there.

## Verification

App + both test projects: **0 errors**. `dotnet format --verify-no-changes`: clean on all three. Unit suite **5566 passed, 0 failed** (5565 → 5566). New integration tests pass in 0.4s.

Four states, each reverted after measuring, because a guard over a class has to be shown not to be hard-coded to one member:

| mutation | guard |
|---|---|
| BrowserCleaner's throw removed | **failed**, naming `BrowserCleanerService.cs` |
| both services' throws removed | **failed**, naming **both** |
| an exemption dropped from the list | **failed**, naming `ProcessManagerService.cs` — so the list is really read |
| the break shape renamed | **failed** on the floor — *"only 0 services … out of 9 measured"* |

Baseline green before and after each.

## Not verified here

That the tab visibly says "Cancelled." after pressing Cancel mid-scan. The mechanism is proven — the service throws, and the branch catching it is the one setting that text — but seeing it is a laptop check.
