### PR TITLE
docs: the README said 52 tabs announce their status when 53 do, and nothing checked

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ someone who tabbed to it, and it is not reliably handed to assistive software. I
 deliberately. An explanation on every button in the app would make it slower to navigate, not clearer.
 
 Every tab also reads out what it is doing as it works. The line at the bottom of each tab — "Scanning…",
-"Removed 1,204 files", "Scan complete." — is announced on all 52 tabs that have one, as are the SFC and DISM
+"Removed 1,204 files", "Scan complete." — is announced on all 53 tabs that have one, as are the SFC and DISM
 results when a system repair finishes and Deep Cleanup's scan and clean summaries. Announcements are polite,
 so they wait their turn rather than cutting across whatever you are reading.
 

--- a/SysManager/SysManager.Tests/ArchitectureTests.cs
+++ b/SysManager/SysManager.Tests/ArchitectureTests.cs
@@ -4472,6 +4472,99 @@ public partial class ArchitectureTests
     /// case-sensitive on purpose: "System health" is not what the sidebar says, and a reader scanning for
     /// the tab they are looking at should find its name written the same way.</para>
     /// </remarks>
+    /// <summary>
+    /// Every "N tabs" the README claims is re-derived from the source, not trusted.
+    /// </summary>
+    /// <remarks>
+    /// Gate-DOCS asks for exactly this and nothing enforced it, so a claim went stale in the one place a
+    /// reader is least able to check it: "announced on all 52 tabs that have one" while the real number was
+    /// 53. Understating by one is harmless in substance; a count claim that drifts silently is not, because
+    /// the same sentence is what tells a screen-reader user whether this app is worth trying.
+    /// <para>Two different denominators are claimed and they are NOT interchangeable: the total tab count
+    /// (58, from the sidebar) and the number of tabs carrying an announced status line (53, which is fewer
+    /// because a tab with nothing long-running has nothing to report). A guard that accepted either would
+    /// pass on the two being swapped, so each claim is classified by the phrase that follows it.</para>
+    /// <para>Screenshot filenames carry numbers too — <c>52-system-logs.png</c>, <c>55-about.png</c> — and
+    /// are not matched, because the pattern requires the word "tabs" after the number rather than a digit
+    /// anywhere. That is the difference between this and the sweep that first found the drift.</para>
+    /// </remarks>
+    [Fact]
+    public void EveryReadmeTabCount_MatchesTheSource()
+    {
+        var appDir = FindAppProjectDir();
+        var viewsDir = Path.Combine(appDir, "Views");
+
+        var tabs = SidebarTabLabels().Count;
+        Assert.True(tabs >= 50, $"only {tabs} tab labels were parsed — the count to compare against is wrong");
+
+        // Tabs with an announced status line: an inline TextBlock bound to StatusMessage, or a
+        // <v:StatusFooter/>, which renders that same line from its own file. Comments stripped, because
+        // DiskAnalyzerView explains in prose why it is NOT using the shared footer (#2274) and a text scan
+        // counts that mention as a call site.
+        var statusLines = Directory.EnumerateFiles(viewsDir, "*.xaml", SearchOption.TopDirectoryOnly)
+            .Select(f => WithoutXamlComments(File.ReadAllText(f)))
+            .Sum(markup =>
+                CountOccurrences(markup, "Text=\"{Binding StatusMessage}\"")
+                + StatusFooterElement().Matches(markup).Count);
+
+        Assert.True(statusLines >= 52,
+            $"only {statusLines} announced status lines were counted, out of 53 measured — the count to "
+            + "compare against is wrong, so the assertions below would enforce a stale number.");
+
+        var readme = File.ReadAllText(Path.Combine(FindRepoRoot(), "README.md"));
+        var wrong = new List<string>();
+        var claims = 0;
+        var statusClaims = 0;
+
+        foreach (var m in ReadmeTabCount().Matches(readme).Cast<Match>())
+        {
+            claims++;
+            var claimed = int.Parse(m.Groups["n"].Value, CultureInfo.InvariantCulture);
+
+            // "…all 53 tabs that have one…" is about the status-line subset; anything else is the total.
+            var after = readme[m.Index..Math.Min(readme.Length, m.Index + m.Length + 20)];
+            var isStatusSubset = after.Contains("that have one", StringComparison.Ordinal);
+            if (isStatusSubset) statusClaims++;
+
+            var expected = isStatusSubset ? statusLines : tabs;
+            if (claimed != expected)
+                wrong.Add($"\"{Collapse(m.Value)}\" — the source says {expected}"
+                          + (isStatusSubset ? " tabs carry an announced status line" : " tabs"));
+        }
+
+        // Both floors are enumerated: five total-count claims and one subset claim today. A pattern that
+        // stopped matching would otherwise let this pass having compared nothing.
+        Assert.True(claims >= 6,
+            $"only {claims} 'N tabs' claims were found in README.md, out of 6 measured — the pattern is out "
+            + "of date, so a pass proves nothing.");
+        Assert.True(statusClaims >= 1,
+            "the 'tabs that have one' claim was not found, so the status-line count is being compared "
+            + "against nothing and a drift in it would pass.");
+
+        Assert.True(wrong.Count == 0,
+            "these README counts no longer match the source. A number a reader cannot verify is worse than "
+            + "no number, and the accessibility claim is the one most likely to be taken on trust:\n  "
+            + string.Join("\n  ", wrong));
+    }
+
+    /// <summary>Occurrences of a literal, which <c>string.Split</c> would over-count by one.</summary>
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        for (var at = haystack.IndexOf(needle, StringComparison.Ordinal);
+             at >= 0;
+             at = haystack.IndexOf(needle, at + needle.Length, StringComparison.Ordinal))
+            count++;
+        return count;
+    }
+
+    /// <summary>
+    /// A "N tabs" claim, allowing one qualifier ("58 feature tabs"). The word is REQUIRED, so a screenshot
+    /// filename like <c>52-system-logs.png</c> cannot match.
+    /// </summary>
+    [GeneratedRegex(@"(?<n>\d+) (?:\w+ )?tabs\b", RegexOptions.Compiled)]
+    private static partial Regex ReadmeTabCount();
+
     [Fact]
     public void EveryTab_HasItsOwnReadmeSection()
     {
@@ -6284,7 +6377,7 @@ public partial class ArchitectureTests
     /// Every tab's status line is a live region, and the fast-moving readouts beside them are not.
     /// </summary>
     /// <remarks>
-    /// 52 tabs report what a long operation is doing through one <c>TextBlock</c> bound to
+    /// 53 tabs report what a long operation is doing through one <c>TextBlock</c> bound to
     /// <c>StatusMessage</c>, and none of them was announced: WCAG 4.1.3 asks that a status change which
     /// never receives focus still reach assistive software, and <c>AutomationProperties.LiveSetting</c> is
     /// the channel. Before this guard the whole project had two occurrences of it, both the same element —
@@ -6396,10 +6489,15 @@ public partial class ArchitectureTests
                            + "view using it went quiet at once while still resolving");
         }
 
-        // Vacuity floor: 52 status lines, one per tab that has one, measured. Raise it when a tab gains one;
-        // a drop means the Text attribute read stopped matching and the whole sweep found nothing.
-        Assert.True(statusLinesSeen >= 50,
-            $"only {statusLinesSeen} StatusMessage lines were found across {files.Length} views, out of 52 "
+        // Vacuity floor: 53 status lines, one per tab that has one, measured. A drop means the Text attribute
+        // read stopped matching and the whole sweep found nothing.
+        //
+        // The floor was 50 against 52 measured, and by the time anyone looked the real number was 53 — so a
+        // tab had gained a status line, the README's "all 52 tabs" claim had gone stale, and three units of
+        // slack absorbed the drift without a word. A floor exists to catch a read that BREAKS, which takes
+        // the count to nearly zero, not to one below. Slack past that only hides movement, so this keeps one.
+        Assert.True(statusLinesSeen >= 52,
+            $"only {statusLinesSeen} StatusMessage lines were found across {files.Length} views, out of 53 "
             + "measured — the element read is out of date, so a pass proves nothing.");
 
         // The negative half needs its own floor, and it is the half most likely to go quiet: an absence


### PR DESCRIPTION
Gate-DOCS asks that README count claims be re-derived from source. Nothing enforced it, and one had drifted.

## The claim

> …is announced on all **52** tabs that have one…

The real number is **53** — 33 inline `StatusMessage` lines plus 20 `<v:StatusFooter/>` elements. Understating by one is harmless in substance, but this is the sentence that tells a screen-reader user whether the app is worth trying, and it is a number they cannot check.

## The guard that should have caught it was part of the problem

`EveryStatusLine_IsALiveRegion_AndTheFastReadoutsAreNot` counts exactly this population. Its vacuity floor was **50 against 52 measured** — and by the time anyone looked, the source said 53. So a tab gained a status line, the README went stale, and three units of slack absorbed the movement without a word.

A floor exists to catch a read that **breaks**, which takes the count to nearly zero, not to one below. Slack past that only hides drift. The floor is now 52 against 53 and keeps one.

That is the same shape as the other floor I found slack in today — 7 against a real 15, in the copy-drift guard (#2282) — worth saying out loud, because "set the floor a bit under" feels safe and is how both went quiet.

## The new guard

`EveryReadmeTabCount_MatchesTheSource` re-derives both numbers and checks every claim:

| number | source | claimed |
|---|---|---|
| total tabs — **58** | the sidebar, via `SidebarTabLabels()` | 5 times |
| tabs with an announced status line — **53** | inline `StatusMessage` lines + `StatusFooter` elements | once |

**The two are not interchangeable** — a tab with nothing long-running has nothing to report — so each claim is classified by the phrase that follows it rather than accepted as "one of the two numbers we know about". A guard doing the looser thing would pass on the two being swapped.

Counting is comment-stripped, because `DiskAnalyzerView` now explains *in prose* why it is **not** using the shared footer (#2274), and a text scan counts that mention as a call site. That is a live trap rather than a hypothetical: my first count said 21 footers where there are 20.

## Proof

Each state reverted after measuring; baseline green before and after.

| mutation | guard |
|---|---|
| the status-line claim back to 52 | **RED** — *"52 tabs" — the source says 53 tabs carry an announced status line* |
| one total claim changed to 57 | **RED** — *"57 feature tabs" — the source says 58 tabs* |
| the claim pattern broken | **RED** on the floor — *"only 0 claims found, out of 6 measured"* |
| `"that have one"` removed from the subset claim | **RED** on the subset floor |
| **the two numbers swapped** | **RED, naming BOTH claims** |

The fifth is the one that matters: it makes "the denominators are distinct" a measurement rather than a claim in a comment.

Screenshot filenames carry numbers too — `52-system-logs.png`, `55-about.png` — and are not matched, because the pattern requires the word "tabs" after the number. The ad-hoc sweep that first found the drift flagged all three of those; this does not.

## Verification

**5577** unit tests pass, 0 failed. Four projects build with **0 errors, 0 warnings**. `dotnet format --verify-no-changes` clean on all four. Leak scan: 43 terms over 146 diff lines, 0 hits.

`docs:` — no release.

## Deliberately not changed

The repo description still says **"55+ tools"** against 58 tabs. The `+` keeps it true, and a round number that does not need editing every release may well be deliberate marketing copy — so that is the user's call rather than mine, and I am raising it here rather than editing the public description unilaterally.
