### PR TITLE
ci: a red unit-test check now says whether a test failed or the host did

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,7 @@ jobs:
       # longer pass as a green run of nothing. 5000 against a real count of ~5160 leaves room to delete
       # a class without editing CI, while still catching any collapse.
       - name: Run unit tests
+        id: unit-tests
         run: >
           dotnet test --project SysManager/SysManager.Tests/SysManager.Tests.csproj
           -c Release --no-build
@@ -344,6 +345,38 @@ jobs:
           --report-xunit-junit --report-xunit-junit-filename unit-results.junit.xml
           --coverage --coverage-output-format cobertura
           --coverage-output unit-coverage.cobertura.xml
+
+      # WHICH kind of failure, not just that there was one — the same step the UI and integration jobs
+      # already carry, finally applied to the job that actually gates a merge.
+      #
+      # A run went red with `total: 5566, failed: 0, error: 1`: every test passed, then the host waited
+      # ten seconds for foreground threads to exit, gave up, and force-exited with code 7. The step
+      # reported `exit code 1` and named no test, so roughly half an hour went into bisecting a diff that
+      # could not have caused it — the same commit passed on re-run. Exit 7 means the test host exited
+      # non-gracefully; that is not a broken test and should not read like one (#2283).
+      #
+      # This covers a non-zero EXIT. The kill case is a different shape and is covered by "Name the hung
+      # test if the run was killed" below, which keys on `cancelled()`: a timeout kill matches neither
+      # `outcome == 'failure'` nor `!cancelled()`, so one step cannot do both.
+      - name: Name the kind of unit-test failure
+        if: ${{ steps.unit-tests.outcome == 'failure' && !cancelled() }}
+        shell: bash
+        run: |
+          report=TestResults/unit-results.trx
+          if [ ! -s "$report" ]; then
+            echo "::warning::The unit run failed and wrote no TRX, so not even the test count is known. Review the unit-test-results artifact."
+            exit 0
+          fi
+          # `grep -o … | wc -l`, never `grep -c`: the TRX puts every <UnitTestResult> on one line, so a
+          # line count returns 1 for the whole suite. Scoped inside `<UnitTestResult` because
+          # <ResultSummary> carries an `outcome` of its own and would be counted as a case.
+          cases=$({ grep -o "<UnitTestResult " "$report" || true; } | wc -l | tr -d ' ')
+          passed=$({ grep -o '<UnitTestResult [^>]*outcome="Passed"' "$report" || true; } | wc -l | tr -d ' ')
+          if [ "$passed" -lt "$cases" ]; then
+            echo "::warning::$((cases - passed)) of $cases unit tests did not pass. This job is blocking, so the failure names itself in the log above — look there for the test names."
+          else
+            echo "::warning::All $cases unit tests PASSED and the run still exited non-zero, so this is an infrastructure or teardown failure rather than a test failure. Do not go looking for a broken test. Exit code 7 means the test host exited non-gracefully (see https://aka.ms/testingplatform/exitcodes); a re-run of the same commit usually passes."
+          fi
 
       # Skip Codecov on fork PRs: forked pull requests have no access to repository
       # secrets, so CODECOV_TOKEN is empty there and the upload would fail noisily for

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -3701,6 +3701,61 @@ public partial class ArchitectureTests
     }
 
     /// <summary>
+    /// Every job that runs tests must say WHICH kind of failure a red result was.
+    /// </summary>
+    /// <remarks>
+    /// A test host can exit non-zero having failed no test. It happened on the blocking unit job:
+    /// <c>total: 5566, failed: 0, error: 1</c> — every test passed, then the host waited ten seconds for
+    /// foreground threads to exit, gave up and force-exited with code 7. The step reported "exit code 1"
+    /// and named nothing, so about half an hour went into bisecting a diff that could not have caused it.
+    /// The same commit passed on re-run.
+    /// <para>The UI and integration jobs had carried exactly this diagnosis for months. The blocking job —
+    /// the only one that actually gates a merge — did not, and nothing noticed, because a step's ABSENCE
+    /// is invisible to every other check. That asymmetry is what this pins (#2283).</para>
+    /// <para>Keyed on the distinguishing SENTENCE rather than on a step name, because the value is the
+    /// message a reader gets: one branch has to name the count that failed, and the other has to say the
+    /// tests passed and the failure is not a test. A step that prints one generic line for both is the
+    /// thing that sent the reader hunting a phantom test, so a guard keyed on "there is a step here"
+    /// would pass on the version that caused the problem.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryTestJob_SaysWhichKindOfFailureItHad()
+    {
+        var ci = File.ReadAllText(Path.Combine(FindRepoRoot(), ".github", "workflows", "ci.yml"));
+
+        // The three suites, by the report each writes — a rename of a job or step cannot hide one.
+        string[] suites = ["unit-results.trx", "ui-results.trx", "integration-results.trx"];
+        var missing = new List<string>();
+
+        foreach (var suite in suites)
+        {
+            // The step reads that suite's report, so its script is where the two branches must be.
+            var at = ci.IndexOf($"report=TestResults/{suite}", StringComparison.Ordinal);
+            if (at < 0)
+            {
+                missing.Add($"{suite} — no step reads this suite's report, so a red run of it names no cause");
+                continue;
+            }
+
+            // Bounded to the step: the next `- name:` at step indentation. Without that the search would
+            // run into the following steps and find another suite's wording.
+            var end = ci.IndexOf("      - name:", at, StringComparison.Ordinal);
+            var script = end < 0 ? ci[at..] : ci[at..end];
+
+            if (!script.Contains("did not pass", StringComparison.Ordinal))
+                missing.Add($"{suite} — its diagnosis never names how many tests failed");
+            if (!script.Contains("PASSED and the run still exited non-zero", StringComparison.Ordinal))
+                missing.Add($"{suite} — its diagnosis cannot say the tests passed and the failure is not a "
+                            + "test, which is the case that costs the most time to read");
+        }
+
+        Assert.True(missing.Count == 0,
+            "a red check on these suites does not distinguish a broken test from a host that exited "
+            + "non-zero having failed nothing. The second reads exactly like the first and sends whoever "
+            + "sees it looking for a test that does not exist:\n  " + string.Join("\n  ", missing));
+    }
+
+    /// <summary>
     /// Every private-reporting route must point at a channel that exists. SECURITY.md and
     /// CODE_OF_CONDUCT.md both told reporters to email "the address on the GitHub profile" — that profile
     /// publishes no email, so the one page a security reporter reads named a dead end. A vulnerability


### PR DESCRIPTION
Closes #2283. The step already exists on two jobs; this puts it on the third — the one that gates a merge — and adds the guard that makes the gap impossible to reintroduce.

## What happened

A run went red with **every test passing**:

```
Test run summary: Failed!
  error: 1
  total: 5566
  failed: 0
Exit code: 7
  Standard output: Waiting 10 seconds for foreground threads to exit...
  Error output: [FATAL ERROR] Foreground threads were left running, forcing process exit
```

`failed: 0`. The step reported `exit code 1` and named nothing, so roughly half an hour went into bisecting a diff that could not have caused it — the only change to the unit project was a source-reading guard, which starts no threads. Re-running the identical commit passed.

Exit code 7 means the test host exited non-gracefully. That is not a broken test and should not read like one.

## The fix is a step this repo already had

The UI and integration jobs have carried this diagnosis for months, down to the sentence:

> All N tests PASSED and the run still exited non-zero, so this is an infrastructure or teardown failure rather than a test failure. Do not go looking for a broken test.

The **blocking** unit job did not have it, and nothing noticed — because a step's *absence* is invisible to every other check. So this is the existing step applied to the third suite, in the same shape and with the same wording, not a new mechanism.

`EveryTestJob_SaysWhichKindOfFailureItHad` closes the asymmetry: it reads `ci.yml`, finds the step that reads each suite's TRX, and requires **both** branches — one naming how many tests failed, the other saying the tests passed and the failure is not a test.

Keyed on the distinguishing *sentence* rather than a step name, deliberately. The value is the message a reader gets; a step printing one generic line for both cases is exactly what caused the problem, so a guard checking only "there is a step here" would have passed on the version that cost the time.

## Proof

Each state reverted after measuring; baseline green before and after.

| mutation | guard |
|---|---|
| the whole new unit step removed | **RED**, naming `unit-results.trx` |
| only the count branch reworded | **RED** — so both halves are really checked |
| only the passed-but-failed branch reworded | **RED** |
| the **UI** job's step removed instead | **RED**, naming `ui-results.trx` |

The fourth matters most: a guard written while fixing one job is exactly the kind that only ever looks at that job.

The shell logic was checked separately, against TRX fixtures whose answers were known in advance — 3 cases all passed, 3 with one failed, an empty file, a missing file — because `<ResultSummary>` carries an `outcome` of its own and an unscoped match would count it as a case. It does not: **3 cases, not 4**. All five workflows still parse.

## What is deliberately not changed

**The step still fails on an exit-7 run.** A run that could not exit has not proven the suite is healthy, and passing it would hide a genuine hang. The value here is the sentence, not the colour.

**It covers a non-zero exit only.** The kill case has a different shape and is already handled by "Name the hung test if the run was killed", which keys on `cancelled()` — a timeout kill matches neither `outcome == 'failure'` nor `!cancelled()`, so one step cannot do both. The comment says so, so the next reader does not try to merge them.

## What was ruled out while diagnosing, so nobody repeats it

The strongest candidate was `StaticPathMethods_AcceptARedirect`, which invokes every parameterless static string method in `SysManager.Services` by reflection — including `SystemReportService.QueryMotherboard()`, a live `Win32_BaseBoard` WMI query. WMI loads a COM stack, so lingering RPC threads looked like the answer.

Measured rather than reasoned about, with a standalone console app: a .NET process only exits once its last **foreground** thread ends, so if the query left one, returning from `Main` would hang.

```
control (no query):  threads 8 -> 8,   returned from Main, exited
WMI query:           threads 8 -> 11,  returned from Main, exited
```

Three threads added, process still exits. They are background threads. **Refuted.** Also ruled out: no `new Thread` without `IsBackground`, no `TaskCreationOptions.LongRunning`, no `Serilog.Sinks.Async`.

The remaining difference is the host. Run directly, the assembly uses the xUnit in-process runner and exits 0 with the same counts; CI runs it under Microsoft.Testing.Platform with the coverage collector and two report writers, and MTP is what performs the foreground-thread check at all. That path cannot be reproduced on this workstation, where the xUnit suite is not run under `dotnet test` — which is precisely why the message has to be in the log.

## Verification

**5567** unit tests pass, 0 failed, exit 0 (5566 + 1). Both projects build with **0 errors, 0 warnings**. `dotnet format --verify-no-changes` clean on all four. Leak scan: 43 terms over 117 diff lines, 0 hits.

`ci:` — no release.
