### PR TITLE
fix: Disk Analyzer announced a new sentence per folder, then named a folder called "Done"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.99.4] - 2026-09-12
+
+**Disk Analyzer no longer talks over itself while it measures, and no longer ends by naming a folder
+called "Done".** The line at the bottom of the tab changed once for every folder the scan reached, and
+that line is the one a screen reader speaks — so analysing a folder with hundreds of small children
+started hundreds of sentences in a few seconds and finished none of them. The tab now keeps a calm
+"Analyzing…" there and shows the running count and current folder on a second line beside it, with the
+full path on hover. Nothing is announced that changes faster than it can be heard.
+
+### Fixed
+
+- The Disk Analyzer status line is no longer rewritten once per folder, so a screen reader hears what the
+  tab is doing instead of a stream of interrupted sentences.
+- The last thing the scan reported was "Scanning folder 1234: Done" — a sentence claiming the scan is still
+  running, naming a folder that does not exist. The final report now names no folder at all.
+- The count and folder name moved to their own line, trimmed to fit, with the folder's full path on hover.
+  Nothing that was on screen before has been taken away.
+
 ## [1.99.3] - 2026-09-12
 
 **Cancelling a Browser Cleaner scan no longer reports that there is nothing to clean.** Stopping the scan

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -491,11 +491,16 @@ public partial class ArchitectureTests
     /// someone adding tab 60 is to copy it from the neighbour, which is how there came to be 21 of them. Once
     /// the control exists, a fresh copy is a regression rather than a starting point — so the exact attribute
     /// run is banned outside the control itself.</para>
-    /// <para>The 16 footers that carry extra content — a docked Cancel or Refresh button, an ETA line, a
+    /// <para>The 17 footers that carry extra content — a docked Cancel or Refresh button, an ETA line, a
     /// trimmed path with a tooltip, a literal <c>IsIndeterminate="True"</c> — are deliberately NOT converted
     /// and are deliberately NOT covered by the ban: they are not the shape this control replaces. The ban is
     /// scoped to the plain form for that reason, and widening it would demand slots that make the control
     /// more complicated than the duplication it removes (#1630).</para>
+    /// <para><b>The call-site count can legitimately go DOWN.</b> Disk Analyzer left this control in #2274:
+    /// it needs a second, silent line beside the status line, which is exactly the extra content the
+    /// paragraph above says not to give the control slots for. So 20 call sites, from 21 — and the floor
+    /// moved with it, deliberately. A drop is a broken element match OR a conversion away, and the two are
+    /// told apart by whether the view that lost it grew a footer of its own.</para>
     /// </remarks>
     [Fact]
     public void EveryStatusFooter_NamesItsProgressBar_AndNobodyReInlinesIt()
@@ -541,9 +546,10 @@ public partial class ArchitectureTests
             + "ProgressName=\"… progress\"/> instead:\n  " + string.Join("\n  ", reInlined));
 
         // Vacuity floor for the naming check below, and only for it: if the element match breaks, `unnamed`
-        // is empty for the wrong reason. 21 call sites when converted.
-        Assert.True(callSites >= 21,
-            $"only {callSites} StatusFooter call sites were found, out of 21 converted — the element match is "
+        // is empty for the wrong reason. 20 call sites — 21 were converted, then Disk Analyzer left again in
+        // #2274 for a second line the control has no slot for (see this test's summary).
+        Assert.True(callSites >= 20,
+            $"only {callSites} StatusFooter call sites were found, out of 20 in use — the element match is "
             + "out of date, so the naming check below proves nothing.");
 
         Assert.True(unnamed.Count == 0,
@@ -8999,6 +9005,196 @@ public partial class ArchitectureTests
     [GeneratedRegex(@"IsCancellationRequested\s*\)\s*\{?\s*(break|yield\s+break|return)\b",
                     RegexOptions.Compiled)]
     private static partial Regex CancellationBreak();
+
+    /// <summary>
+    /// No progress callback writes a property that a view renders in a live region.
+    /// </summary>
+    /// <remarks>
+    /// A progress callback fires per item, so what it writes changes as fast as the work does. A live region
+    /// speaks every change. Put those together and a screen reader gets continuous speech instead of
+    /// information — it starts each sentence and is interrupted by the next.
+    /// <para>Disk Analyzer wrote <c>StatusMessage</c> — which <c>StatusFooter</c> renders through
+    /// <c>StatusLine</c>, i.e. announced — straight from its callback, with no rate limit at all: once per
+    /// top-level subfolder as the walk reached it. On a folder with hundreds of small children that is
+    /// hundreds of sentences in a few seconds, so the tab said LESS the more there was to say (#2274).</para>
+    /// <para><b>Why the existing live-region guard could not see it.</b>
+    /// <c>EveryStatusLine_IsALiveRegion_AndTheFastReadoutsAreNot</c> asserts that each status line IS
+    /// announced and that each NAMED fast readout is not. Disk Analyzer satisfied both: its status line was
+    /// announced as required, and it had no separate fast readout to list, because the fast value went
+    /// directly into the announced line. That rule watches for a fast value BESIDE the status line and never
+    /// for the status line itself being fast — the gap that let this survive #1545 and #2143. Checking the
+    /// writer rather than the neighbour is what closes it.</para>
+    /// <para><b>The population is every live region, not just the callback-written ones.</b> That is the
+    /// point: the check reads every announced binding in the app against every progress callback, so wiring
+    /// a fast value into any live region fails here when it is written rather than when someone finally runs
+    /// a screen reader.</para>
+    /// <para><b>Three exemptions, all reasoned.</b> Deep Cleanup's scan and clean lines are announced AND
+    /// callback-written, and they are correct: their report carries a <c>Total</c>, so the number of
+    /// announcements equals the number of categories — around a dozen for a whole pass, which is what a live
+    /// region is for. Duplicate Finder's writes only the coarse phase label, the shape #2143 established;
+    /// its fast half is <c>ScanReadout</c>, which the sibling guard holds silent. A name added here has to
+    /// argue that its line is SLOW, not merely that it is useful.</para>
+    /// </remarks>
+    [Fact]
+    public void NoProgressCallback_WritesAnAnnouncedLine()
+    {
+        // Announced and callback-written on purpose. The reason is the rate, not the usefulness.
+        (string Vm, string Property, string Why)[] exempt =
+        [
+            ("DeepCleanupViewModel", "ScanStatusLine",
+                "bounded by the report's Total: one announcement per category, ~12 per scan"),
+            ("DeepCleanupViewModel", "CleanStatusLine", "same, for the clean pass"),
+            ("DuplicateFileViewModel", "StatusMessage",
+                "writes only the coarse phase label; the fast half is ScanReadout (#2143)"),
+        ];
+
+        var appDir = FindAppProjectDir();
+        var viewsDir = Path.Combine(appDir, "Views");
+        var vmDir = Path.Combine(appDir, "ViewModels");
+
+        // Every property any view announces. StatusMessage is included whenever a view uses
+        // <v:StatusFooter/>, which renders it through StatusLine from ANOTHER file — most tabs reach it that
+        // way, so a sweep that only read TextBlocks in each view would miss all of them.
+        string[] announcedStyles = ["{StaticResource StatusLine}", "{StaticResource SubtleStatusLine}"];
+        var announced = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var path in Directory.EnumerateFiles(viewsDir, "*.xaml", SearchOption.TopDirectoryOnly))
+        {
+            var root = System.Xml.Linq.XDocument.Load(path).Root;
+            if (root is null) continue;
+
+            if (root.DescendantsAndSelf().Any(e => e.Name.LocalName == "StatusFooter"))
+                announced.Add("StatusMessage");
+
+            foreach (var block in root.DescendantsAndSelf().Where(e => e.Name.LocalName == "TextBlock"))
+            {
+                if (BoundProperty(Attr(block, "Text")) is not { } bound) continue;
+                if (IsAnnounced(block, announcedStyles)) announced.Add(bound);
+            }
+        }
+
+        // Vacuity floor on the corpus this reads FROM, as an enumerated SET rather than a count: the whole
+        // app has six announced properties and naming them is strictly stronger than a number, in the same
+        // way the sibling guard's mustStaySilent list is. StatusMessage reaches this through 22
+        // <v:StatusFooter/> call sites plus Disk Analyzer's own inline StatusLine; the other five carry
+        // AutomationProperties.LiveSetting directly. A NEW live region needs no entry here — it is checked
+        // automatically — so this list only has to keep pace with renames.
+        string[] knownAnnounced =
+        [
+            "StatusMessage", "ScanStatusLine", "CleanStatusLine", "SfcVerdict", "DismVerdict", "StoreVerdict",
+        ];
+        var missing = knownAnnounced.Except(announced, StringComparer.Ordinal).ToList();
+        Assert.True(missing.Count == 0,
+            "these properties are announced in the views but this guard did not find them, so the live-region "
+            + "read is out of date and the check below covers less than it claims. They were renamed or their "
+            + $"binding changed shape — update the list with the current names:\n  "
+            + string.Join("\n  ", missing));
+
+        var offenders = new List<string>();
+        var callbacksSeen = 0;
+
+        foreach (var file in Directory.EnumerateFiles(vmDir, "*ViewModel.cs", SearchOption.TopDirectoryOnly))
+        {
+            var vm = Path.GetFileNameWithoutExtension(file);
+            var code = WithoutComments(File.ReadAllText(file));
+
+            foreach (var body in ProgressCallbackBodies(code))
+            {
+                callbacksSeen++;
+                foreach (var written in AssignedProperties(body).Where(announced.Contains))
+                {
+                    if (exempt.Any(e => e.Vm == vm && e.Property == written)) continue;
+                    offenders.Add($"{vm}.{written}");
+                }
+            }
+        }
+
+        // Floor on the OTHER corpus: the callbacks themselves.
+        Assert.True(callbacksSeen >= 11,
+            $"only {callbacksSeen} progress callbacks were found — the callback shape is out of date, so no "
+            + "writer is being read.");
+
+        Assert.True(offenders.Count == 0,
+            "these write a live region from inside a progress callback, so a screen reader is told the fast "
+            + "value: it starts a sentence per item and is cut off by the next, which is less useful than "
+            + "silence. Announce the coarsest line the tab has and move the per-item value to a silent "
+            + "readout beside it, as Duplicate Finder and Disk Analyzer do:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The body of every <c>new Progress&lt;T&gt;(…)</c> in a view model — the lambda's statements, or the
+    /// named method's body when one is passed by reference.
+    /// </summary>
+    /// <remarks>
+    /// Both forms have to be read or the rule is evaded by extracting a method, which is exactly what the two
+    /// tabs that got this right do: <c>new Progress&lt;ScanProgress&gt;(ApplyScanProgress)</c>. A
+    /// call-site-only reader would report those two as clean without ever looking at what they write.
+    /// </remarks>
+    private static IEnumerable<string> ProgressCallbackBodies(string code)
+    {
+        foreach (var m in ProgressConstruction().Matches(code).Cast<Match>())
+        {
+            var argument = m.Groups["arg"].Value;
+
+            // A bare identifier is a method reference: read that method's body instead. Anything else is a
+            // lambda, whose body runs from the construction to the parenthesis that closes it.
+            if (argument.Length > 0)
+            {
+                if (MethodBodiesByName(code).TryGetValue(argument, out var overloads))
+                    foreach (var body in overloads)
+                        yield return body;
+                continue;
+            }
+
+            yield return BalancedFrom(code, m.Index);
+        }
+    }
+
+    /// <summary>
+    /// The text from <paramref name="start"/> to the close of the parenthesis group it opens — a lambda's
+    /// whole body, however many lines and nested braces it spans.
+    /// </summary>
+    private static string BalancedFrom(string code, int start)
+    {
+        var depth = 0;
+        for (var i = start; i < code.Length; i++)
+        {
+            if (code[i] == '(') depth++;
+            else if (code[i] == ')')
+            {
+                depth--;
+                if (depth == 0) return code[start..(i + 1)];
+            }
+        }
+        return code[start..];
+    }
+
+    /// <summary>The property names assigned in a block — the left side of a plain <c>X = …</c>.</summary>
+    /// <remarks>
+    /// <c>item.Status = …</c> is deliberately NOT matched: a row's own property is not a tab-level line, and
+    /// no view announces one.
+    /// </remarks>
+    private static IEnumerable<string> AssignedProperties(string body)
+    {
+        foreach (var m in PropertyAssignment().Matches(body).Cast<Match>())
+            yield return m.Groups["name"].Value;
+    }
+
+    /// <summary>
+    /// A <c>new Progress&lt;T&gt;(</c> construction. <c>arg</c> captures the argument only when it is a bare
+    /// identifier — a method group — and is empty for a lambda, which is how the reader tells them apart.
+    /// </summary>
+    /// <remarks>
+    /// The whole construction must match either way, or the lambda form would not be seen at all. Hence the
+    /// optional group rather than requiring the identifier.
+    /// </remarks>
+    [GeneratedRegex(@"new\s+Progress<[^>]*>\s*\((?:\s*(?<arg>[A-Za-z_]\w*)\s*\))?", RegexOptions.Compiled)]
+    private static partial Regex ProgressConstruction();
+
+    /// <summary>An assignment to a bare property name at the start of a statement.</summary>
+    [GeneratedRegex(@"(?:^|[;{}]|=>)\s*(?<name>[A-Z]\w*)\s*=(?!=)", RegexOptions.Compiled)]
+    private static partial Regex PropertyAssignment();
 
     private static string FindAppProjectDir()
     {

--- a/SysManager/SysManager.Tests/DiskAnalyzerServiceTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerServiceTests.cs
@@ -206,7 +206,10 @@ public class DiskAnalyzerServiceTests : IDisposable
         await _service.AnalyzeAsync(_root, progress);
 
         Assert.True(progress.Reports.Count >= 1);
-        Assert.Contains(progress.Reports, r => r.CurrentFolder == "Done");
+        // This asserted `r.CurrentFolder == "Done"`, so the placeholder was not merely unnoticed — it was the
+        // EXPECTED value, which is why #2274 survived two sweeps of the live-region rules. What this test is
+        // for is that reporting happens at all; the specific contract is pinned in the two tests below.
+        Assert.Contains(progress.Reports, r => r.CurrentFolder.Length > 0);
     }
 
     // ── ShouldSkip ──
@@ -264,5 +267,43 @@ public class DiskAnalyzerServiceTests : IDisposable
         Assert.Contains("FileCount", changed);
         Assert.Contains("FolderCount", changed);
         Assert.Contains("IsAccessDenied", changed);
+    }
+
+    // ── What the progress reports carry (#2274) ──
+
+    [Fact]
+    public async Task EveryProgressReport_CarriesTheFullPath_SoTheTabCanShowItOnHover()
+    {
+        CreateFile(Path.Combine("Alpha", "a.bin"), 16);
+        CreateFile(Path.Combine("Beta", "b.bin"), 16);
+        var progress = new SyncProgress<DiskAnalyzerService.AnalysisProgress>();
+
+        await _service.AnalyzeAsync(_root, progress);
+
+        // Reported the whole path, not just the leaf: the tab trims it for the line and shows the path on
+        // hover, so a name alone would leave the hover with nothing to add.
+        var walked = progress.Reports.Where(r => r.CurrentFolder.Length > 0).ToList();
+        Assert.Equal(2, walked.Count);
+        Assert.All(walked, r => Assert.True(Path.IsPathFullyQualified(r.CurrentFolder),
+            $"expected a full path, got \"{r.CurrentFolder}\""));
+        Assert.Contains(walked, r => r.CurrentFolder.EndsWith("Alpha", StringComparison.Ordinal));
+        Assert.Contains(walked, r => r.CurrentFolder.EndsWith("Beta", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TheFinalReport_NamesNoFolder_RatherThanAFolderCalledDone()
+    {
+        // It used to pass the literal "Done" where a folder goes, and the tab rendered that into
+        // "Scanning folder 2: Done" — a sentence saying the scan is still running, naming a folder that does
+        // not exist. Empty leaves the consumer nothing fake to display and no sentinel to recognise.
+        CreateFile(Path.Combine("Alpha", "a.bin"), 16);
+        var progress = new SyncProgress<DiskAnalyzerService.AnalysisProgress>();
+
+        await _service.AnalyzeAsync(_root, progress);
+
+        var last = Assert.Single(progress.Reports.TakeLast(1));
+        Assert.Equal("", last.CurrentFolder);
+        Assert.Equal(1, last.FoldersScanned);   // the settled count is the point of the report
+        Assert.DoesNotContain(progress.Reports, r => r.CurrentFolder == "Done");
     }
 }

--- a/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
+++ b/SysManager/SysManager.Tests/DiskAnalyzerViewModelTests.cs
@@ -312,4 +312,110 @@ public class DiskAnalyzerViewModelTests
         Assert.Contains("About the same",
             DiskAnalyzerViewModel.DescribeTrend(prior, 5_000_000_000), StringComparison.Ordinal);
     }
+
+    // ── The announced half vs the shown half (#2274) ──
+    // The status line is a live region, and the scan reported into it once per top-level subfolder with no
+    // rate limit at all. A folder with hundreds of small children announced hundreds of sentences in a few
+    // seconds, so the tab said LESS the more there was to say. The per-folder value now goes to a silent
+    // readout and the status line keeps the coarse phase, exactly as Duplicate Finder's was split in #2143.
+
+    private static DiskAnalyzerService.AnalysisProgress Tick(int scanned, string folder) =>
+        new(scanned, folder);
+
+    [Fact]
+    public void TheAnnouncedLine_IsNotTouched_WhileTheReadoutChangesEveryFolder()
+    {
+        var vm = NewVm();
+        var before = vm.StatusMessage;
+        var raised = vm.RecordPropertyChanges();
+
+        // What analysing a user profile looks like: one report per child directory, as fast as the walk
+        // reaches them.
+        for (var i = 1; i <= 40; i++)
+            vm.ApplyScanProgress(Tick(i, $@"C:\Sample\folder{i}"));
+
+        // Not "changed twice" — not at all. This callback has no coarse value to contribute: the phase
+        // boundaries are the command's own, so every announcement this tab makes is one of the three
+        // sentences it says when a scan starts or ends.
+        Assert.DoesNotContain(nameof(vm.StatusMessage), raised);
+        Assert.Equal(before, vm.StatusMessage);
+
+        // …while the eye still gets every report. Without this half the test would also pass on a callback
+        // that had simply stopped reporting anything.
+        Assert.Equal(40, raised.Count(n => n == nameof(vm.ScanReadout)));
+    }
+
+    [Fact]
+    public void TheReadout_ShowsTheCount_AndTheFolderNameRatherThanItsPath()
+    {
+        var vm = NewVm();
+        vm.ApplyScanProgress(Tick(1234, @"C:\Users\Sample\AppData\Local"));
+
+        Assert.Equal("1,234 folders measured · Local", vm.ScanReadout);
+        // The path goes to the hover instead: the count plus a deep path exceeds the row at a small window.
+        Assert.Equal(@"C:\Users\Sample\AppData\Local", vm.CurrentFolder);
+    }
+
+    [Fact]
+    public void TheSettlingReport_ClearsTheReadout_RatherThanNamingAFolderCalledDone()
+    {
+        // The service sends one last report with the settled count and no folder. It used to pass the literal
+        // "Done" there, which the tab rendered as "Scanning folder 1234: Done" — a sentence claiming the scan
+        // is still running, naming a folder that does not exist.
+        var vm = NewVm();
+        vm.ApplyScanProgress(Tick(1234, @"C:\Sample\Local"));
+        Assert.NotEmpty(vm.ScanReadout);
+
+        vm.ApplyScanProgress(Tick(1234, string.Empty));
+
+        Assert.Equal("", vm.ScanReadout);
+        Assert.Equal("", vm.CurrentFolder);
+    }
+
+    [Fact]
+    public void AFolderPathEndingInASeparator_StillShowsSomethingAfterTheCount()
+    {
+        // Path.GetFileName returns "" for a trailing separator, which would leave the readout ending in a
+        // bare separator. The service applies the same fallback when it names the entry itself.
+        var vm = NewVm();
+        vm.ApplyScanProgress(Tick(3, @"C:\Sample\"));
+
+        Assert.Equal(@"3 folders measured · C:\Sample\", vm.ScanReadout);
+    }
+
+    [Fact]
+    public void DiskAnalyzerView_AnnouncesTheStatusLine_AndShowsTheReadoutSilently()
+    {
+        // The assertions above would all pass on markup that still bound one combined line, and the
+        // live-region rule itself is enforced in ArchitectureTests. What only the shipped markup can show is
+        // which line each half landed on — so this reads the XAML, in the same shape as the equivalent test
+        // on Duplicate Finder.
+        var root = System.Xml.Linq.XDocument.Load(ViewPath("DiskAnalyzerView.xaml")).Root;
+        Assert.NotNull(root);
+
+        System.Xml.Linq.XElement BoundTo(string property) =>
+            Assert.Single(root!.Descendants(),
+                e => e.Name.LocalName == "TextBlock"
+                     && e.Attribute("Text")?.Value == $"{{Binding {property}}}");
+
+        var coarse = BoundTo("StatusMessage");
+        Assert.Equal("{StaticResource StatusLine}", coarse.Attribute("Style")?.Value);
+        Assert.Null(coarse.Attribute("ToolTip"));
+
+        var readout = BoundTo("ScanReadout");
+        Assert.Equal("{Binding CurrentFolder}", readout.Attribute("ToolTip")?.Value);
+        Assert.Equal("CharacterEllipsis", readout.Attribute("TextTrimming")?.Value);
+
+        // Caption, not StatusLine: StatusLine IS Caption plus AutomationProperties.LiveSetting, so basing the
+        // readout on it would look identical and quietly put the fast half back into the announcements.
+        var inline = Assert.Single(readout.Elements()
+            .Where(e => e.Name.LocalName == "TextBlock.Style")
+            .SelectMany(e => e.Elements().Where(s => s.Name.LocalName == "Style")));
+        Assert.Equal("{StaticResource Caption}", inline.Attribute("BasedOn")?.Value);
+
+        // This tab no longer uses the shared footer, because that control deliberately has no second slot.
+        // Asserting its absence pins the reason: a well-meaning "deduplicate this" would delete the readout.
+        Assert.DoesNotContain(root!.Descendants(), e => e.Name.LocalName == "StatusFooter");
+    }
+
 }

--- a/SysManager/SysManager/Services/DiskAnalyzerService.cs
+++ b/SysManager/SysManager/Services/DiskAnalyzerService.cs
@@ -17,6 +17,14 @@ namespace SysManager.Services;
 /// </summary>
 public sealed class DiskAnalyzerService
 {
+    /// <summary>How far the walk has got, reported once per top-level subfolder as it is reached.</summary>
+    /// <param name="FoldersScanned">Top-level subfolders started so far. Not a fraction: the total is not
+    /// known until the walk ends, which is why the tab shows an indeterminate bar rather than a
+    /// percentage.</param>
+    /// <param name="CurrentFolder">The FULL PATH of the folder being measured, empty on the settling report
+    /// that follows the walk. The consumer trims it for display and shows the path on hover, so a name alone
+    /// would leave the hover with nothing to add. Empty rather than a word like "Done" because a caller
+    /// rendering this into a sentence would otherwise name a folder that does not exist (#2273, #2274).</param>
     public sealed record AnalysisProgress(int FoldersScanned, string CurrentFolder);
 
     // Skip system subtrees that are slow or inaccessible.
@@ -100,7 +108,7 @@ public sealed class DiskAnalyzerService
             catch (IOException) { continue; }
 
             scanned++;
-            progress?.Report(new AnalysisProgress(scanned, Path.GetFileName(dir)));
+            progress?.Report(new AnalysisProgress(scanned, dir));
 
             var (size, files, folders, denied) = MeasureFolder(dir, ct);
             var name = Path.GetFileName(dir);
@@ -145,7 +153,11 @@ public sealed class DiskAnalyzerService
                 r.Percentage = Math.Round(r.SizeBytes * 100.0 / total, 1);
         }
 
-        progress?.Report(new AnalysisProgress(scanned, "Done"));
+        // The settling report: the final count, with no folder. It carried the literal "Done", which the tab
+        // rendered as "Scanning folder 1234: Done" — a sentence saying the scan is still running and naming a
+        // folder that does not exist. Empty gives the consumer nothing fake to display and needs no sentinel
+        // to recognise, the same fix as LargeFileScanner (#2273).
+        progress?.Report(new AnalysisProgress(scanned, string.Empty));
         return results;
     }
 

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.99.3</Version>
-    <FileVersion>1.99.3.0</FileVersion>
-    <AssemblyVersion>1.99.3.0</AssemblyVersion>
+    <Version>1.99.4</Version>
+    <FileVersion>1.99.4.0</FileVersion>
+    <AssemblyVersion>1.99.4.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
+++ b/SysManager/SysManager/ViewModels/DiskAnalyzerViewModel.cs
@@ -36,6 +36,30 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
     [ObservableProperty] private string _selectedPath = "";
     [ObservableProperty] private string _scanSummary = "Select a drive or folder and click Analyze.";
 
+    /// <summary>
+    /// The per-folder line shown beside the status line while a scan runs — and NOT announced.
+    /// </summary>
+    /// <remarks>
+    /// The scan reports once per top-level subfolder with no rate limit, and that value used to go straight
+    /// into <c>StatusMessage</c>, which the footer renders as a live region. Analysing a folder with hundreds
+    /// of small children announced hundreds of sentences in a few seconds and a screen reader finished none
+    /// of them, so the tab said less the more there was to say (#2274).
+    /// <para>Split exactly as Duplicate Finder's was in #2143: the status line keeps the coarse "Analyzing…"
+    /// that the command sets at the phase boundaries, and the fast half lives here. Named
+    /// <c>ScanReadout</c> to match that tab deliberately — same role, same name, one entry covering both in
+    /// the guard that asserts these stay silent.</para>
+    /// </remarks>
+    [ObservableProperty] private string _scanReadout = "";
+
+    /// <summary>
+    /// The full path of the folder being measured, for the readout's hover. Also silent.
+    /// </summary>
+    /// <remarks>
+    /// The readout trims to a name because the counts plus a deep path exceed the row at a small window
+    /// size, so the path needs somewhere to go. Mirrors <c>CurrentFile</c> on Duplicate Finder.
+    /// </remarks>
+    [ObservableProperty] private string _currentFolder = "";
+
     // The delta line: "3.2 GB larger than your last scan on 12 Jul", or empty when this root has no
     // remembered scan yet. Explicitly "since last scan", never framed as continuous monitoring — the
     // sampling is user-triggered and irregular. Empty string keeps the row collapsed (see the view).
@@ -159,10 +183,10 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
 
         try
         {
-            var progress = new Progress<DiskAnalyzerService.AnalysisProgress>(p =>
-            {
-                StatusMessage = $"Scanning folder {p.FoldersScanned}: {p.CurrentFolder}";
-            });
+            // Writes the SILENT half only. StatusMessage is set at the phase boundaries — "Analyzing…" above,
+            // and the outcome below — so the announced line changes twice per scan instead of once per
+            // folder. See ScanReadout for what over-announcing did here.
+            var progress = new Progress<DiskAnalyzerService.AnalysisProgress>(ApplyScanProgress);
 
             var results = await _service.AnalyzeAsync(SelectedPath, progress, ct);
 
@@ -198,7 +222,42 @@ public sealed partial class DiskAnalyzerViewModel : ViewModelBase
         {
             IsBusy = false;
             IsProgressIndeterminate = false;
+            // Both belong to the run that just ended, however it ended. Leaving them would strand the last
+            // folder's name under a finished scan.
+            ScanReadout = "";
+            CurrentFolder = "";
         }
+    }
+
+    /// <summary>
+    /// Applies one progress report to the two silent readouts. Deliberately does not touch
+    /// <see cref="ViewModelBase.StatusMessage"/> — see <see cref="ScanReadout"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named method rather than a lambda so the split is testable without driving a real scan, matching
+    /// <c>DuplicateFileViewModel.ApplyScanProgress</c>.
+    /// </remarks>
+    internal void ApplyScanProgress(DiskAnalyzerService.AnalysisProgress p)
+    {
+        // The settling report carries no folder: it exists to deliver the final count, and rendering it
+        // would put a bare separator under a scan that has finished.
+        if (string.IsNullOrEmpty(p.CurrentFolder))
+        {
+            ScanReadout = "";
+            CurrentFolder = "";
+            return;
+        }
+
+        CurrentFolder = p.CurrentFolder;
+
+        // Falls back to the whole path when the leaf is empty, which is what the service does when it builds
+        // the entry's own Name — a path ending in a separator would otherwise show the count and a separator
+        // with nothing after it.
+        var leaf = Path.GetFileName(p.CurrentFolder);
+        if (string.IsNullOrEmpty(leaf)) leaf = p.CurrentFolder;
+
+        ScanReadout = string.Create(CultureInfo.InvariantCulture,
+            $"{p.FoldersScanned:N0} folders measured · {leaf}");
     }
 
     /// <summary>

--- a/SysManager/SysManager/Views/DiskAnalyzerView.xaml
+++ b/SysManager/SysManager/Views/DiskAnalyzerView.xaml
@@ -189,6 +189,38 @@
         </Border>
 
         <!-- Status bar -->
-        <v:StatusFooter Grid.Row="4" Margin="0,8,0,0" ProgressName="Scan progress"/>
+        <!-- Not <v:StatusFooter/>: this tab needs a second line, which the shared control deliberately has
+             no slot for. Same two-line shape as Duplicate Finder, the sibling tab in this group. -->
+        <DockPanel Grid.Row="4" Margin="0,8,0,0">
+            <ProgressBar AutomationProperties.Name="Scan progress" DockPanel.Dock="Left" Width="120" Height="4" Margin="0,0,12,0"
+                         IsIndeterminate="{Binding IsProgressIndeterminate}"
+                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+            <!-- Two lines that look identical on purpose: StatusLine IS Caption plus
+                 AutomationProperties.LiveSetting, so the row reads exactly as before while only its coarse
+                 half is spoken. This line carried the folder count and the folder name and changed once per
+                 subfolder, which announced a new sentence before the last one finished (#2274). -->
+            <TextBlock DockPanel.Dock="Left" Text="{Binding StatusMessage}"
+                       Style="{StaticResource StatusLine}" Margin="0,0,8,0"/>
+            <!-- Trimmed rather than allowed to stretch the row: the count plus a deep folder name can exceed
+                 the width at a small window size. The tooltip carries the full path, which nothing else
+                 shows. -->
+            <TextBlock Text="{Binding ScanReadout}"
+                       TextTrimming="CharacterEllipsis"
+                       ToolTip="{Binding CurrentFolder}">
+                <TextBlock.Style>
+                    <!-- BasedOn Caption, NOT StatusLine: same appearance, no live region. Declared inline
+                         rather than as a style reference because it adds a tooltip trigger. -->
+                    <Style TargetType="TextBlock" BasedOn="{StaticResource Caption}">
+                        <!-- No tooltip outside a scan: an empty one renders as a stray blank box. -->
+                        <Setter Property="ToolTipService.IsEnabled" Value="False"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsBusy}" Value="True">
+                                <Setter Property="ToolTipService.IsEnabled" Value="True"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+        </DockPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
Closes #2274. Third tab with this defect, so it also brings the guard that would have caught all three.

## The defect

Disk Analyzer wrote the folder it was measuring straight into `StatusMessage`, which `StatusFooter` renders through `StatusLine` — a live region, so every change is spoken:

```csharp
// DiskAnalyzerViewModel.cs, before
var progress = new Progress<DiskAnalyzerService.AnalysisProgress>(p =>
{
    StatusMessage = $"Scanning folder {p.FoldersScanned}: {p.CurrentFolder}";
});
```

No rate limit anywhere. The service reports once per top-level child directory as the walk reaches it, so analysing a folder with hundreds of small children started hundreds of sentences in a few seconds and finished none of them. **The tab said less the more there was to say.**

And the settling report passed the literal `"Done"` where a folder goes, so the last thing announced was:

> Scanning folder 1234: Done

A sentence claiming the scan is still running, naming a folder that does not exist.

## The fix

Split exactly as Duplicate Finder's was in #2143, which is now the established shape:

- `StatusMessage` keeps the coarse `"Analyzing…"` the command already set, and its outcome sentence. **The callback writes nothing announced** — not "changes twice" but not at all, because the phase boundaries belong to the command, not to the walk.
- The count and folder name move to a silent `ScanReadout`, trimmed, with the full path on hover in `CurrentFolder`. Named to match Duplicate Finder on purpose: same role, same name, one entry covering both in the guard that holds them silent.
- The service reports the **full path** rather than the leaf, so the hover has something the line does not already show, and its final report names no folder at all.

Nothing that was on screen before has been taken away — the row reads the same, because `StatusLine` *is* `Caption` plus `AutomationProperties.LiveSetting`.

This tab also leaves `<v:StatusFooter/>`, because it now needs a second line and that control deliberately has no slot for extra content (#1630). The floor on its call sites moves 21 → 20 with the reason written down: a drop is either a broken element match or a conversion away, and the comment now says how to tell them apart.

## A test had enshrined the placeholder

This is the other reason two sweeps of the live-region rules missed it:

```csharp
// DiskAnalyzerServiceTests.Analyze_ReportsProgress, before
Assert.Contains(progress.Reports, r => r.CurrentFolder == "Done");
```

`"Done"` was not merely unnoticed — it was the *expected* value. That assertion is now the correct one, and the specific contract lives in two new tests beside it.

## Why the existing guard could not see it, and the new one

`EveryStatusLine_IsALiveRegion_AndTheFastReadoutsAreNot` asserts that every status line IS announced and that every *named* fast readout is not. Disk Analyzer satisfied both: its status line was announced as required, and it had no separate fast readout to list — **because the fast value went directly into the announced line.** That rule watches for a fast value *beside* the status line and never for the status line itself being fast. That gap is why this survived #1545 and #2143.

`NoProgressCallback_WritesAnAnnouncedLine` checks the **writer** instead: no progress callback may assign a property any view renders in a live region. It reads every announced binding in the app (6 properties: `StatusMessage` via 20 footer call sites plus two inline `StatusLine` TextBlocks, and five carrying `LiveSetting` directly) against every progress callback (12 across 9 view models) — **including method references**, since the two tabs that get this right pass a method rather than a lambda, and a call-site-only reader would report both as clean without looking at what they write.

Three exemptions, all reasoned rather than convenient:

| exempt | why |
|---|---|
| `DeepCleanupViewModel.ScanStatusLine` | bounded by the report's `Total` — one announcement per category, ~12 per scan, which is what a live region is *for* |
| `DeepCleanupViewModel.CleanStatusLine` | same, for the clean pass |
| `DuplicateFileViewModel.StatusMessage` | writes only the coarse phase label; its fast half is `ScanReadout` (#2143) |

Its vacuity floor names the six announced properties as a set rather than counting them — strictly stronger, and a *new* live region needs no entry because it is checked automatically.

## Proof

**The guard**, six states, each reverted after measuring, baseline green before and after:

| mutation | guard |
|---|---|
| `ApplyScanProgress` writes `StatusMessage` | **RED**, naming `DiskAnalyzerViewModel.StatusMessage` — method-reference bodies are read |
| back to the old inline lambda | **RED**, same — lambda bodies are read |
| Deep Cleanup's exemption dropped | **RED**, naming `DeepCleanupViewModel.ScanStatusLine` — the list is really consulted |
| the `Progress<>` shape broken | **RED** on the floor: *"only 0 progress callbacks were found"* |
| the `IsAnnounced` branch disabled | **RED** on the announced-set floor |
| both paths to `StatusMessage` broken | **RED**, ditto for `StatusMessage` itself |

The fifth and sixth are split deliberately. `StatusMessage` has two independent paths into the set, so breaking one leaves the set unchanged and nothing *should* fire — the set is what the offender check consumes, not how many views contribute to it. My first attempt at that mutation expected a red, got green, and the guard was right.

**The behaviour**, three states, each failing a *specific* named test rather than reddening the class:

| mutation | fails |
|---|---|
| the callback writes `StatusMessage` again | `TheAnnouncedLine_IsNotTouched_WhileTheReadoutChangesEveryFolder` |
| the service reports the leaf name again | `EveryProgressReport_CarriesTheFullPath_SoTheTabCanShowItOnHover` |
| the service's last report says `"Done"` again | `TheFinalReport_NamesNoFolder_RatherThanAFolderCalledDone`, and the full-path test too — `"Done"` is not a qualified path, so that test independently rejects a placeholder |

And removing the `finally` clear reds `EveryTransientReadout_IsClearedWhenItsOperationEnds`, so the clear is pinned rather than incidentally satisfied.

## Verification

**5574** unit tests pass, 0 failed, exit 0 (5566 + 8 new). All 144 architecture guards green. Four projects build with **0 errors, 0 warnings**. `dotnet format --verify-no-changes` clean on all four. Leak scan: 43 terms over 631 diff lines, 0 hits. Re-ran the full suite and the format gate again after merging main in, since a merge is a change.

## Not verified here

That the two-line row looks right at a small window size, and that a screen reader now hears "Analyzing…" once instead of a stream — both need a desktop session, so they are laptop checks. What is verified is the wiring: the tests read the shipped XAML to confirm the coarse line carries `StatusLine`, the readout is `BasedOn` `Caption`, the hover binds `CurrentFolder`, and the shared footer is gone.
