### PR TITLE
fix: a failed update download said nothing at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.99.5] - 2026-09-12
+
+**When an update download fails, the tab now says why.** Pressing Download and having it fail showed you
+nothing at all: the progress bar disappeared, a "Manual download" button quietly appeared beside it, and
+the sentence explaining what went wrong — a firewall blocking the connection, a server that was
+temporarily unavailable, a timeout — was written to a line that had just been hidden. The explanation now
+appears in amber under the update, and it wraps, so a long message is readable rather than cut off.
+
+### Fixed
+
+- A failed update download shows the reason it failed instead of only a new button appearing.
+- The message wraps to as many lines as it needs. The four explanations are full sentences that tell you
+  what to try next, and the old row would have shown about a third of one.
+
 ## [1.99.4] - 2026-09-12
 
 **Disk Analyzer no longer talks over itself while it measures, and no longer ends by naming a folder

--- a/SysManager/SysManager.Tests/AboutViewModelTests.cs
+++ b/SysManager/SysManager.Tests/AboutViewModelTests.cs
@@ -671,6 +671,70 @@ public sealed class AboutViewModelRollbackTests : IDisposable
         Assert.Contains("RollBackStatus", xaml);   // feedback is rendered, not dead
     }
 
+    [Fact]
+    public void AFailedDownload_HasSomewhereVisibleToSayWhy()
+    {
+        // DownloadStatus was rendered in exactly two places, one gated on IsDownloading and one on
+        // DownloadedPath, and a failure leaves BOTH false: IsDownloading is cleared in the command's
+        // finally, and DownloadedPath is never set. So all four failure messages — the ones naming a
+        // firewall, an unavailable server, a timeout — were assigned to elements that had just gone
+        // invisible, and the only signal the user got was the Manual download button appearing (#2281).
+        //
+        // Both halves are asserted, because either alone passes on the broken code: the markup needs a
+        // renderer whose gate a failure SETS, and the command has to actually set it. A substring check
+        // for "DownloadStatus" would have passed before the fix, since the binding was already there.
+        var root = System.Xml.Linq.XDocument.Load(ViewPath("AboutView.xaml")).Root;
+        Assert.NotNull(root);
+
+        var parents = root!.Descendants()
+            .SelectMany(p => p.Elements().Select(c => (Child: c, Parent: p)))
+            .ToDictionary(x => x.Child, x => x.Parent);
+
+        // Every gate above each element that renders DownloadStatus.
+        var gateChains = root.Descendants()
+            .Where(e => (string?)e.Attribute("Text") == "{Binding DownloadStatus}")
+            .Select(e =>
+            {
+                var gates = new List<string>();
+                for (var n = e; n is not null; n = parents.GetValueOrDefault(n))
+                    if ((string?)n.Attribute("Visibility") is { } v)
+                        gates.Add(v);
+                return gates;
+            })
+            .ToList();
+
+        Assert.True(gateChains.Count >= 3,
+            $"only {gateChains.Count} elements render DownloadStatus — expected the in-progress line, the "
+            + "success row and the failure row, so this test is no longer looking at what it thinks.");
+
+        Assert.Contains(gateChains, chain =>
+            chain.Any(g => g.Contains("AutoDownloadFailed", StringComparison.Ordinal)));
+
+        // …and the flag that gate depends on is set by every failure path, or the row above can never
+        // appear. Read from the source because the command needs a release and a network to run.
+        var command = MethodBody(File.ReadAllText(ViewModelPath("AboutViewModel.cs")),
+                                 "private async Task DownloadAsync()");
+        var failureWrites = System.Text.RegularExpressions.Regex
+            .Matches(command, @"AutoDownloadFailed\s*=\s*true").Count;
+        Assert.Equal(4, failureWrites);   // returned-nothing, HttpRequestException, IOException, timeout
+    }
+
+    /// <summary>The body of a method, delimited by counting braces from its signature.</summary>
+    private static string MethodBody(string source, string signature)
+    {
+        var at = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(at >= 0, $"{signature} not found — the test would assert over the whole file");
+
+        var open = source.IndexOf('{', at);
+        var depth = 0;
+        for (var i = open; i < source.Length; i++)
+        {
+            if (source[i] == '{') depth++;
+            else if (source[i] == '}' && --depth == 0) return source[open..(i + 1)];
+        }
+        return source[open..];
+    }
+
     // Walks up from the test binaries to the app project — .xaml is not copied to the output.
     private static string ViewPath(string fileName)
     {
@@ -680,6 +744,19 @@ public sealed class AboutViewModelRollbackTests : IDisposable
 
         Assert.NotNull(dir);   // else the assertions above would silently test nothing
         var path = Path.Combine(dir!.FullName, "SysManager", "Views", fileName);
+        Assert.True(File.Exists(path), $"{fileName} not found at {path}");
+        return path;
+    }
+
+    /// <summary>The same walk, for a view-model source file — .cs is not copied to the output either.</summary>
+    private static string ViewModelPath(string fileName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "SysManager", "ViewModels")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);
+        var path = Path.Combine(dir!.FullName, "SysManager", "ViewModels", fileName);
         Assert.True(File.Exists(path), $"{fileName} not found at {path}");
         return path;
     }

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.99.4</Version>
-    <FileVersion>1.99.4.0</FileVersion>
-    <AssemblyVersion>1.99.4.0</AssemblyVersion>
+    <Version>1.99.5</Version>
+    <FileVersion>1.99.5.0</FileVersion>
+    <AssemblyVersion>1.99.5.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>

--- a/SysManager/SysManager/Views/AboutView.xaml
+++ b/SysManager/SysManager/Views/AboutView.xaml
@@ -198,6 +198,32 @@
                                 <Hyperlink Command="{Binding OpenDownloadFolderCommand}" Foreground="{DynamicResource Accent}">Show file</Hyperlink>
                             </TextBlock>
                         </StackPanel>
+
+                        <!-- Download FAILED. The mirror of the row above, and the reason it has to exist:
+                             DownloadStatus was rendered in exactly two places, one gated on IsDownloading
+                             and one on DownloadedPath, and a failure leaves both false — IsDownloading is
+                             cleared in the command's finally, and DownloadedPath is never set. So all four
+                             failure messages were written to elements that had just gone invisible. The user
+                             pressed Download, watched the bar, and everything vanished; the only signal left
+                             was the Manual download button silently appearing (#2281).
+
+                             Warning rather than Danger, and the same brush for the dot and the text as the
+                             success row uses: an automatic download that failed with a working manual
+                             fallback is a setback, not a loss, and Danger is this app's destructive-action
+                             colour. Both clear 4.5:1 on the card (8.1:1 measured for the worse case).
+
+                             DockPanel, not the success row's horizontal StackPanel: these messages are long
+                             — "…a network issue or firewall blocking the connection. Try 'Manual download'
+                             as fallback." — and a child of a horizontal StackPanel is given infinite width,
+                             so TextWrapping would never take effect. -->
+                        <DockPanel Margin="0,14,0,0"
+                                   Visibility="{Binding AutoDownloadFailed, Converter={StaticResource FlexVis}}">
+                            <Ellipse DockPanel.Dock="Left" Width="10" Height="10" Fill="{DynamicResource Warning}"
+                                     VerticalAlignment="Top" Margin="0,5,8,0"/>
+                            <TextBlock Text="{Binding DownloadStatus}" Foreground="{DynamicResource Warning}"
+                                       FontWeight="SemiBold" TextWrapping="Wrap"
+                                       AutomationProperties.Name="Why the download failed"/>
+                        </DockPanel>
                     </StackPanel>
                 </Border>
 


### PR DESCRIPTION
Closes #2281.

## The defect

`DownloadStatus` was rendered in exactly two places, and a failure leaves **both** gates false:

| renderer | gate | after a failure |
|---|---|---|
| `AboutView.xaml:174` — the in-progress line | `IsDownloading` | false — cleared in the command's `finally` |
| `AboutView.xaml:195` — the success row | `DownloadedPath` | empty — never set on a failure path |

So all four failure messages were assigned to elements that had just gone invisible. The user pressed Download, watched the bar, and everything vanished — the only signal left was the **Manual download** button quietly appearing beside it.

The success path was fine, which is exactly why this survived: `DownloadedPath` *is* set there, so "Download complete. Click Install to restart with the new version." shows correctly. Only the four explanations were affected, and they are the most useful strings in the command — they name a firewall, a temporarily unavailable server, a timeout, and what to try next.

## The fix

The mirror of the success row, gated on `AutoDownloadFailed`, which every failure path already sets. **No view-model change** — the flag and the wording both already existed; nothing rendered under the flag.

Three deliberate differences from the row it mirrors:

- **`Warning`, not `Danger`.** An automatic download that failed with a working manual fallback is a setback, not a loss, and `Danger` is this app's destructive-action colour. Measured rather than assumed before choosing: `Warning` is **8.12:1** against the card at worst, so the contrast rule does not force the lighter `WarningText` variant, and symmetry with the success row (same brush for dot and text) wins.
- **`DockPanel`, not the success row's horizontal `StackPanel`.** These are full sentences, and a child of a horizontal `StackPanel` is given infinite width, so `TextWrapping` would never take effect. `WindowsUpdateView` had already reached the same conclusion for the same reason — its comment says so, which is a good sign the shape is right rather than invented here.
- **No "Show file" link**, because there is no file.

## Proof

Each state reverted after measuring; baseline green before and after.

| mutation | test |
|---|---|
| the row's gate swapped for `DownloadedPath` | **RED** on the markup half |
| the timeout catch stops setting the flag | **RED** on the source half |

The first is the one that matters: a row that *exists* but is gated on the flag the `finally` clears is the defect wearing the fix's shape, and a test asserting only "there are three renderers" would pass on it.

The test asserts **both** halves because either alone passes on the broken code — the markup needs a renderer whose gate a failure *sets*, and the command has to actually set it. A substring check for `"DownloadStatus"` would have passed before this change, since the binding was already there. That is what the existing rollback test in the same file does, and it is why this one parses the XML and walks the ancestor gate chain instead.

## No general guard, deliberately — with the numbers

The obvious follow-up is a guard for the class: *a message assigned in a `catch` must be rendered somewhere whose visibility can be true after that catch runs.* I measured it before writing it, and it is not ready.

I swept every `catch` block in `ViewModels/`. **132** write something their own view renders. A strict "every renderer is gated on something this catch does not set" rule flags **12**. Eleven are false positives, each refuted by reading the code:

- `AboutViewModel.UpdateStatus` and `WindowsUpdateViewModel.ModuleStatus` are rendered **twice** — once under the flag and once under the same flag with `ConverterParameter=Inverse` — so one of the two is always visible. My heuristic did not model `Inverse`.
- `DashboardViewModel.QuickActionStatus` is gated on `IsQuickActionRunning`, which that `finally` does **not** clear. The panel is still up when the catch runs.
- `CleanupViewModel`'s Sfc/Dism/Store statuses do go invisible — but the same catch also writes the tab's **ungated** `StatusMessage` and a self-gated verdict line, so the error reaches the user twice over. That one was the first I checked by hand, and it is why the rule is per *catch block* rather than per property.

One true positive out of twelve. A guard on that heuristic would be noise; making it correct needs it to model `Inverse` converters and to distinguish a context gate the method never touches from one its `finally` falsifies. Recorded on the issue as the follow-up rather than shipped half-right.

## Verification

**5576** unit tests pass, 0 failed, exit 0. Four projects build with **0 errors, 0 warnings**. `dotnet format --verify-no-changes` clean on all four. Leak scan: 43 terms over 172 diff lines, 0 hits. Re-ran the suite after merging main in.

## Not verified here

That the amber row looks right and wraps as intended at a small window size — a desktop check, so it is deferred to the laptop. What is verified is the wiring and the contrast maths.
