### PR TITLE
fix: Cancel was accepted, reported, and ignored if it arrived while the runspace was opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ That paragraph is not decoration: the release workflow copies each entry verbati
 the GitHub release body and the announcement discussion, so it is the first thing a
 prospective user reads. CI fails a pull request whose newest entry is missing it.
 
+## [1.99.6] - 2026-09-12
+
+**Pressing Cancel just as a background check starts now actually stops it.** There was a narrow window —
+the moment while the app was opening the PowerShell session it needs — where Cancel was accepted, reported
+back as cancelled, and yet the work carried on to the end anyway. Anything cancelled in that instant ran to
+completion in the background while the tab already said it had stopped. Cancel is now delivered even when
+it arrives in that window.
+
+### Fixed
+
+- Cancelling during the moment a PowerShell session is being opened now stops the script, instead of
+  reporting a cancellation while the script kept running to its natural end.
+
 ## [1.99.5] - 2026-09-12
 
 **When an update download fails, the tab now says why.** Pressing Download and having it fail showed you

--- a/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
+++ b/SysManager/SysManager.IntegrationTests/PowerShellRunnerTests.cs
@@ -583,17 +583,33 @@ public class PowerShellRunnerTests
             + $"exception {ex?.GetType().Name ?? "NONE"} ({ex?.Message ?? "-"}); {lines.Count} line(s) captured"
             + (errors.Count > 0 ? $", errors: {string.Join(" | ", errors.Take(2))}" : "");
 
-        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
-            "Cancellation took too long. " + diagnosis
-            + " — the exception MESSAGE is the discriminator, because both cancellation paths raise "
-            + "OperationCanceledException: \"stopped by cancellation\" means ps.Stop() interrupted the "
-            + "pipeline and only the bound failed, while \"completed on its own\" means Stop never "
-            + "interrupted anything and the script ran to its natural end. NONE means the run predates the "
-            + "post-await check entirely.");
-
         // Stopping without reporting it is its own defect: every caller's cancel branch is written around
         // OperationCanceledException, so a silent return would show a cancelled operation as a completed one.
+        // Asserted FIRST, because the two below describe what KIND of cancellation it was and neither means
+        // anything if there was none.
         Assert.True(ex is OperationCanceledException, "Cancellation did not surface as OperationCanceledException. " + diagnosis);
+
+        // The message, not the clock, and this is the assertion that actually names the defect.
+        //
+        // BlockingScript is a LOOP of 50 ms sleeps, and ps.Stop() interrupts a pipeline between statements —
+        // the blocking-call test below measured this exact shape cancelling in 2.2 s. So "completed on its
+        // own" here does NOT mean "PowerShell cannot interrupt a blocking call", which is the legitimate
+        // outcome that test pins. It means the stop was LOST: the registration fired while the instance was
+        // still NotStarted, Stop() threw InvalidOperationException, it was swallowed, and BeginInvoke then
+        // ran the script in full (#2286). The runner now re-asserts Stop after BeginInvoke to close that.
+        //
+        // This replaces a bare `elapsed < 5s`, which was the same defect measured through a proxy: it could
+        // only see a lost stop when the loss also happened to be slow, and when it fired it reported "took
+        // too long", which reads as a loaded runner. Two of the three explanations its own message offered
+        // were about timing, and the true one was not.
+        Assert.Contains("stopped by cancellation", ex!.Message, StringComparison.Ordinal);
+
+        // The bound is KEPT, below the script's own 20 seconds so a lost stop cannot pass it, and well above
+        // the ~350 ms a working stop takes. It is now a backstop rather than the discriminator: if it ever
+        // fires while the message above passes, the stop worked and the runner got slow, which is a
+        // different finding and the message says which.
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
+            "Cancellation was reported as a real stop but took too long. " + diagnosis);
     }
 
     /// <summary>
@@ -679,9 +695,14 @@ public class PowerShellRunnerTests
     /// "exception NONE". A test whose coverage depends on execution order is not a regression test.</para>
     /// <para><b>How this one is deterministic.</b> The <c>openRunspace</c> seam blocks until the test has
     /// cancelled, so the token is guaranteed to be already cancelled when <c>Register</c> runs — which
-    /// invokes the callback synchronously, putting <c>ps.Stop()</c> on a <c>NotStarted</c> instance.
-    /// <c>BeginInvoke</c>/<c>EndInvoke</c> then complete without throwing and without running the script.
-    /// No timing, no sleeping, and the same sequence on every machine.</para>
+    /// invokes the callback synchronously, putting <c>ps.Stop()</c> on a <c>NotStarted</c> instance, where it
+    /// throws <c>InvalidOperationException</c> and is swallowed. No timing, no sleeping, and the same
+    /// sequence on every machine.</para>
+    /// <para><b>Corrected:</b> this said <c>BeginInvoke</c>/<c>EndInvoke</c> then complete "without running
+    /// the script". They do not — the script RUNS, and against <c>1 + 1</c> that is simply invisible. The
+    /// test below runs the same seam with a script that blocks for 20 seconds and measured exactly that: the
+    /// full 20 seconds before the fix in #2286, about a second after it. The claim was untestable here and
+    /// wrong there.</para>
     /// <para>The MESSAGE is asserted, not just the exception type. Both cancellation paths raise
     /// <c>OperationCanceledException</c>, so accepting either would let this pass on the wrong one — and the
     /// wrong one is the path that already worked.</para>
@@ -717,7 +738,88 @@ public class PowerShellRunnerTests
             + "With no exception the caller receives an empty result set and no indication that anything was "
             + "cancelled — for a query that is indistinguishable from a real answer of \"nothing found\".");
 
-        Assert.Contains("completed on its own", ex!.Message, StringComparison.Ordinal);
+        // EITHER discriminator is correct here now, and that is a change from what this asserted.
+        //
+        // It pinned "completed on its own", which was the honest description of a hole: the registration
+        // fired while the instance was NotStarted, Stop() threw InvalidOperationException, it was swallowed,
+        // and BeginInvoke went on to run the script with nothing having asked it to stop. The runner now
+        // re-asserts Stop after BeginInvoke and closes that window (#2286), so this scenario reaches the
+        // pipeline properly.
+        //
+        // Which message comes back is then genuinely racy — and only because THIS script is `1 + 1`. Against
+        // a trivial script the stop and the script's own completion are in a real race, and both outcomes
+        // are correct: cancellation is reported either way, which is the contract asserted above and the
+        // reason this test exists. Pinning the winner of that race is precisely what made
+        // RunAsync_SupportsCancellation flaky, so it is not repeated here.
+        //
+        // The deterministic pin lives there instead, where the script BLOCKS for 20 seconds: a lost stop
+        // cannot hide behind a fast script, so "stopped by cancellation" is the only correct answer and is
+        // asserted exactly.
+        Assert.True(ex!.Message.Contains("stopped by cancellation", StringComparison.Ordinal)
+                    || ex.Message.Contains("completed on its own", StringComparison.Ordinal),
+            "the cancellation was reported without either discriminator in its message, so a future reader "
+            + $"cannot tell which path ran: \"{ex.Message}\"");
+    }
+
+    /// <summary>
+    /// A run cancelled while the runspace is opening must not go on to RUN the script.
+    /// </summary>
+    /// <remarks>
+    /// The test above proves the cancellation is reported. It cannot prove the script did not run, because
+    /// its script is <c>1 + 1</c> — indistinguishable from not running at all. This one uses the same
+    /// deterministic seam with a script that BLOCKS for 20 seconds, which separates the two outright: a lost
+    /// stop takes the full 20 seconds, a delivered one returns in about a second.
+    /// <para>That distinction is the whole of #2286. CI saw a cancel at 390 ms against a looping script and
+    /// the run finish its entire 20 seconds reporting "not interrupted … completed on its own". Since a loop
+    /// of 50 ms sleeps IS interruptible — the blocking-call test below measures that same shape cancelling in
+    /// 2.2 s — the stop was not refused, it was lost in the NotStarted window: <c>Register</c> fires
+    /// synchronously, <c>Stop()</c> throws <c>InvalidOperationException</c> on a not-yet-invoked instance, it
+    /// is swallowed, and <c>BeginInvoke</c> starts a pipeline nothing has asked to stop.</para>
+    /// <para>Deterministic for the same reason as the test above — the seam holds the open until the test has
+    /// cancelled — so this needs no sleeping to arrange the race and cannot depend on execution order. It is
+    /// the regression test the fix would otherwise not have: removing the runner's post-BeginInvoke
+    /// re-assertion takes this from about a second to the script's full 20.</para>
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_CancelledWhileTheRunspaceIsOpening_DoesNotRunTheScriptAnyway()
+    {
+        using var cancelled = new SemaphoreSlim(0);
+        using var reachedOpen = new SemaphoreSlim(0);
+
+        using var runner = new PowerShellRunner(
+            action => Task.Run(action),
+            isElevated: static () => false,
+            openRunspace: async runspace =>
+            {
+                reachedOpen.Release();
+                await cancelled.WaitAsync(TimeSpan.FromSeconds(10));
+                await Task.Run(runspace.Open);
+            });
+
+        using var cts = new CancellationTokenSource();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var run = runner.RunAsync(BlockingScript, cancellationToken: cts.Token);
+
+        Assert.True(await reachedOpen.WaitAsync(TimeSpan.FromSeconds(10)),
+            "the runspace open was never reached, so nothing below is about the opening window.");
+        await cts.CancelAsync();
+        cancelled.Release();
+
+        var ex = await BoundedAsync(Record.ExceptionAsync(() => run),
+                                    nameof(RunAsync_CancelledWhileTheRunspaceIsOpening_DoesNotRunTheScriptAnyway));
+        sw.Stop();
+
+        var diagnosis = $"elapsed {sw.Elapsed}; exception {ex?.GetType().Name ?? "NONE"} ({ex?.Message ?? "-"})";
+
+        Assert.True(ex is OperationCanceledException, "the run did not report cancellation at all. " + diagnosis);
+
+        // The assertion that matters: well under the script's own 20 seconds, so a stop that was swallowed
+        // and never re-asserted cannot pass. 5 seconds rather than 2 leaves room for a cold runspace open on
+        // a loaded runner without leaving room for the defect.
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
+            "a run cancelled during the runspace open went on to execute the script in full — the stop was "
+            + "swallowed on a NotStarted instance and never re-asserted, so the user's Cancel did nothing "
+            + "but the call still reported cancellation. " + diagnosis);
     }
 
     /// <summary>

--- a/SysManager/SysManager.Tests/PipelineStoppedDetectionTests.cs
+++ b/SysManager/SysManager.Tests/PipelineStoppedDetectionTests.cs
@@ -91,6 +91,50 @@ public class PipelineStoppedDetectionTests
             new InvalidOperationException("outer", new TimeoutException())));
     }
 
+    // ── The out-of-process transport's own way of saying "stopped" (#2286) ──
+    //
+    // Closing the lost-stop window meant the stop started landing on the elevated out-of-process transport,
+    // where EndInvoke throws PSRemotingDataStructureException("The remote pipeline has been stopped.")
+    // rather than the PipelineStoppedException an in-process runspace raises. So a cancellation that now
+    // WORKED surfaced as a raw remoting error. CI found it; this workstation's in-process runspace cannot.
+
+    [Fact]
+    public void ARemotingDataStructureFault_IsRecognisedAsOurStop()
+    {
+        Assert.True(PowerShellRunner.IsRemotingTornDownByOurStop(
+            new System.Management.Automation.Remoting.PSRemotingDataStructureException(
+                "The remote pipeline has been stopped.")));
+    }
+
+    [Fact]
+    public void ARemotingDataStructureFault_IsRecognisedWhenWrapped()
+    {
+        // FromAsync surfaces EndInvoke's exception directly, but a transport can nest it — the sibling
+        // predicate unwraps one level for the same reason and this must not be the weaker of the two.
+        Assert.True(PowerShellRunner.IsRemotingTornDownByOurStop(
+            new InvalidOperationException("outer",
+                new System.Management.Automation.Remoting.PSRemotingDataStructureException("stopped"))));
+    }
+
+    [Fact]
+    public void ARemotingFault_IsNotTreatedAsAStopByTheStrictPredicate()
+    {
+        // The two predicates stay separate on purpose. IsPipelineStopped answers "does this exception mean
+        // the pipeline was stopped", and a general remoting fault does not — folding it in would make a real
+        // transport breakdown read as a user cancellation. What makes the weaker inference safe is the call
+        // site's `cancellationToken.IsCancellationRequested`, not the type.
+        Assert.False(PowerShellRunner.IsPipelineStopped(
+            new System.Management.Automation.Remoting.PSRemotingDataStructureException(
+                "The remote pipeline has been stopped.")));
+    }
+
+    [Fact]
+    public void AnUnrelatedException_IsNotTakenForOurStop()
+    {
+        Assert.False(PowerShellRunner.IsRemotingTornDownByOurStop(new TimeoutException("timed out")));
+        Assert.False(PowerShellRunner.IsRemotingTornDownByOurStop(new PipelineStoppedException()));
+    }
+
     /// <summary>
     /// Builds a <see cref="RemoteException"/> carrying <paramref name="serialized"/>.
     /// </summary>

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -236,7 +236,8 @@ public sealed class PowerShellRunner : IPowerShellRunner, IDisposable
         {
             await task.ConfigureAwait(false);
         }
-        catch (Exception ex) when (cancellationToken.IsCancellationRequested && IsPipelineStopped(ex))
+        catch (Exception ex) when (cancellationToken.IsCancellationRequested
+                                   && (IsPipelineStopped(ex) || IsRemotingTornDownByOurStop(ex)))
         {
             // Cancellation calls ps.Stop(), which makes EndInvoke throw. Surface the standard cancellation
             // signal so callers that catch OperationCanceledException treat a cancelled PowerShell run as
@@ -746,6 +747,32 @@ public sealed class PowerShellRunner : IPowerShellRunner, IDisposable
         || ex.InnerException is PipelineStoppedException
         || (ex as RemoteException)?.SerializedRemoteException?.TypeNames
                .Any(name => name.EndsWith("PipelineStoppedException", StringComparison.Ordinal)) == true;
+
+    /// <summary>
+    /// The out-of-process transport reporting the stop WE asked for: a remoting data-structure fault raised
+    /// while cancellation is already requested.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately separate from <see cref="IsPipelineStopped"/>, which answers "does this exception mean
+    /// the pipeline was stopped" and must keep answering it honestly —
+    /// <c>PSRemotingDataStructureException</c> is a general remoting protocol fault, so folding it in there
+    /// would make a genuine transport breakdown read as a stop, and that method's negative tests exist to
+    /// prevent exactly that.
+    /// <para><b>What makes the weaker inference safe is the caller, not the type.</b> The one call site is
+    /// guarded by <c>cancellationToken.IsCancellationRequested</c>, so this is only ever consulted after we
+    /// have called <c>Stop()</c> ourselves. With no cancellation requested the exception propagates as
+    /// itself, which is what a real remoting failure must do.</para>
+    /// <para>Found by CI, and only by CI: the in-process runspace this workstation uses raises
+    /// <c>PipelineStoppedException</c>, which the method above already matches. Closing the lost-stop window
+    /// in #2286 meant the stop started landing on the elevated out-of-process transport too, where
+    /// <c>EndInvoke</c> instead threw <c>PSRemotingDataStructureException("The remote pipeline has been
+    /// stopped.")</c> — so a cancellation that now WORKED surfaced as a raw remoting error rather than as
+    /// <c>OperationCanceledException</c>. Matched by TYPE and not by that message, which is a sentence from
+    /// PowerShell and not a contract.</para>
+    /// </remarks>
+    internal static bool IsRemotingTornDownByOurStop(Exception ex) =>
+        ex is System.Management.Automation.Remoting.PSRemotingDataStructureException
+        || ex.InnerException is System.Management.Automation.Remoting.PSRemotingDataStructureException;
 
     private async Task<RunspaceLease> LeaseRunspaceAsync()
     {

--- a/SysManager/SysManager/Services/PowerShellRunner.cs
+++ b/SysManager/SysManager/Services/PowerShellRunner.cs
@@ -212,6 +212,26 @@ public sealed class PowerShellRunner : IPowerShellRunner, IDisposable
             ps.BeginInvoke<PSObject, PSObject>(null, output),
             ar => ps.EndInvoke(ar));
 
+        // The registration above can fire while this instance is still NotStarted, and Stop() then throws
+        // InvalidOperationException, which is swallowed — so nothing has asked the pipeline to stop, and
+        // BeginInvoke goes on to run the script in full. The window is real rather than theoretical: leasing
+        // and opening a runspace takes a few hundred milliseconds, which is the same order as the delay any
+        // caller puts before cancelling.
+        //
+        // Measured on CI: a cancel at 390 ms against a script that loops on 50 ms sleeps, and the run
+        // finished its whole 20 seconds reporting "not interrupted … completed on its own". A loop of that
+        // shape IS interruptible — the blocking-call test below measured the same script cancelling in
+        // 2.2 s — so the stop was not refused, it was lost.
+        //
+        // Re-asserting here closes the window, because BeginInvoke has returned by this point and the
+        // instance will accept a Stop. Idempotent either way: a second Stop on an already-stopping pipeline
+        // raises the same InvalidOperationException this swallows, and on a pipeline that is running it does
+        // exactly what the registration intended to do the first time.
+        if (cancellationToken.IsCancellationRequested)
+        {
+            try { ps.Stop(); } catch (InvalidOperationException) { }
+        }
+
         try
         {
             await task.ConfigureAwait(false);

--- a/SysManager/SysManager/SysManager.csproj
+++ b/SysManager/SysManager/SysManager.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>SysManager</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU1603;NU1701</NoWarn>
-    <Version>1.99.5</Version>
-    <FileVersion>1.99.5.0</FileVersion>
-    <AssemblyVersion>1.99.5.0</AssemblyVersion>
+    <Version>1.99.6</Version>
+    <FileVersion>1.99.6.0</FileVersion>
+    <AssemblyVersion>1.99.6.0</AssemblyVersion>
     <Product>SysManager</Product>
     <Description>SysManager — Windows system monitoring toolkit by laurentiu021. Network, updates, health, logs, safe deep cleanup.</Description>
     <PackageProjectUrl>https://github.com/laurentiu021/SystemManager</PackageProjectUrl>


### PR DESCRIPTION
Closes #2286. **I filed that issue as a flaky test and it was wrong** — the test was right and its own diagnosis message was the answer. Correcting that is most of what this change is.

## The defect

`RunAsync` registers `ps.Stop()` on the token *before* invoking:

```csharp
using var reg = cancellationToken.Register(() => { try { ps.Stop(); } catch (InvalidOperationException) { } });

var task = Task.Factory.FromAsync(ps.BeginInvoke<PSObject, PSObject>(null, output), ar => ps.EndInvoke(ar));
```

If the token fires while the instance is still `NotStarted` — which it is for the few hundred milliseconds a runspace lease and open take — `Stop()` throws `InvalidOperationException`, the catch swallows it, and `BeginInvoke` then starts a pipeline **nothing has asked to stop**.

The post-await check still reports `OperationCanceledException`, so the caller's cancel branch runs and the tab says it stopped. The script runs to the end anyway, in the background.

## Why I first read this as a test problem, and what changed my mind

CI showed a cancel at 390 ms against a script that loops on 50 ms sleeps, and the run finishing its whole 20 seconds reporting *"not interrupted … completed on its own"*. My first reading: the 5-second assertion was a wall-clock bound on a race PowerShell does not promise to win, so the test was at fault.

It is not. The blocking-call test in the same file measures **that same loop shape cancelling in 2.2 s** — `ps.Stop()` interrupts a pipeline between statements, and a loop of 50 ms sleeps has a statement boundary every 50 ms. So the stop was not *refused*, it was **lost**. The assertion was correct and the message it printed named the cause; I had read "took too long" as a symptom of a loaded runner.

That matters beyond this fix: had I shipped the issue as filed, the timing assertion would have been relaxed and the defect would have gone quiet.

## The fix

Re-assert `Stop()` after `BeginInvoke`, where the instance will accept it. Idempotent — on an already-stopping pipeline it raises the same `InvalidOperationException` this swallows, and on a running one it does what the registration meant to do the first time.

## A deterministic reproduction already existed

I built a simulation before noticing that. The `openRunspace` seam holds the open until the test has cancelled, so the token is *guaranteed* cancelled before `BeginInvoke` — precisely the window. The existing test using it runs `1 + 1`, where "the script ran anyway" is invisible.

The new test runs the same seam with `BlockingScript`, which separates them outright:

| state | result |
|---|---|
| re-assert **removed** | **RED, 20.5 s** — the script ran in full: the CI symptom exactly |
| re-assert **present** | **GREEN, 0.46 s** |
| whole class, either way | 29 tests, and only that one differs |

No sleeping to arrange the race, and no dependence on execution order — which is what the two older cancellation tests suffer from, as their own docs say.

## Two existing tests corrected, both because they had encoded the hole

- `RunAsync_CancelledWhileTheRunspaceIsOpening_ReportsCancellation` asserted the message `"completed on its own"`. That was the honest description of the defect. With the window closed, which message comes back is **genuinely racy for a trivial script** — the stop and `1 + 1` finishing are in a real race, and cancellation is correctly reported either way — so it now accepts either discriminator. Pinning the winner of a race is exactly what made the other test look flaky; the deterministic pin lives in the new test, where the script blocks.
- That test's doc claimed `BeginInvoke`/`EndInvoke` "complete without throwing **and without running the script**". They do not — the script runs. The claim was untestable against `1 + 1` and is measurably wrong against a blocking one. Corrected in place rather than deleted, since the reasoning around it is still right.

`RunAsync_SupportsCancellation` now asserts the **discriminator** rather than only the clock. For a looping script, "completed on its own" means the stop was lost — a defect, not a slow runner. The 5-second bound is **kept** as a backstop, below the script's own 20 seconds so a lost stop cannot pass it, with a message that says which of the two findings it is.

## Verification

**5576** unit tests pass, 0 failed. **29/29** `PowerShellRunnerTests`. Four projects build with **0 errors, 0 warnings**. `dotnet format --verify-no-changes` clean on all four. Leak scan: 43 terms over 370 diff lines, 0 hits. Ran after merging main in.

The integration suite as a whole is left to CI — parts of it touch the network, which is not run on this workstation.

## Scope note

The user-visible effect is narrow: it needs Cancel pressed in the window while a PowerShell session is being opened. But the failure mode is the bad kind — the app reports that it stopped and keeps working — and it is the same family as #2206, where a cancelled query returned as a successful empty result.
